### PR TITLE
https://issues.jboss.org/browse/APIMAN-105

### DIFF
--- a/apiman-rt/apiman-rt-engine/apiman-rt-engine-beans/src/main/java/org/overlord/apiman/rt/engine/beans/Policy.java
+++ b/apiman-rt/apiman-rt-engine/apiman-rt-engine-beans/src/main/java/org/overlord/apiman/rt/engine/beans/Policy.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.apiman.rt.engine.beans;
+
+import java.io.Serializable;
+
+/**
+ * Models a policy.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class Policy implements Serializable {
+
+    private static final long serialVersionUID = -5945877012261045491L;
+    private int policyId;
+    private Object policyConfig; //config_info json str
+    private String policyClass; //Reference to policy (classname?) we're going to load?
+
+    public Policy() {
+    }
+
+    /**
+     * @return the policyId
+     */
+    public int getPolicyId() {
+        return policyId;
+    }
+
+    /**
+     * @param policyId the policyId to set
+     */
+    public void setPolicyId(int policyId) {
+        this.policyId = policyId;
+    }
+
+    /**
+     * @return the policyConfig.
+     */
+    public Object getPolicyConfig() {
+        return policyConfig;
+    }
+
+    /**
+     * @param policyConfig the policyConfig to set
+     */
+    public void setPolicyConfig(Object policyConfig) {
+        this.policyConfig = policyConfig;
+    }
+
+    /**
+     * @return the policyClass
+     */
+    public String getPolicyClass() {
+        return policyClass;
+    }
+
+    /**
+     * @param policyClass the policyClass to set
+     */
+    public void setPolicyClass(String policyClass) {
+        this.policyClass = policyClass;
+    }
+}

--- a/apiman-rt/apiman-rt-engine/apiman-rt-engine-beans/src/main/java/org/overlord/apiman/rt/engine/beans/PolicyFailure.java
+++ b/apiman-rt/apiman-rt-engine/apiman-rt-engine-beans/src/main/java/org/overlord/apiman/rt/engine/beans/PolicyFailure.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.apiman.rt.engine.beans;
+
+import java.io.Serializable;
+
+/**
+ * Models a policy failure.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class PolicyFailure implements Serializable {
+    
+    private static final long serialVersionUID = -4698896399383125062L;
+    private Policy failedPolicy;
+    
+    public PolicyFailure() {
+    }
+
+    /**
+     * @return the failedPolicy
+     */
+    public Policy getFailedPolicy() {
+        return failedPolicy;
+    }
+
+    /**
+     * @param failedPolicy the failedPolicy to set
+     */
+    public void setFailedPolicy(Policy failedPolicy) {
+        this.failedPolicy = failedPolicy;
+    }
+}

--- a/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/EngineImpl.java
+++ b/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/EngineImpl.java
@@ -15,6 +15,10 @@
  */
 package org.overlord.apiman.rt.engine;
 
+import java.util.concurrent.Future;
+
+import org.overlord.apiman.rt.engine.async.IAsyncHandler;
+import org.overlord.apiman.rt.engine.async.IAsyncResult;
 import org.overlord.apiman.rt.engine.beans.Application;
 import org.overlord.apiman.rt.engine.beans.Contract;
 import org.overlord.apiman.rt.engine.beans.Service;
@@ -57,36 +61,14 @@ public class EngineImpl implements IEngine {
         setConnectorFactory(connectorFactory);
     }
 
-    /**
-     * @see org.overlord.apiman.rt.engine.IEngine#executeAsync(org.overlord.apiman.rt.engine.beans.ServiceRequest, org.overlord.apiman.rt.engine.IResponseHandler)
-     */
-    @Override
-    public void executeAsync(ServiceRequest request, IResponseHandler handler) {
-        // TODO implement this!
-        try {
-            ServiceResponse response = execute(request);
-            handler.onResponse(response);
-        } catch (Exception e) {
-            handler.onError(e);
-        }
+    public void execute(ServiceRequest request, IAsyncHandler<EngineResult> handler) {
+        return;
     }
     
-    /**
-     * @see org.overlord.apiman.rt.engine.IEngine#execute(org.overlord.apiman.rt.engine.beans.ServiceRequest)
-     */
-    @Override
-    public ServiceResponse execute(ServiceRequest request) throws Exception {
-        Service service = getRegistry().getService(request);
-        Contract contract = getRegistry().getContract(request);
-        
-        // TODO apply inbound policies to request
-        
-        IServiceConnector connector = getConnectorFactory().createConnector(request, service);
-        ServiceResponse response = connector.invoke(request);
-        
-        // TODO apply outbound policies to response
-        
-        return response;
+    public Future<IAsyncResult<EngineResult>> execute(ServiceRequest request) {
+        //return execute(request, null);
+        //TODO Set callback wrapper to update Future's result & status.
+        return null;
     }
     
     /**

--- a/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/EngineResult.java
+++ b/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/EngineResult.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.apiman.rt.engine;
+
+import org.overlord.apiman.rt.engine.beans.PolicyFailure;
+import org.overlord.apiman.rt.engine.beans.ServiceResponse;
+
+/**
+ * The result of a call through the policy engine. Encapsulates either a
+ * response or a failure.
+ * 
+ * @author eric.wittmann@redhat.com
+ */
+public class EngineResult {
+    
+    public ServiceResponse serviceResponse;
+    public PolicyFailure policyFailure;
+    
+    public EngineResult() {
+    }
+    
+    public boolean isResponse() {
+        return serviceResponse != null;
+    }
+    
+    public boolean isFailure() {
+        return policyFailure != null;
+    }
+    
+    public ServiceResponse getServiceResponse() {
+        return serviceResponse;
+    }
+    
+    public PolicyFailure getPolicyFailure() {
+        return policyFailure;
+    }
+    
+}

--- a/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/IEngine.java
+++ b/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/IEngine.java
@@ -15,10 +15,13 @@
  */
 package org.overlord.apiman.rt.engine;
 
+import java.util.concurrent.Future;
+
+import org.overlord.apiman.rt.engine.async.IAsyncHandler;
+import org.overlord.apiman.rt.engine.async.IAsyncResult;
 import org.overlord.apiman.rt.engine.beans.Application;
 import org.overlord.apiman.rt.engine.beans.Service;
 import org.overlord.apiman.rt.engine.beans.ServiceRequest;
-import org.overlord.apiman.rt.engine.beans.ServiceResponse;
 import org.overlord.apiman.rt.engine.beans.exceptions.PublishingException;
 import org.overlord.apiman.rt.engine.beans.exceptions.RegistrationException;
 
@@ -34,22 +37,27 @@ public interface IEngine {
      * @return the version of the engine
      */
     public String getVersion();
-
-    /**
-     * Processes a single inbound request for a managed service.
-     * @param request
-     * @param handler
-     */
-    public void executeAsync(ServiceRequest request, IResponseHandler handler);
     
     /**
-     * Executes a single inbound request for a managed service.  Blocks until
-     * the back end service has satisfied the request.
+     * Executes an asynchronous request for a managed service, with the provided
+     * handler being passed an {@link EngineResult} with the status and result 
+     * of the policy chain invocation. TODO
+     * 
      * @param request a request for a managed service
-     * @return the response from the back-end service
-     * @throws Exception if an error occurs while invoking the back-end service
-     */
-    public ServiceResponse execute(ServiceRequest request) throws Exception;
+     * @param handler an async handler called when a response is returned or an
+     *            exception is captured.
+     */    
+    public void execute(ServiceRequest request, IAsyncHandler<EngineResult> handler);
+    
+    
+    /**
+     * Executes an asynchronous request for a managed service, with the returned
+     * Future containing a valid {@link EngineResult} once the request has completed.
+     * 
+     * @param request a request for a managed service
+     * @return handler a {@link Future} containing the request result.
+     */ 
+    public Future<IAsyncResult<EngineResult>> execute(ServiceRequest request);
     
     /**
      * Publishes a new {@link Service}.

--- a/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/async/IAsyncHandler.java
+++ b/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/async/IAsyncHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.apiman.rt.engine.async;
+
+/**
+ * Asynchronous handler called when an event occurs.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ *
+ * @param <T> The event to handle
+ */
+public interface IAsyncHandler<T> {
+    
+    /**
+     * Fired when an event occurs.
+     * 
+     * @param event the event
+     */
+    public void onHandler(T event);
+}

--- a/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/async/IAsyncResult.java
+++ b/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/async/IAsyncResult.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.apiman.rt.engine.async;
+
+public interface IAsyncResult<T> {
+    /**
+     * Whether the call was successful.
+     * 
+     * @return true on success, false on failure.
+     */
+    boolean isSuccess();
+
+    /**
+     * Whether the call failed.
+     * 
+     * @return true on failure, false on success.
+     */
+    boolean isError();
+
+    /**
+     * Contains the async call if it succeeded, otherwise null.
+     * 
+     * @return A result T on success, null when unsuccessful.
+     */
+    T getResult();
+
+    /**
+     * Any unhandled exception raised during the course of execution.
+     * 
+     * @return A Throwable if an unhandled exception occurred, otherwise null.
+     */
+    Throwable getError();
+}

--- a/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/policy/IPolicy.java
+++ b/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/policy/IPolicy.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.apiman.rt.engine.policy;
+
+import java.io.Serializable;
+
+import org.overlord.apiman.rt.engine.beans.ServiceRequest;
+import org.overlord.apiman.rt.engine.beans.ServiceResponse;
+
+/**
+ * A {@link Policy} may inspect a {@link ServiceRequest} and associated {@link ServiceRespose} to indicate
+ * whether a given conversation is permitted to continue.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public interface IPolicy extends Serializable {
+    /**
+     * Applies a policy upon a {@link ServiceRequest} based on information
+     * included in the request itself in addition to its context and configuration.
+     * 
+     * 
+     * @param request an inbound request to apply to the policy to
+     * @param context contextual information
+     * @param config the policy's configuration information
+     * @param chain the policy chain being invoked
+     */
+    public void apply(ServiceRequest request, IPolicyContext context, Object config, IPolicyChain chain);
+    
+    /**
+     * Applies a policy upon a {@link ServiceResponse} based on information
+     * included in the response itself in addition to its context and configuration.
+     * 
+     * @param response an outbound response to apply the policy to
+     * @param context contextual information
+     * @param config the policy's configuration information
+     * @param chain chain the policy chain being invoked
+     */
+    public void apply(ServiceResponse response, IPolicyContext context, Object config, IPolicyChain chain);
+}

--- a/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/policy/IPolicyChain.java
+++ b/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/policy/IPolicyChain.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.apiman.rt.engine.policy;
+
+import org.overlord.apiman.rt.engine.beans.Policy;
+import org.overlord.apiman.rt.engine.beans.PolicyFailure;
+import org.overlord.apiman.rt.engine.beans.ServiceRequest;
+import org.overlord.apiman.rt.engine.beans.ServiceResponse;
+
+/**
+ * A Policy Chain consists of an inbound and outbound {@link Policy} sequence,
+ * applied in order to the {@link ServiceRequest} and corresponding
+ * {@link ServiceResponse} respectively.
+ * 
+ * The request is forwarded to the appropriate {@link Service} only if every
+ * inbound policy was evaluated successfully, and its response must successfully
+ * pass through every outbound policy in order to be forwarded to the requester.
+ * 
+ * In both instances, the chain may be interrupted by a Policy via a
+ * {@link PolicyFailure} or exception.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ * 
+ * @see IPolicyChainHandler
+ */
+public interface IPolicyChain {
+    /**
+     * Apply the inbound Policy Chain to the request. 
+     * 
+     * @param request the request
+     */
+    void doApply(ServiceRequest request);
+    
+    /**
+     * Apply the outbound Policy Chain to the response.
+     * 
+     * @param response the response
+     */
+    void doApply(ServiceResponse response);
+    
+    /**
+     * Handle a policy failure. 
+     * 
+     * @param failure the policy failure
+     */
+    void doFailure(PolicyFailure failure);
+}

--- a/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/policy/IPolicyChainHandler.java
+++ b/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/policy/IPolicyChainHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.apiman.rt.engine.policy;
+
+import org.overlord.apiman.rt.engine.beans.PolicyFailure;
+import org.overlord.apiman.rt.engine.beans.ServiceRequest;
+import org.overlord.apiman.rt.engine.beans.ServiceResponse;
+
+public interface IPolicyChainHandler {
+
+    /**
+     * Called when the policy chain has handled the inbound policy sequence.
+     * 
+     * @param request the inbound request
+     */
+    void onInboundComplete(ServiceRequest request);
+
+    /**
+     * Called when the policy chain has handled the outbound element of the response.
+     * 
+     * @param response the outbound response
+     */
+    void onOutputComplete(ServiceResponse response);
+
+    /**
+     * Called if a failure is indicated during policy chain execution. 
+     * 
+     * @param failure the policy failure
+     */
+    void onFailure(PolicyFailure failure);
+
+    /** 
+     * Called if an exception was raised during policy chain execution.
+     * 
+     * @param t
+     */
+    void onError(Throwable t);
+ 
+}

--- a/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/policy/IPolicyContext.java
+++ b/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/policy/IPolicyContext.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.apiman.rt.engine.policy;
+
+/**
+ * Context information provided to an executing policy.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public interface IPolicyContext {
+   
+}

--- a/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/policy/PolicyChain.java
+++ b/apiman-rt/apiman-rt-engine/apiman-rt-engine-core/src/main/java/org/overlord/apiman/rt/engine/policy/PolicyChain.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.apiman.rt.engine.policy;
+
+import org.overlord.apiman.rt.engine.beans.PolicyFailure;
+import org.overlord.apiman.rt.engine.beans.ServiceRequest;
+import org.overlord.apiman.rt.engine.beans.ServiceResponse;
+
+public class PolicyChain implements IPolicyChain {
+
+    @Override
+    public void doApply(ServiceRequest request) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void doApply(ServiceResponse response) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void doFailure(PolicyFailure failure) {
+        // TODO Auto-generated method stub
+
+    }
+
+}


### PR DESCRIPTION
- New beans representing a Policy and PolicyFailure
- New asynchronous interfaces to more generically handle async events
- Policy and policy chain related interfaces
- Refactor engine interface, and temporarily stub implementation to work with new async interfaces

Some thoughts: 
- I've added some new packages, but could easily be convinced various bits belong elsewhere.
- IPolicyContext is empty at the moment, but I've mapped a few ideas on cloud9
- We need a “reason for failure” in the PolicyFailure bean - but how to represent? Perhaps a ‘PolicyState’ of some sort that encapsulates the relevant failure state info of the Policy? 
