### PR TITLE
Ignore OS X .DS_Store metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/
 .checkstyle
 .errai
 gwt-unitCache
+.DS_Store


### PR DESCRIPTION
These files are created automatically by OS X’s finder app.
