### PR TITLE
Vert.x Apiman Gateway Implementation

### DIFF
--- a/gateway/platforms/pom.xml
+++ b/gateway/platforms/pom.xml
@@ -13,6 +13,7 @@
   <modules>
     <module>servlet</module>
     <module>undertow</module>
+    <module>vertx</module>
     <module>war</module>
     <module>war/wildfly8</module>
   </modules>

--- a/gateway/platforms/vertx/.gitignore
+++ b/gateway/platforms/vertx/.gitignore
@@ -1,0 +1,13 @@
+.idea/
+*.iml
+*.ipr
+*.iws
+.classpath
+.project
+.settings/
+
+.gradle/
+build/
+target/
+
+mods/

--- a/gateway/platforms/vertx/README.md
+++ b/gateway/platforms/vertx/README.md
@@ -1,0 +1,80 @@
+# Apiman Vert.x Gateway 
+
+This is the initial version of an apiman gateway implemented as a [Vert.x](http://www.vertx.io) module.
+
+## Configuration
+
+The following is the standard configuration that should be [provided to the module](http://vertx.io/mods_manual.html) at runtime.
+
+	{
+	  "registry": { "class": "io.apiman.gateway.engine.impl.InMemoryRegistry", "config": {} },
+	  "connector-factory": { "class": "io.apiman.gateway.vertx.connector.HttpConnectorFactory", "config": {} },
+	  "policy-factory": { "class": "io.apiman.gateway.engine.policy.PolicyFactoryImpl", "config": {} },
+	  
+	  "connectors": {
+	    "http-rest": "io.apiman.gateway.connector.HttpConnectorFactory", "config": {}
+	  },
+	  
+	  "components": {
+	    "IHttpClientComponent": { "class": "io.apiman.gateway.vertx.components.HttpClientComponentImpl", 
+	    	"config": {} },
+	
+	    "ISharedStateComponent": { "class": "io.apiman.gateway.engine.impl.InMemorySharedStateComponent", 
+	    	"config": {} },
+	    	
+	    "IRateLimiterComponent": { "class": "io.apiman.gateway.engine.impl.InMemoryRateLimiterComponent", 
+	    	"config": {} },
+	    	
+	    "IPolicyFailureFactoryComponent": { "class": "io.apiman.gateway.vertx.components.PolicyFailureFactoryComponent", 
+	    	"config": {} }
+	  },
+	  
+	  // Host-name to bind to for this machine.
+	  "hostname": "localhost",
+	  
+	  // You can force a particular endpoint here (e.g. if you have some clustered setup with exotic DNS setup) 
+	  "endpoint": "localhost",
+	  
+	  "routes": {
+	    "http-dispatcher": 8200,
+	    "http-gateway": 8201,
+	    "api": 8202
+	  },
+	  
+	  "auth": {
+	    "file-basic": {
+	      "example" : "NhWA8jbnUXSGDx0+LsTGFLsC6UHykp7kgnRiWF5X8KU="
+	    }
+	  },
+	
+	  "authenticated": true,
+	  "realm": "apiman-gateway"
+	}
+	
+For instance, `vert runzip target/<themodule>.zip -conf /path/to/the/conf.json"`. Or you can pass it in programatically with `deployModule(...)`.
+
+### Registries and factories
+
+Unless you are providing your own implementations, you should leave these values as defined above. 
+
+### Routes
+
+You can freely alter which ports a given verticle listens on, and they can be accessed directly or indirectly via the `http-dispatcher`. 
+
+The `http-dispatcher` is a convenient reverse proxy, which forwards traffic to the defined routes. For instance, accessing `localhost:8200/api` will forward the traffic to the `api` verticle on `8202`, whilst `localhost:8200/http-gateway` will be forwarded to the `http-gateway` on `8201`. This allows you to pass all traffic over a single port.
+
+Conversely, if you prefer, the endpoints can be accessed directly.
+
+### Auth
+
+At present, there is only BASIC authentication support for the api. You must provide a string key of your username and a base64 encoded SHA256 hash of the corresponding password. This situation is clearly not very secure, and hence will be superseded shortly using a more comprehensive, secure solution (such as KeyCloak).
+
+Authentication can be turned off entirely by setting: `"authenticated": false`
+
+### Components
+
+These are the various runtime components made available to apiman. 
+
+## Current limitations & future
+
+This first rendition uses mostly simple in-memory components which don't fully exercise the platform's distributed scaling potential. The underlying architecture of the gateway is ready to facilitate significant scaling, hence the next release will implement the necessary distributed components which will enable us to expose clustered, multi-verticle configurations, etc.

--- a/gateway/platforms/vertx/pom.xml
+++ b/gateway/platforms/vertx/pom.xml
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.apiman</groupId>
+    <artifactId>apiman-gateway-platforms</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>apiman-gateway-platforms-vertx</artifactId>
+  <packaging>jar</packaging>
+  <name>apiman-gateway-platforms-vertx</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- Set pullInDeps to true if you want any modules specified in 
+	 the 'includes' and 'deploys' fields in your mod.json to be automatically 
+	 pulled in during packaging and added inside your module. Doing this means 
+	 your module won't download and install those dependencies at run-time when 
+	 they're first requested. -->
+    <vertx.pullInDeps>false</vertx.pullInDeps>
+
+    <!-- Set createFatJar to true if you want to create a fat executable 
+	 jar which contains the Vert.x binaries along with the module so it can be 
+	 run with java -jar <jarname> -->
+    <vertx.createFatJar>false</vertx.createFatJar>
+
+    <!--Vertx module name -->
+    <module.name>${project.groupId}~${project.artifactId}~${project.version}</module.name>
+
+    <!-- The directory where the module will be assembled - you can override 
+	 this on the command line with -Dmods.directory=mydir -->
+    <mods.directory>target/mods</mods.directory>
+
+    <!--Dependency versions -->
+    <vertx.version>2.1.1</vertx.version>
+    <vertx.testtools.version>2.0.3-final</vertx.testtools.version>
+    <maven.vertx.plugin.version>2.0.11-final</maven.vertx.plugin.version>
+    <maven.surefire.report.plugin.version>2.14</maven.surefire.report.plugin.version>
+    <maven.failsafe.plugin.version>2.14</maven.failsafe.plugin.version>
+    
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>sonatype-nexus-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <!--Vertx provided dependencies -->
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>${vertx.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-platform</artifactId>
+      <version>${vertx.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-hazelcast</artifactId>
+      <version>${vertx.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!--Test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>testtools</artifactId>
+      <version>${vertx.testtools.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- apiman dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>apiman-gateway-engine-beans</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>apiman-gateway-engine-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>apiman-gateway-api-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>apiman-gateway-api-rest-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>apiman-gateway-test</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>apiman-test-common</artifactId>
+    </dependency>
+
+    <!-- Third Party Dependencies -->
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.4.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.4.3</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+
+      <!-- The vert.x Maven plugin -->
+      <plugin>
+	<groupId>io.vertx</groupId>
+	<artifactId>vertx-maven-plugin</artifactId>
+	<version>${maven.vertx.plugin.version}</version>
+	<!-- You can specify extra config to the plugin as required 
+	     here <configuration> <configFile>/path/to/MyVerticle.conf</configFile> <instances>1</instances> 
+	     <classpath>src/main/resources/:src/test/resources/:target/classes/:target/test-classes/</classpath> 
+	     </configuration> -->
+	<!-- Make sure that the plugin uses the vert.x versions from 
+	     this pom.xml not from its own pom.xml -->
+	<dependencies>
+	  <dependency>
+	    <groupId>io.vertx</groupId>
+	    <artifactId>vertx-platform</artifactId>
+	    <version>${vertx.version}</version>
+	  </dependency>
+	  <dependency>
+	    <groupId>io.vertx</groupId>
+	    <artifactId>vertx-core</artifactId>
+	    <version>${vertx.version}</version>
+	  </dependency>
+	  <dependency>
+	    <groupId>io.vertx</groupId>
+	    <artifactId>vertx-hazelcast</artifactId>
+	    <version>${vertx.version}</version>
+	  </dependency>
+	</dependencies>
+	<executions>
+	  <execution>
+	    <id>PullInDeps</id>
+	    <phase>prepare-package</phase>
+	    <goals>
+	      <goal>pullInDeps</goal>
+	    </goals>
+	  </execution>
+	</executions>
+      </plugin>
+
+      <!-- Other plugins required by the build -->
+      <plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-compiler-plugin</artifactId>
+	<configuration>
+	  <source>1.7</source>
+	  <target>1.7</target>
+	</configuration>
+      </plugin>
+      <plugin>
+	<artifactId>maven-resources-plugin</artifactId>
+	<executions>
+	  <execution>
+	    <id>copy-mod-to-target</id>
+	    <phase>process-classes</phase>
+	    <goals>
+	      <goal>copy-resources</goal>
+	    </goals>
+	    <configuration>
+	      <overwrite>true</overwrite>
+	      <outputDirectory>${mods.directory}/${module.name}</outputDirectory>
+	      <resources>
+		<resource>
+		  <directory>target/classes</directory>
+		</resource>
+	      </resources>
+	    </configuration>
+	  </execution>
+	</executions>
+      </plugin>
+      <plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-dependency-plugin</artifactId>
+	<executions>
+	  <execution>
+	    <id>copy-mod-dependencies-to-target</id>
+	    <phase>prepare-classes</phase>
+	    <goals>
+	      <goal>copy-dependencies</goal>
+	    </goals>
+	    <configuration>
+	      <outputDirectory>${mods.directory}/${module.name}/lib</outputDirectory>
+	      <includeScope>runtime</includeScope>
+	    </configuration>
+	  </execution>
+	  <execution>
+	    <id>copy-mod-dependencies-to-target-dependencies</id>
+	    <phase>prepare-classes</phase>
+	    <goals>
+	      <goal>copy-dependencies</goal>
+	    </goals>
+	    <configuration>
+	      <outputDirectory>target/dependencies</outputDirectory>
+	      <includeScope>runtime</includeScope>
+	    </configuration>
+	  </execution>
+	</executions>
+      </plugin>
+      <plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-surefire-plugin</artifactId>
+	<configuration>
+	  <includes>
+	    <include>**/unit/*Test*.java</include>
+	  </includes>
+	</configuration>
+      </plugin>
+      <plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-failsafe-plugin</artifactId>
+    <version>${maven.failsafe.plugin.version}</version>
+	<configuration>
+	  <systemProperties>
+	    <property>
+	      <name>vertx.mods</name>
+	      <value>${mods.directory}</value>
+	    </property>
+	  </systemProperties>
+	  <includes>
+	    <include>**/integration/**/*Test*</include>
+	  </includes>
+	</configuration>
+	<executions>
+	  <execution>
+	    <goals>
+	      <goal>integration-test</goal>
+	      <goal>verify</goal>
+	    </goals>
+	  </execution>
+	</executions>
+      </plugin>
+      <plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-surefire-report-plugin</artifactId>
+	<version>${maven.surefire.report.plugin.version}</version>
+	<executions>
+	  <execution>
+	    <id>generate-test-report</id>
+	    <phase>test</phase>
+	    <goals>
+	      <goal>report-only</goal>
+	    </goals>
+	  </execution>
+	  <execution>
+	    <id>generate-integration-test-report</id>
+	    <phase>integration-test</phase>
+	    <goals>
+	      <goal>failsafe-report-only</goal>
+	    </goals>
+	  </execution>
+	</executions>
+      </plugin>
+      <plugin>
+	<artifactId>maven-assembly-plugin</artifactId>
+	<configuration>
+	  <descriptors>
+	    <descriptor>src/main/assembly/mod.xml</descriptor>
+	  </descriptors>
+	</configuration>
+	<executions>
+	  <execution>
+	    <id>assemble</id>
+	    <phase>package</phase>
+	    <goals>
+	      <goal>single</goal>
+	    </goals>
+	  </execution>
+	</executions>
+      </plugin>
+    </plugins>
+  </build>
+  <reporting>
+    <plugins>
+      <plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-surefire-report-plugin</artifactId>
+      </plugin>
+      <plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-javadoc-plugin</artifactId>
+	<version>${maven.javadoc.plugin.version}</version>
+	<configuration>
+	  <aggregate>true</aggregate>
+	</configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/gateway/platforms/vertx/src/main/assembly/mod.xml
+++ b/gateway/platforms/vertx/src/main/assembly/mod.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+
+    <id>mod</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <fileSets>
+        <fileSet>
+            <outputDirectory></outputDirectory>
+            <directory>${mods.directory}/${module.name}</directory>
+            <includes>
+                <include>**</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/api/ApiCatchHandler.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/api/ApiCatchHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.api;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.eventbus.Message;
+import org.vertx.java.core.json.DecodeException;
+import org.vertx.java.core.json.JsonObject;
+import org.vertx.java.core.json.impl.Json;
+
+/**
+ * A handler that copes with a variety of errors, responding appropriate on the implementor's behalf.
+ *
+ * @author Marc Savy <msavy@redhat.com>
+ *
+ * @param <T> Type of message
+ */
+public abstract class ApiCatchHandler<T> implements Handler<Message<T>> {
+
+    private static final JsonObject OK_STATUS = new JsonObject().putBoolean("status", true);
+
+    @Override
+    public final void handle(Message<T> message) {
+        try {
+            handleApi(message);
+        } catch(DecodeException e) {
+            replyError(message, new GenericError(HttpResponseStatus.UNPROCESSABLE_ENTITY.code(),
+                    e.getLocalizedMessage(), e));
+        }  catch(Exception e) {
+            replyError(message, new GenericError(HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                    "Unexpected server error: " + e.getLocalizedMessage(), e));
+        }
+    }
+
+    protected void replyError(Message<T> message, GenericError genericException) {
+        JsonObject error = new JsonObject().
+                putBoolean("status", false).
+                putObject("error", new JsonObject(Json.encode(genericException)));
+
+        message.reply(error);
+    }
+
+    protected void replyOk(Message<T> message) {
+        message.reply(OK_STATUS);
+    }
+
+    protected abstract void handleApi(Message<T> message);
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/api/ApiListener.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/api/ApiListener.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.api;
+
+import io.apiman.gateway.engine.IEngine;
+import io.apiman.gateway.engine.beans.Application;
+import io.apiman.gateway.engine.beans.Service;
+import io.apiman.gateway.engine.beans.exceptions.PublishingException;
+import io.apiman.gateway.engine.beans.exceptions.RegistrationException;
+import io.apiman.gateway.vertx.config.VertxEngineConfig;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.vertx.java.core.eventbus.EventBus;
+import org.vertx.java.core.eventbus.Message;
+import org.vertx.java.core.json.JsonObject;
+import org.vertx.java.core.json.impl.Json;
+
+/**
+ * Listens for api updates.
+ *
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class ApiListener {
+    private EventBus eb;
+    private String uuid;
+
+    /**
+     * Constructor
+     *
+     * @param eb entity bus
+     * @param uuid verticle's unique id
+     */
+    public ApiListener(EventBus eb, String uuid) {
+        this.eb = eb;
+        this.uuid = uuid;
+    }
+
+    public void listen(final IEngine engine) {
+        // Subscribe to the api
+        eb.send(VertxEngineConfig.APIMAN_API_SUBSCRIBE, uuid);
+
+        // register application
+        eb.registerHandler(uuid + VertxEngineConfig.APIMAN_API_APPLICATIONS_REGISTER,
+                new ApiCatchHandler<String>() {
+
+            @Override
+            protected void handleApi(Message<String> message) {
+                try {
+                    Application application = Json.decodeValue(message.body(), Application.class);
+                    engine.registerApplication(application);
+                    // Signal that everything seems OK
+                    replyOk(message);
+                    //logger.debug(("registered app " + application.getApplicationId());
+                    //logger.debug(("with contract(s): ");
+
+                    // for(Contract c : application.getContracts()) {
+                    //     logger.debug(("API KEY = "  + c.getApiKey());
+                    // }
+
+                } catch (RegistrationException e) {
+                    replyError(message, new GenericError(HttpResponseStatus.NOT_FOUND.code(),
+                            e.getLocalizedMessage(), e));
+                }
+            };
+        });
+
+        // delete application
+        eb.registerHandler(uuid + VertxEngineConfig.APIMAN_API_APPLICATIONS_DELETE,
+                new ApiCatchHandler<JsonObject>() {
+
+            protected void handleApi(Message<JsonObject> message) {
+                JsonObject json = message.body();
+
+                try {
+                    engine.unregisterApplication(json.getString("organizationId"),
+                            json.getString("applicationId"),
+                            json.getString("version"));
+                    //logger.debug(("Deleted app");
+                    replyOk(message);
+                } catch (RegistrationException e) {
+                    replyError(message, new GenericError(HttpResponseStatus.NOT_FOUND.code(),
+                            e.getLocalizedMessage(), e));
+                }
+            };
+        });
+
+        // register service
+        eb.registerHandler(uuid + VertxEngineConfig.APIMAN_API_SERVICES_REGISTER,
+                new ApiCatchHandler<String>() {
+
+            @Override
+            public void handleApi(Message<String> message) {
+                Service service = Json.decodeValue(message.body(), Service.class);
+
+                try {
+                    engine.publishService(service);
+                    //logger.debug(("registered service " + service.getEndpointType());
+                    replyOk(message);
+                } catch (PublishingException e) {
+                    replyError(message, new GenericError(HttpResponseStatus.CONFLICT.code(),
+                            e.getLocalizedMessage(), e));
+                }
+
+            };
+        });
+
+        // retire service
+        eb.registerHandler(uuid + VertxEngineConfig.APIMAN_API_SERVICES_DELETE,
+                new ApiCatchHandler<JsonObject>() {
+
+            public void handleApi(Message<JsonObject> message) {
+                JsonObject json = message.body();
+
+                //logger.debug(("retiring service " + json);
+                try {
+                    engine.retireService(json.getString("organizationId"),
+                            json.getString("serviceId"),
+                            json.getString("version"));
+                    replyOk(message);
+                } catch (PublishingException e) {
+                    replyError(message, new GenericError(HttpResponseStatus.NOT_FOUND.code(),
+                            e.getLocalizedMessage(), e));
+                }
+            };
+        });
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/api/AuthenticatingRouteMatcher.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/api/AuthenticatingRouteMatcher.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.api;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+
+import io.apiman.gateway.vertx.config.VertxEngineConfig;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.codec.binary.Base64;
+import org.vertx.java.core.http.HttpHeaders;
+import org.vertx.java.core.http.HttpServerRequest;
+import org.vertx.java.core.http.HttpServerResponse;
+import org.vertx.java.core.http.RouteMatcher;
+import org.vertx.java.core.logging.Logger;
+
+/**
+ * A RouteMatcher with BASIC authentication.
+ *
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class AuthenticatingRouteMatcher extends RouteMatcher {
+
+    private Map<String, String> fileBasicAuthData;
+    private Logger logger;
+    private VertxEngineConfig config;
+
+    public AuthenticatingRouteMatcher(VertxEngineConfig config, Logger logger) {
+        this.config = config;
+        this.fileBasicAuthData = config.loadFileBasicAuth();
+        this.logger = logger;
+    }
+
+    @Override
+    public void handle(HttpServerRequest request) {
+        if(!config.isAuthenticationEnabled() || authenticate(request)) {
+            super.handle(request);
+        } else {
+            notAuthorised(request.response());
+        }
+    }
+
+    private boolean authenticate(HttpServerRequest request) {
+        String authString = request.headers().get(HttpHeaders.AUTHORIZATION);
+
+        if(authString == null)
+            return false;
+
+        String[] basicAuth = StringUtils.splitByWholeSeparator(authString, "Basic ");
+
+        if(basicAuth.length == 1) {
+            return basicAuth(request, basicAuth[0]);
+        }
+
+        return false;
+    }
+
+    private boolean basicAuth(HttpServerRequest request, String encodedAuth) {
+        byte[] authBytes = Base64.decodeBase64(encodedAuth);
+        String decodedString = new String(authBytes);
+        String[] splitAuth = StringUtils.split(StringUtils.trim(decodedString), ":");
+
+        if(splitAuth.length != 2)
+            return false;
+
+        if(fileBasicAuthData.containsKey(splitAuth[0])) {
+            String storedHash = new String (Base64.decodeBase64(fileBasicAuthData.get(splitAuth[0])));
+
+            MessageDigest digest;
+            try {
+                digest = MessageDigest.getInstance("SHA-256");
+                digest.update(splitAuth[1].getBytes());
+
+                String receivedHash = new String(digest.digest());
+
+                if(storedHash.equals(receivedHash)) {
+                    return true;
+                }
+            } catch (NoSuchAlgorithmException e) {
+                logger.error(e.getMessage(), e.getCause());
+            }
+      }
+
+      request.response().headers().add("WWW-Authenticate", "Basic realm=\""+ config.getRealm() + "\"");
+
+      return false;
+    }
+
+    private void notAuthorised(HttpServerResponse response) {
+        response.setStatusCode(HttpResponseStatus.UNAUTHORIZED.code());
+        response.setStatusMessage(HttpResponseStatus.UNAUTHORIZED.reasonPhrase());
+        response.end();
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/api/GenericError.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/api/GenericError.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.api;
+
+/**
+ * A serializable (with jackson) error, which can be easily transmitted over the bus
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class GenericError extends RuntimeException {
+    
+    private static final long serialVersionUID = -3910654049532937590L;
+    private int responseCode;
+    private String message;
+    private Throwable cause;
+    
+    /**
+     * Empty constructor for Jackson
+     */
+    public GenericError() {}
+    
+    /**
+     * Constructor
+     * @param responseCode a response code
+     * @param message an error message
+     * @param cause the exception that caused the problem
+     */
+    public GenericError(int responseCode, String message, Throwable cause) {
+        super(message, cause);
+        this.cause = cause;
+        this.message = message;
+        this.responseCode = responseCode;
+    }
+    
+    /**
+     * @return response code
+     */
+    public int getResponseCode() {
+        return responseCode;
+    }
+    
+    /**
+     * @param message error message
+     */
+    public void setMessage(String message) {
+        this.message = message;
+    }
+    
+    @Override
+    public String getMessage() {
+        return message;
+    }
+    
+    /**
+     * @param responseCode set a response code
+     */
+    public void setResponseCode(int responseCode) {
+        this.responseCode = responseCode;
+    }
+    
+    /**
+     * @param cause cause of the exception
+     */
+    public void setCause(Throwable cause) {
+        this.cause = cause;
+    }
+    
+    /**
+     * The cause of the exception
+     */
+    public Throwable getCause() {
+        return cause;
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/common/DoubleHandler.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/common/DoubleHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.common;
+
+/**
+ * Handler that returns two elements of different types.
+ * 
+ * Use very sparingly.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ *
+ * @param <T1> First element returned
+ * @param <T2> Second element returned
+ */
+public interface DoubleHandler<T1, T2> {
+    /**
+     * Handle elements
+     * 
+     * @param elem0 First element
+     * @param elem1 Second element
+     */
+    void handle(T1 elem0, T2 elem1);
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/components/HttpClientComponentImpl.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/components/HttpClientComponentImpl.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.components;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.Vertx;
+import org.vertx.java.core.VoidHandler;
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.http.HttpClient;
+import org.vertx.java.core.http.HttpClientRequest;
+import org.vertx.java.core.http.HttpClientResponse;
+
+import io.apiman.gateway.engine.async.AsyncResultImpl;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.components.IHttpClientComponent;
+import io.apiman.gateway.engine.components.http.HttpMethod;
+import io.apiman.gateway.engine.components.http.IHttpClientRequest;
+import io.apiman.gateway.engine.components.http.IHttpClientResponse;
+import io.apiman.gateway.vertx.config.VertxEngineConfig;
+
+/**
+ * A Vert.x based implementation of {@link IHttpClientComponent}. Ensure that
+ * {@link IHttpClientRequest#close()} is called after writing is finished, or your data may never be sent, and
+ * the connection will be left hanging.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class HttpClientComponentImpl implements IHttpClientComponent {
+
+    private Vertx vertx;
+    private IAsyncResultHandler<IHttpClientResponse> responseHandler;
+
+    public HttpClientComponentImpl(Vertx vertx, VertxEngineConfig engineConfig, Map<String, String> config) {
+        this.vertx = vertx;
+    }
+
+    @Override
+    public IHttpClientRequest request(String endpoint, HttpMethod method,
+            IAsyncResultHandler<IHttpClientResponse> handler) {
+        this.responseHandler = handler;
+
+        URL pEndpoint = parseEndpoint(endpoint);
+
+        HttpClient client = vertx.createHttpClient().
+                setHost(pEndpoint.getHost()).
+                setPort(pEndpoint.getPort());
+
+        HttpClientRequest request = client.request(method.toString(), 
+                pEndpoint.getPath(),
+                new HttpClientResponseImpl());
+
+        return new HttpClientRequestImpl(request);
+    }
+
+    private class HttpClientResponseImpl implements IHttpClientResponse, Handler<HttpClientResponse> {
+
+        private HttpClientResponse response;
+        private Buffer body;
+
+        @Override
+        public void handle(HttpClientResponse response) {
+            this.response = response;
+
+            // The interface stipulates accumulating the whole body,
+            response.bodyHandler(new Handler<Buffer>() {
+
+                @Override
+                public void handle(Buffer wholeBody) {
+                    body = wholeBody;
+                }
+            });
+
+            response.endHandler(new VoidHandler() {
+
+                @Override
+                public void handle() {
+                    responseHandler.handle(AsyncResultImpl
+                            .<IHttpClientResponse> create(HttpClientResponseImpl.this));
+                }
+            });
+        }
+
+        @Override
+        public int getResponseCode() {
+            return response.statusCode();
+        }
+
+        @Override
+        public String getResponseMessage() {
+            return response.statusMessage();
+        }
+
+        @Override
+        public String getHeader(String headerName) {
+            return response.headers().get(headerName);
+        }
+
+        @Override
+        public String getBody() {
+            return body.toString();
+        }
+
+        @Override
+        // Doesn't make sense in async world.
+        public void close() {
+        }
+
+    }
+
+    class HttpClientRequestImpl implements IHttpClientRequest {
+
+        private boolean finished = false;
+        private HttpClientRequest request;
+
+        public HttpClientRequestImpl(HttpClientRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public void addHeader(String headerName, String headerValue) {
+            request.putHeader(headerName, headerValue);
+        }
+
+        @Override
+        public void removeHeader(String headerName) {
+            request.headers().remove(headerName);
+        }
+
+        @Override
+        public void write(byte[] data) {
+            if (finished) {
+                throw new IllegalStateException("Attempted write to connector after #end() was called.");
+            }
+
+            request.write(new Buffer(data));
+        }
+
+        @Override
+        public void write(String body, String charsetName) {
+            if (finished) {
+                throw new IllegalStateException("Attempted write to connector after #end() was called.");
+            }
+
+            request.write(new Buffer(body, charsetName));
+        }
+
+        @Override
+        public void end() {
+            request.end();
+            finished = true;
+        }
+    }
+
+    private URL parseEndpoint(String endpoint) {
+        try {
+            return new URL(endpoint);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/components/PolicyFailureFactoryComponent.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/components/PolicyFailureFactoryComponent.java
@@ -1,0 +1,26 @@
+package io.apiman.gateway.vertx.components;
+
+import io.apiman.gateway.engine.beans.PolicyFailure;
+import io.apiman.gateway.engine.beans.PolicyFailureType;
+import io.apiman.gateway.engine.components.IPolicyFailureFactoryComponent;
+
+public class PolicyFailureFactoryComponent implements IPolicyFailureFactoryComponent {
+    
+    /**
+     * Constructor.
+     */
+    public PolicyFailureFactoryComponent() {
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.components.IPolicyFailureFactoryComponent#createFailure(io.apiman.gateway.engine.beans.PolicyFailureType, int, java.lang.String)
+     */
+    @Override
+    public PolicyFailure createFailure(PolicyFailureType type, int failureCode, String message) {
+        PolicyFailure failure = new PolicyFailure(); // TODO pool
+        failure.setFailureCode(failureCode);
+        failure.setMessage(message);
+        failure.setType(type);
+        return failure;
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/config/RouteMapper.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/config/RouteMapper.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+import org.vertx.java.core.json.JsonObject;
+
+/**
+ * Maps simple http path to bus address.
+ * 
+ * Example: '/gateway -> vertx.apiman.gateway'
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class RouteMapper {
+    private Map<String, Integer> routeMap = new HashMap<>();
+    
+    public RouteMapper() {}
+    
+    public RouteMapper(JsonObject routeMappings) {        
+        for(String routeName : routeMappings.getFieldNames()) {
+            routeMap.put(routeName, routeMappings.getInteger(routeName));
+        }
+    }
+    
+    public Map<String, Integer> getRoutes() {
+        return routeMap;
+    }
+    
+    public Integer getAddress(String path) {
+        return routeMap.get(firstPathElem(path));
+    }
+    
+    public boolean hasRoute(String path) {
+        return getAddress(path) != null;
+    }   
+    
+    /**
+     * Simplistic & fast mapping of first element of path, avoiding any regex for now.
+     * For instance /gateway/a/b/c => gateway
+     */
+    protected String firstPathElem(String path) {
+        return StringUtils.split(path, "/", 2)[0];
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/config/VertxEngineConfig.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/config/VertxEngineConfig.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import io.apiman.gateway.engine.IComponent;
+import io.apiman.gateway.engine.IConnectorFactory;
+import io.apiman.gateway.engine.IEngineConfig;
+import io.apiman.gateway.engine.IRegistry;
+import io.apiman.gateway.engine.i18n.Messages;
+import io.apiman.gateway.engine.policy.IPolicyFactory;
+
+import org.vertx.java.core.json.JsonObject;
+
+/**
+ * Engine configuration, read simplistically from Vert'x JSON config.
+ *
+ * @see "http://vertx.io/manual.html#using-vertx-from-the-command-line"
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class VertxEngineConfig implements IEngineConfig {
+
+    public static final String APIMAN_RT_REGISTRY_PREFIX = "registry"; //$NON-NLS-1$
+    public static final String APIMAN_RT_CONNECTOR_FACTORY_PREFIX = "connector-factory"; //$NON-NLS-1$
+    public static final String APIMAN_RT_POLICY_FACTORY_PREFIX = "policy-factory"; //$NON-NLS-1$
+
+    public static final String APIMAN_RT_COMPONENT_PREFIX = "components"; //$NON-NLS-1$
+
+    private static final String APIMAN_RT_AUTH_PREFIX = "auth"; //$NON-NLS-1$
+
+    public static final String APIMAN_RT_GATEWAY_SERVER_PORT = "server-port"; //$NON-NLS-1$
+
+    public static final String APIMAN_RT_CONFIG = "config"; //$NON-NLS-1$
+    public static final String APIMAN_RT_CLASS = "class"; //$NON-NLS-1$
+
+    public static final String APIMAN_RT_EP_SERVICE_REQUEST = ".apiman.gateway.service.request"; //$NON-NLS-1$
+    public static final String APIMAN_RT_EP_SERVICE_RESPONSE = ".apiman.gateway.service.response"; //$NON-NLS-1$
+
+    public static final String APIMAN_RT_READY_SUFFIX = ".ready"; //$NON-NLS-1$
+    public static final String APIMAN_RT_HEAD_SUFFIX = ".head"; //$NON-NLS-1$
+    public static final String APIMAN_RT_BODY_SUFFIX = ".body"; //$NON-NLS-1$
+    public static final String APIMAN_RT_END_SUFFIX = ".end"; //$NON-NLS-1$
+    public static final String APIMAN_RT_ERROR_SUFFIX = ".error"; //$NON-NLS-1$
+    public static final String APIMAN_RT_FAILURE_SUFFIX = ".failure"; //$NON-NLS-1$
+
+    public static final String APIMAN_RT_GATEWAY_ROUTES = "routes"; //$NON-NLS-1$
+    public static final String APIMAN_RT_EP_GATEWAY_REG_POLICY = "apiman.gateway.register.policy"; //$NON-NLS-1$
+
+    public static final String APIMAN_API_APPLICATIONS_REGISTER = ".apiman.api.applications.register"; //$NON-NLS-1$
+    public static final String APIMAN_API_APPLICATIONS_DELETE = ".apiman.api.applications.delete"; //$NON-NLS-1$
+    public static final String APIMAN_API_SERVICES_REGISTER = ".apiman.api.services.register"; //$NON-NLS-1$
+    public static final String APIMAN_API_SERVICES_DELETE = ".apiman.api.services.delete"; //$NON-NLS-1$
+    public static final String APIMAN_API_SUBSCRIBE = "apiman.api.subscribe"; //$NON-NLS-1$
+
+    private static final String APIMAN_RT_AUTH_BASIC = "file-basic";
+    private static final String APIMAN_RT_AUTH_ENABLED = "authenticated";
+    private static final String APIMAN_RT_AUTH_REALM = "realm";
+    private static final String APIMAN_RT_HOSTNAME = "hostname";
+    private static final String APIMAN_RT_ENDPOINT = "endpoint";
+
+    private RouteMapper routeMap;
+    private JsonObject config;
+
+    public VertxEngineConfig(JsonObject config) {
+        this.config = config;
+
+        if(config.getObject(APIMAN_RT_GATEWAY_ROUTES) != null) {
+            routeMap = new RouteMapper(config.getObject(APIMAN_RT_GATEWAY_ROUTES));
+        } else {
+            routeMap = new RouteMapper();
+        }
+    }
+
+    public JsonObject getConfig() {
+        return config;
+    }
+
+    @Override
+    public Class<? extends IRegistry> getRegistryClass() {
+        return loadConfigClass(getClassname(config, APIMAN_RT_REGISTRY_PREFIX),
+                IRegistry.class);
+    }
+
+    @Override
+    public Map<String, String> getRegistryConfig() {
+        return toFlatStringMap(getConfig(config, APIMAN_RT_REGISTRY_PREFIX));
+    }
+
+    @Override
+    public Class<? extends IConnectorFactory> getConnectorFactoryClass() {
+        return loadConfigClass(getClassname(config, APIMAN_RT_CONNECTOR_FACTORY_PREFIX),
+                IConnectorFactory.class);
+    }
+
+    @Override
+    public Map<String, String> getConnectorFactoryConfig() {
+        return toFlatStringMap(getConfig(config, APIMAN_RT_CONNECTOR_FACTORY_PREFIX));
+    }
+
+    @Override
+    public Class<? extends IPolicyFactory> getPolicyFactoryClass() {
+        return loadConfigClass(getClassname(config, APIMAN_RT_POLICY_FACTORY_PREFIX),
+                IPolicyFactory.class);
+    }
+
+    @Override
+    public Map<String, String> getPolicyFactoryConfig() {
+        return toFlatStringMap(getConfig(config, APIMAN_RT_POLICY_FACTORY_PREFIX));
+    }
+
+    @Override
+    public <T extends IComponent> Class<T> getComponentClass(Class<T> componentType) {
+        String className = config.getObject(APIMAN_RT_COMPONENT_PREFIX).
+                getObject(componentType.getSimpleName()).
+                getString(APIMAN_RT_CLASS);
+
+        return loadConfigClass(className, componentType);
+    }
+
+    @Override
+    public <T extends IComponent> Map<String, String> getComponentConfig(Class<T> componentType) {
+        JsonObject componentConfig = config.getObject(APIMAN_RT_COMPONENT_PREFIX).
+                getObject(componentType.getSimpleName()).
+                getObject(APIMAN_RT_CONFIG);
+
+        return toFlatStringMap(componentConfig);
+    }
+
+
+    public Boolean isAuthenticationEnabled() {
+        return boolConfigWithDefault(APIMAN_RT_AUTH_ENABLED, false);
+    }
+
+    public String getRealm() {
+        return stringConfigWithDefault(APIMAN_RT_AUTH_REALM, "apiman-realm");
+    }
+
+    public RouteMapper getRouteMap() {
+        return routeMap;
+    }
+    
+    public String hostname() {
+        return stringConfigWithDefault(APIMAN_RT_HOSTNAME, "localhost");
+    }
+    
+    public String getEndpoint() {
+        return stringConfigWithDefault(APIMAN_RT_ENDPOINT, "localhost");   
+    }
+
+    public Map<String, String> loadFileBasicAuth() {
+        JsonObject pairs = config.getObject(APIMAN_RT_AUTH_PREFIX).getObject(APIMAN_RT_AUTH_BASIC);
+
+        Map<String, String> map = new HashMap<>();
+
+        for (String username : pairs.getFieldNames()) {
+            map.put(username, pairs.getString(username));
+        }
+
+        return map;
+    }
+
+    protected Map<String, String> toFlatStringMap(JsonObject jsonObject) {
+        Map<String, String> outMap = new HashMap<>();
+
+        for(Entry<String, Object> pair : jsonObject.toMap().entrySet()) {
+            outMap.put(pair.getKey(), pair.getValue().toString());
+        }
+
+        return outMap;
+    }
+
+    protected String getClassname(JsonObject obj, String prefix) {
+        return obj.getObject(prefix).getString(APIMAN_RT_CLASS);
+    }
+
+    protected JsonObject getConfig(JsonObject obj, String prefix) {
+        return obj.getObject(prefix).getObject(APIMAN_RT_CONFIG);
+    }
+
+    /**
+     * @return a loaded class
+     */
+    @SuppressWarnings("unchecked")
+    protected <T> Class<T> loadConfigClass(String classname, Class<T> type) {
+
+        if (classname == null) {
+            throw new RuntimeException("No " + type.getSimpleName() + " class configured."); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        try {
+            Class<T> c = (Class<T>) Thread.currentThread().getContextClassLoader().loadClass(classname);
+            return c;
+        } catch (ClassNotFoundException e) {
+            // Not found via Class.forName() - try other mechanisms.
+        }
+        try {
+            Class<T> c = (Class<T>) Class.forName(classname);
+            return c;
+        } catch (ClassNotFoundException e) {
+            // Not found via Class.forName() - try other mechanisms.
+        }
+        throw new RuntimeException(Messages.i18n.format("EngineConfig.FailedToLoadClass", classname)); //$NON-NLS-1$
+    }
+    
+    protected String stringConfigWithDefault(String name, String defaultValue) {
+        String str = config.getString(name);
+        return str == null ? defaultValue : str;
+    }
+    
+    protected Boolean boolConfigWithDefault(String name, Boolean defaultValue) {
+        Boolean bool = config.containsField(name);
+         
+        return bool == null ? defaultValue : bool;
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/connector/ConnectorFactory.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/connector/ConnectorFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.connector;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.vertx.java.core.Vertx;
+import org.vertx.java.platform.Container;
+
+import io.apiman.gateway.engine.IConnectorFactory;
+import io.apiman.gateway.engine.IServiceConnection;
+import io.apiman.gateway.engine.IServiceConnectionResponse;
+import io.apiman.gateway.engine.IServiceConnector;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.beans.Service;
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.exceptions.ConnectorException;
+
+/**
+ * Create Vert.x connectors to the enable apiman to connect to a backend service.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class ConnectorFactory implements IConnectorFactory {
+
+    private static final Set<String> SUPPRESSED_HEADERS = new HashSet<>();
+    static {
+        SUPPRESSED_HEADERS.add("Transfer-Encoding"); //$NON-NLS-1$
+        SUPPRESSED_HEADERS.add("Content-Length"); //$NON-NLS-1$
+        SUPPRESSED_HEADERS.add("X-API-Key"); //$NON-NLS-1$
+    }
+
+    private Vertx vertx;
+    private Container container;
+
+    /**
+     * Constructor
+     * @param vertx a vertx instance
+     */
+    public ConnectorFactory(Vertx vertx, Container container) {
+        this.vertx = vertx;
+        this.container = container;
+    }
+
+    @Override
+    public IServiceConnector createConnector(ServiceRequest request, final Service service) {
+        return new IServiceConnector() {
+            
+            @Override
+            public IServiceConnection connect(ServiceRequest request,
+                    IAsyncResultHandler<IServiceConnectionResponse> resultHandler)
+                    throws ConnectorException {
+                // In the future we can switch to different back-end implementations here!
+                return new HttpConnector(vertx, container, service, request, resultHandler);
+            }
+        };
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/connector/HttpConnector.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/connector/HttpConnector.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.connector;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+
+import io.apiman.gateway.engine.IServiceConnection;
+import io.apiman.gateway.engine.IServiceConnectionResponse;
+import io.apiman.gateway.engine.async.AsyncResultImpl;
+import io.apiman.gateway.engine.async.IAsyncHandler;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.beans.Service;
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.io.IApimanBuffer;
+import io.apiman.gateway.engine.io.ISignalReadStream;
+import io.apiman.gateway.engine.io.ISignalWriteStream;
+import io.apiman.gateway.vertx.http.HttpServiceFactory;
+import io.apiman.gateway.vertx.io.VertxApimanBuffer;
+
+import org.apache.commons.lang.StringUtils;
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.Vertx;
+import org.vertx.java.core.VoidHandler;
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.http.HttpClient;
+import org.vertx.java.core.http.HttpClientRequest;
+import org.vertx.java.core.http.HttpClientResponse;
+import org.vertx.java.core.logging.Logger;
+import org.vertx.java.platform.Container;
+
+/**
+ * A vert.x-based HTTP connector; implementing both {@link ISignalReadStream} and {@link ISignalWriteStream}.
+ *
+ * Its {@link ISignalWriteStream} elements are valid immediately and its {@link ISignalReadStream} is sent as
+ * an event to the provided {@link #resultHandler} when once it has reached a valid state. Hence, it is safe
+ * to return instances immediately after the constructor has returned.
+ *
+ * @author Marc Savy <msavy@redhat.com>
+ */
+class HttpConnector implements IServiceConnectionResponse, IServiceConnection {
+
+    private static final Set<String> SUPPRESSED_HEADERS = new HashSet<>();
+    static {
+        SUPPRESSED_HEADERS.add("Transfer-Encoding"); //$NON-NLS-1$
+        SUPPRESSED_HEADERS.add("Content-Length"); //$NON-NLS-1$
+        SUPPRESSED_HEADERS.add("X-API-Key"); //$NON-NLS-1$
+    }
+
+    private Vertx vertx;
+    private Logger logger;
+
+    private ServiceRequest serviceRequest;
+    private ServiceResponse serviceResponse;
+
+    private IAsyncResultHandler<IServiceConnectionResponse> resultHandler;
+    private IAsyncHandler<IApimanBuffer> bodyHandler;
+    private IAsyncHandler<Void> endHandler;
+    private ExceptionHandler exceptionHandler;
+
+    private boolean inboundFinished = false;
+    private boolean outboundFinished = false;
+
+    private String servicePath;
+    private String serviceHost;
+    private int servicePort;
+
+    private HttpClientRequest clientRequest;
+    private HttpClientResponse clientResponse;
+
+    /**
+     * Construct an {@link HttpConnector} instance. The {@link #resultHandler} must remain exclusive to a
+     * given instance.
+     *
+     * @param vertx a vertx
+     * @param service a service
+     * @param request a request with fields filled
+     * @param resultHandler a handler, called when reading is permitted
+     */
+    public HttpConnector(Vertx vertx, Container container, Service service, ServiceRequest request,
+            IAsyncResultHandler<IServiceConnectionResponse> resultHandler) {
+       this.vertx = vertx;
+       this.logger = container.logger();
+       this.serviceRequest = request;
+       this.resultHandler = resultHandler;
+       this.exceptionHandler = new ExceptionHandler();
+
+       URL serviceEndpoint = parseServiceEndpoint(service);
+
+       serviceHost = serviceEndpoint.getHost();
+       servicePort = serviceEndpoint.getPort();
+       servicePath = StringUtils.removeEnd(serviceEndpoint.getPath(), "/");
+
+       doConnection();
+    }
+
+    private void doConnection() {
+        HttpClient client = vertx.createHttpClient()
+                .setHost(serviceHost)
+                .setPort(servicePort);
+
+        String destination = servicePath + serviceRequest.getDestination();
+
+        clientRequest = client.request(serviceRequest.getType(), destination,
+                new Handler<HttpClientResponse>() {
+
+            @Override
+            public void handle(final HttpClientResponse vxClientResponse) {
+                clientResponse = vxClientResponse;
+
+                logger.debug("We have a response");
+
+                // Pause until we're given permission to xfer the response.
+                vxClientResponse.pause();
+
+                serviceResponse = HttpServiceFactory.buildResponse(vxClientResponse, SUPPRESSED_HEADERS);
+
+                vxClientResponse.dataHandler(new Handler<Buffer>() {
+
+                    @Override
+                    public void handle(Buffer chunk) {
+                        //logger.debug("Received data from the back end! " + chunk.toString());
+                        bodyHandler.handle(new VertxApimanBuffer(chunk));
+                    }
+                });
+
+                vxClientResponse.endHandler(new VoidHandler() {
+
+                    @Override
+                    protected void handle() {
+                        endHandler.handle((Void) null);
+                    }
+                });
+
+                vxClientResponse.exceptionHandler(exceptionHandler);
+
+                // The response is only ever returned when vxClientResponse is valid.
+                resultHandler.handle(AsyncResultImpl
+                        .create((IServiceConnectionResponse) HttpConnector.this));
+            }
+        });
+
+        clientRequest.exceptionHandler(exceptionHandler);
+        clientRequest.setChunked(true);
+        clientRequest.headers().add(serviceRequest.getHeaders());
+    }
+
+    @Override
+    public ServiceResponse getHead() {
+        return serviceResponse;
+    }
+
+    @Override
+    public void transmit() {
+        //logger.debug("Resuming HttpConnector!");
+        clientResponse.resume();
+    }
+
+    @Override
+    public void abort() {
+        bodyHandler(null);
+
+        if(clientRequest != null) {
+           clientRequest.end();
+        }
+
+        if(clientResponse != null) {
+            clientResponse.netSocket().close(); //TODO verify
+        }
+    }
+
+    @Override
+    public void bodyHandler(IAsyncHandler<IApimanBuffer> bodyHandler) {
+        this.bodyHandler = bodyHandler;
+    }
+
+    @Override
+    public void endHandler(IAsyncHandler<Void> endHandler) {
+        this.endHandler = endHandler;
+    }
+
+    @Override
+    public void write(IApimanBuffer chunk) {
+        if (inboundFinished) {
+            throw new IllegalStateException("Attempted write to connector after #end() was called."); //$NON-NLS-1$
+        }
+
+        if (chunk.getNativeBuffer() instanceof Buffer) {
+            clientRequest.write((Buffer) chunk.getNativeBuffer());
+        } else {
+            throw new IllegalArgumentException("Chunk not of expected Vert.x Buffer type."); //$NON-NLS-1$
+        }
+    }
+
+    @Override
+    public void end() {
+        //logger.debug("HttpConnector clientRequest.end");
+        clientRequest.end();
+        inboundFinished = true;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return inboundFinished && outboundFinished;
+    }
+
+    private URL parseServiceEndpoint(Service service) {
+        try {
+            return new URL(service.getEndpoint());
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private class ExceptionHandler implements Handler<Throwable> {
+        @Override
+        public void handle(Throwable error) {
+            resultHandler.handle(AsyncResultImpl
+                    .<IServiceConnectionResponse> create(error));
+        }
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/conversation/AbstractServiceExecutor.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/conversation/AbstractServiceExecutor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.conversation;
+
+import io.apiman.gateway.vertx.config.VertxEngineConfig;
+import io.apiman.gateway.vertx.io.ISimpleWriteStream;
+
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.eventbus.EventBus;
+import org.vertx.java.core.json.impl.Json;
+import org.vertx.java.core.logging.Logger;
+
+/**
+ * Execute a service
+ *
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public abstract class AbstractServiceExecutor<H> implements ISimpleWriteStream {
+
+    protected EventBus eb;
+    protected Logger logger;
+    protected String address;
+
+    protected boolean finished;
+
+    public AbstractServiceExecutor(String address, EventBus eb, Logger logger) {
+        this.address = address;
+        this.eb = eb;
+        this.logger = logger;
+        this.finished = false;
+    }
+
+    // Send head
+    protected void execute(H service) {
+        eb.send(address + VertxEngineConfig.APIMAN_RT_HEAD_SUFFIX, Json.encode(service));
+    }
+
+    public void write(Buffer chunk) {
+        eb.send(address + VertxEngineConfig.APIMAN_RT_BODY_SUFFIX, chunk);
+    }
+
+    public void end() {
+        eb.send(address + VertxEngineConfig.APIMAN_RT_END_SUFFIX, (Void) null);
+        finished = true;
+    }
+
+    /**
+     * @return the finished
+     */
+    public boolean isFinished() {
+        return finished;
+    }
+
+    public void reset() {
+        this.finished = false;
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/conversation/AbstractServiceListener.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/conversation/AbstractServiceListener.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.conversation;
+
+import io.apiman.gateway.vertx.config.VertxEngineConfig;
+import io.apiman.gateway.vertx.io.IResettable;
+
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.eventbus.EventBus;
+import org.vertx.java.core.eventbus.Message;
+import org.vertx.java.core.json.impl.Json;
+import org.vertx.java.core.logging.Logger;
+
+/**
+ * Listen for something.
+ *
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public abstract class AbstractServiceListener<E> implements IResettable {
+
+    protected EventBus eb;
+    protected Logger logger;
+    protected String address;
+    protected boolean finished = false;
+
+    private Handler<Void> finishHandler;
+    private Handler<E> serviceHandler;
+    private Handler<Buffer> bodyHandler;
+    private Class<E> klazz;
+    private Handler<Throwable> errorHandler;
+
+    public AbstractServiceListener(EventBus eb, Logger logger, String address, Class<E> klazz) {
+        this.eb = eb;
+        this.logger = logger;
+        this.address = address;
+        this.klazz = klazz;
+    }
+
+    protected void listen() {
+        eb.registerHandler(address + VertxEngineConfig.APIMAN_RT_HEAD_SUFFIX, new Handler<Message<String>>() {
+
+            @Override
+            public void handle(Message<String> message) {
+
+                E serviceObj = Json.<E>decodeValue(message.body(), klazz);
+
+                if (serviceHandler != null)
+                    serviceHandler.handle(serviceObj);
+            }
+        });
+
+        eb.registerHandler(address + VertxEngineConfig.APIMAN_RT_BODY_SUFFIX, new Handler<Message<Buffer>>() {
+
+            @Override
+            public void handle(Message<Buffer> event) {
+                if(finished) {
+                    throw new IllegalStateException("Block arrived after #end() was called."); //$NON-NLS-1$
+                }
+
+                if (bodyHandler != null)
+                    bodyHandler.handle(event.body());
+            }
+        });
+
+        eb.registerHandler(address + VertxEngineConfig.APIMAN_RT_END_SUFFIX, new Handler<Message<Void>>() {
+
+            @Override
+            public void handle(Message<Void> signal) {
+                logger.debug("Received finish signal in ServiceListener");
+                end();
+            }
+        });
+
+        eb.registerHandler(address + VertxEngineConfig.APIMAN_RT_ERROR_SUFFIX, new Handler<Message<String>>() {
+
+            @Override
+            public void handle(Message<String> message) {
+                if (errorHandler != null){
+                    errorHandler.handle(Json.<Throwable>decodeValue(message.body(), Throwable.class));
+                }
+                end();
+            }
+        });
+    }
+
+    protected void end() {
+        if (finishHandler != null && !finished){
+            finished = true;
+            finishHandler.handle((Void) null);
+        }
+    }
+
+    public void serviceHandler(Handler<E> handler) {
+        this.serviceHandler = handler;
+    }
+
+    public void bodyHandler(Handler<Buffer> bodyHandler) {
+        this.bodyHandler = bodyHandler;
+    }
+
+    public void endHandler(Handler<Void> finishHandler) {
+        this.finishHandler = finishHandler;
+    }
+
+    public void errorHandler(Handler<Throwable> errorHandler) {
+        this.errorHandler = errorHandler;
+    }
+
+    /**
+     * @return the finished
+     */
+    public boolean isFinished() {
+        return finished;
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/conversation/ServiceRequestListener.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/conversation/ServiceRequestListener.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.conversation;
+
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.vertx.config.VertxEngineConfig;
+
+import org.vertx.java.core.eventbus.EventBus;
+import org.vertx.java.core.logging.Logger;
+
+/**
+ * Handle a service request.
+ *
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class ServiceRequestListener extends AbstractServiceListener<ServiceRequest> {
+
+    public ServiceRequestListener(EventBus eb, Logger logger, String address) {
+        super(eb, logger, address, ServiceRequest.class);
+        logger.debug(ServiceRequestListener.class.getCanonicalName()+ " on " + address);
+    }
+
+    @Override
+    public void listen() {
+        super.listen();
+    }
+
+    @Override
+    public void reset() {
+       finished = false;
+    }
+
+    public void ready() {
+        logger.debug("Sending ready flag on the bus - ready to receive data " +
+          address + VertxEngineConfig.APIMAN_RT_READY_SUFFIX);
+
+        eb.send(address + VertxEngineConfig.APIMAN_RT_READY_SUFFIX, (Void) null);
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/conversation/ServiceResponseExecutor.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/conversation/ServiceResponseExecutor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.conversation;
+
+import io.apiman.gateway.vertx.config.VertxEngineConfig;
+import io.apiman.gateway.vertx.io.IResettable;
+import io.apiman.gateway.engine.beans.PolicyFailure;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.eventbus.EventBus;
+import org.vertx.java.core.json.impl.Json;
+import org.vertx.java.core.logging.Logger;
+
+/**
+ * Send a service response
+ *
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class ServiceResponseExecutor implements IResettable {
+
+    private EventBus eb;
+    @SuppressWarnings("unused")
+    private Logger logger;
+    private String address;
+    private boolean finished = false;
+
+    public ServiceResponseExecutor(EventBus eb, Logger logger, String address) {
+        this.eb = eb;
+        this.logger = logger;
+        this.address = address;
+    }
+
+    public void writeResponse(ServiceResponse serviceResponse) {
+        eb.send(address + VertxEngineConfig.APIMAN_RT_HEAD_SUFFIX, Json.encode(serviceResponse));
+    }
+
+    public void write(Buffer bodyBuffer) {
+        if(finished) {
+            throw new IllegalStateException("Attempted write to connector after #end() was called.");
+        }
+
+        eb.send(address + VertxEngineConfig.APIMAN_RT_BODY_SUFFIX, bodyBuffer);
+    }
+
+    public void end() {
+        eb.send(address + VertxEngineConfig.APIMAN_RT_END_SUFFIX, (Void) null);
+        finished = true;
+    }
+
+    public void error(Throwable error) {
+        eb.send(address + VertxEngineConfig.APIMAN_RT_ERROR_SUFFIX, Json.encode(error));
+    }
+
+    public void failure(PolicyFailure failure) {
+        eb.send(address + VertxEngineConfig.APIMAN_RT_FAILURE_SUFFIX, Json.encode(failure));
+    }
+
+    public boolean isFinished() {
+        return finished;
+    }
+
+    public void reset() {
+        finished = false;
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/conversation/ServiceResponseListener.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/conversation/ServiceResponseListener.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.conversation;
+
+import io.apiman.gateway.vertx.common.DoubleHandler;
+import io.apiman.gateway.vertx.config.VertxEngineConfig;
+import io.apiman.gateway.engine.beans.PolicyFailure;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.Vertx;
+import org.vertx.java.core.eventbus.Message;
+import org.vertx.java.core.http.HttpServerResponse;
+import org.vertx.java.core.json.impl.Json;
+import org.vertx.java.platform.Container;
+
+/**
+ * Listen for a {@link ServiceResponse}.
+ *
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class ServiceResponseListener extends AbstractServiceListener<ServiceResponse> {
+    protected HttpServerResponse serverResponse;
+    private DoubleHandler<PolicyFailure, String> failureHandler;
+
+    public ServiceResponseListener(Vertx vertx, Container container, String address) {
+        super(vertx.eventBus(), container.logger(), address, ServiceResponse.class);
+    }
+
+    @Override
+    public void listen() {
+        logger.debug("ServiceResponseListener listening on " + address);
+
+        eb.registerHandler(address + VertxEngineConfig.APIMAN_RT_FAILURE_SUFFIX, new Handler<Message<String>>() {
+
+            @Override
+            public void handle(Message<String> message) {
+                PolicyFailure failure = Json.decodeValue(message.body(), PolicyFailure.class);
+                failureHandler.handle(failure, message.body().toString());
+            }
+        });
+
+        super.listen();
+    }
+
+    public void policyFailureHandler(DoubleHandler<PolicyFailure, String> failureHandler) {
+        this.failureHandler = failureHandler;
+    }
+
+    @Override
+    public void reset() {
+        finished = false;
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/conversation/SignalRequestExecutor.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/conversation/SignalRequestExecutor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.conversation;
+
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.vertx.config.VertxEngineConfig;
+import io.apiman.gateway.vertx.io.IReadyExecute;
+import io.apiman.gateway.vertx.io.ISimpleWriteStream;
+
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.Vertx;
+import org.vertx.java.core.eventbus.EventBus;
+import org.vertx.java.core.eventbus.Message;
+import org.vertx.java.platform.Container;
+
+/**
+ * Send a {@link ServiceRequest} over the {@link EventBus}.
+ *
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class SignalRequestExecutor<H> extends AbstractServiceExecutor<H> implements IReadyExecute<H, ISimpleWriteStream> {
+
+    public SignalRequestExecutor(Vertx vertx, Container container, String address) {
+        super(address, vertx.eventBus(), container.logger());
+    }
+
+    // Signals when the other end is ready to receive blocks.
+    public void execute(final H service, final Handler<ISimpleWriteStream> readyHandler) {
+        logger.debug("Listening for ready on: " + address + VertxEngineConfig.APIMAN_RT_READY_SUFFIX);
+
+        eb.registerHandler(address + VertxEngineConfig.APIMAN_RT_READY_SUFFIX, new Handler<Message<Void>>() {
+
+            @Override
+            public void handle(Message<Void> signal) {
+                //logger.debug("Got the OK signal!");
+                readyHandler.handle(SignalRequestExecutor.this);
+            }
+        });
+
+        super.execute(service);
+    }
+
+    public void reset() {
+        super.reset();
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/engine/VertxConfigDrivenComponentRegistry.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/engine/VertxConfigDrivenComponentRegistry.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.engine;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
+
+import org.vertx.java.core.Vertx;
+
+import io.apiman.gateway.engine.IComponent;
+import io.apiman.gateway.engine.beans.exceptions.ComponentNotFoundException;
+import io.apiman.gateway.engine.impl.ConfigDrivenComponentRegistry;
+import io.apiman.gateway.vertx.config.VertxEngineConfig;
+
+/**
+ * Extends {@link ConfigDrivenComponentRegistry} to allow components to be constructed with a {@link Vertx}
+ * instance; else the standard mechanisms are fallen back on.
+ *
+ * @see ConfigDrivenComponentRegistry
+ *
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class VertxConfigDrivenComponentRegistry extends ConfigDrivenComponentRegistry {
+
+    private VertxEngineConfig engineConfig;
+    private Vertx vertx;
+
+    public VertxConfigDrivenComponentRegistry(Vertx vertx, VertxEngineConfig engineConfig) {
+        super(engineConfig);
+        this.engineConfig = engineConfig;
+        this.vertx = vertx;
+    }
+
+    @Override
+    public <T extends IComponent> T createAndRegisterComponent(Class<T> componentType)
+            throws ComponentNotFoundException {
+        try {
+            Class<T> componentClass = engineConfig.getComponentClass(componentType);
+            Map<String, String> componentConfig = engineConfig.getComponentConfig(componentType);
+            T component = createWithVertx(componentClass, engineConfig, componentConfig);
+            super.addComponentMapping(componentType, component);
+            return component;
+        } catch (Exception e) {
+            throw new ComponentNotFoundException(componentType.getName(), e);
+        }
+    }
+
+    /**
+     * Creates components, but allows a {@link #vertx} instance to be passed in.
+     *
+     * Note that we can't have a static {@link #vertx} object, so we can't override the super method.
+     *
+     * @param type component type
+     * @param config configuration (if necessary).
+     * @return instance of Class<T>
+     */
+    protected <T> T createWithVertx(Class<T> type, VertxEngineConfig engineConfig, Map<String, String> mapConfig) {
+        try {
+            Constructor<T> constructor = type.getConstructor(Vertx.class, VertxEngineConfig.class, Map.class);
+            return constructor.newInstance(vertx, engineConfig, mapConfig);
+        } catch (Exception e) {
+        }
+        try {
+            Constructor<T> constructor = type.getConstructor(Map.class);
+            return constructor.newInstance(mapConfig);
+        } catch (Exception e) {
+        }
+        try {
+            return type.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/engine/VertxConfigDrivenEngineFactory.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/engine/VertxConfigDrivenEngineFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.engine;
+
+import org.vertx.java.core.Vertx;
+import org.vertx.java.platform.Container;
+
+import io.apiman.gateway.engine.IComponentRegistry;
+import io.apiman.gateway.engine.IConnectorFactory;
+import io.apiman.gateway.engine.impl.ConfigDrivenEngineFactory;
+import io.apiman.gateway.vertx.config.VertxEngineConfig;
+import io.apiman.gateway.vertx.connector.ConnectorFactory;
+
+/**
+ * A configuration driven engine specifically for Vert.x
+ * 
+ * @see ConfigDrivenEngineFactory
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class VertxConfigDrivenEngineFactory extends ConfigDrivenEngineFactory {
+
+    private Vertx vertx;
+    private Container container;
+    private VertxEngineConfig vxConfig;
+
+    public VertxConfigDrivenEngineFactory(Vertx vertx, Container container, VertxEngineConfig config) {
+        super(config);
+        this.vertx  = vertx;
+        this.container = container;
+        this.vxConfig = config;
+    }
+    
+    @Override
+    protected IConnectorFactory createConnectorFactory() {
+        return new ConnectorFactory(vertx, container);
+    }
+    
+    @Override
+    protected IComponentRegistry createComponentRegistry() {
+        return new VertxConfigDrivenComponentRegistry(vertx, vxConfig);
+    }
+   
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/http/HttpGatewayStreamer.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/http/HttpGatewayStreamer.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.http;
+
+import java.util.Map.Entry;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.Vertx;
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.http.HttpHeaders;
+import org.vertx.java.core.http.HttpServerRequest;
+import org.vertx.java.core.http.HttpServerResponse;
+import org.vertx.java.core.logging.Logger;
+import org.vertx.java.platform.Container;
+
+import io.apiman.gateway.engine.beans.PolicyFailure;
+import io.apiman.gateway.engine.beans.PolicyFailureType;
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.vertx.common.DoubleHandler;
+import io.apiman.gateway.vertx.config.VertxEngineConfig;
+import io.apiman.gateway.vertx.conversation.ServiceResponseListener;
+import io.apiman.gateway.vertx.conversation.SignalRequestExecutor;
+import io.apiman.gateway.vertx.io.ISimpleWriteStream;
+import io.apiman.gateway.vertx.verticles.PolicyVerticle;
+import io.apiman.gateway.vertx.worker.Registrant;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Handles an {@link HttpServerRequest}<=>{@link HttpServerResponse} conversation. This involves converting
+ * the HTTP data into appropriate apiman equivalents which are pushed onto the event bus, where a
+ * corresponding {@link PolicyVerticle} is awaiting data on the other end. Successful, unsuccessful and
+ * erroneous responses are all handled and unmarshalled, as appropriate; for instance, all response types are
+ * translated into their equivalent HTTP response codes.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class HttpGatewayStreamer implements Registrant, Handler<HttpServerRequest> {
+
+    private String policyVerticleAddress;
+    private String stripString;
+    private Logger logger;
+
+    private SignalRequestExecutor<ServiceRequest> requestExecutor;
+    private ServiceResponseListener responseListener;
+
+    private HttpServerRequest request;
+    private HttpServerResponse response;
+    private Handler<Void> endHandler;
+
+    public HttpGatewayStreamer(Vertx vertx, Container container, String policyVerticleAddress, String stripString) {
+        this.policyVerticleAddress = policyVerticleAddress;
+        this.logger = container.logger();
+        this.stripString = stripString;
+
+        // Handles request related stuff
+        requestExecutor = new SignalRequestExecutor<>(vertx, container, policyVerticleAddress
+                + VertxEngineConfig.APIMAN_RT_EP_SERVICE_REQUEST);
+
+        // Handles response related stuff
+        responseListener = new ServiceResponseListener(vertx, container, policyVerticleAddress
+                + VertxEngineConfig.APIMAN_RT_EP_SERVICE_RESPONSE);
+    }
+
+    @Override
+    public String getAddress() {
+        return policyVerticleAddress;
+    }
+
+    @Override
+    public void handle(HttpServerRequest r) {
+        this.request = r;
+
+        request.pause();
+
+        handleResponse(request.response());
+
+        ServiceRequest serviceRequest = HttpServiceFactory.build(request, stripString);
+
+        // Received a request, handler called when #ready has been indicated.
+        requestExecutor.execute(serviceRequest, new Handler<ISimpleWriteStream>() {
+
+            @Override
+            public void handle(final ISimpleWriteStream writeStream) {
+                request.dataHandler(new Handler<Buffer>() {
+
+                    @Override
+                    public void handle(Buffer buffer) {
+                        writeStream.write(buffer);
+                    }
+                });
+
+                request.endHandler(new Handler<Void>() {
+
+                    @Override
+                    public void handle(Void flag) {
+                        writeStream.end();
+                    }
+                });
+
+                logger.debug("Resuming GatewayStreamer receive");
+                // As we've now set the handlers, it's safe to resume.
+                request.resume();
+            }
+        });
+    }
+
+    private void handleResponse(HttpServerResponse r) {
+        this.response = r;
+
+        response.setChunked(true);
+
+        responseListener.serviceHandler(new Handler<ServiceResponse>() {
+
+            @Override
+            public void handle(ServiceResponse amanResponse) {
+                logger.debug("Received a response on: " + policyVerticleAddress + " code: "
+                        + amanResponse.getCode() + " with message: " + amanResponse.getMessage());
+
+                HttpServiceFactory.buildResponse(response, amanResponse);
+            }
+        });
+
+        // Set up the response listening sections.
+        responseListener.bodyHandler(new Handler<Buffer>() {
+
+            @Override
+            public void handle(Buffer buffer) {
+                logger.debug("Received chunk in GatewayStreamer " + buffer.toString());
+                response.write(buffer);
+            }
+        });
+
+        responseListener.endHandler(new Handler<Void>() {
+
+            @Override
+            public void handle(Void flag) {
+                end(response);
+            }
+        });
+
+        // TODO move to ServiceFactory
+        responseListener.errorHandler(new Handler<Throwable>() {
+
+            @Override
+            public void handle(Throwable error) {
+                response.setStatusCode(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+                response.setStatusMessage(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase());
+                response.headers().add("X-Exception", String.valueOf(error.getMessage()));
+                response.write(ExceptionUtils.getStackTrace(error));
+                end(response);
+            }
+        });
+
+        responseListener.policyFailureHandler(new DoubleHandler<PolicyFailure, String>() {
+
+            @Override
+            public void handle(PolicyFailure failure, String rawResponse) {
+              response.headers().add("X-Policy-Failure-Type", String.valueOf(failure.getType()));
+              response.headers().add("X-Policy-Failure-Message", failure.getMessage());
+              response.headers().add("X-Policy-Failure-Code", String.valueOf(failure.getFailureCode()));
+              response.headers().add(HttpHeaders.CONTENT_TYPE, "application/json"); //$NON-NLS-N$
+
+              HttpResponseStatus status = HttpResponseStatus.INTERNAL_SERVER_ERROR;
+
+              if (failure.getType() == PolicyFailureType.Authentication) {
+                  status = HttpResponseStatus.UNAUTHORIZED;
+              } else if (failure.getType() == PolicyFailureType.Authorization) {
+                  status = HttpResponseStatus.FORBIDDEN;
+              }
+
+              response.setStatusCode(status.code());
+              response.setStatusMessage(failure.getMessage());
+
+              for (Entry<String, String> entry : failure.getHeaders().entrySet()) {
+                  response.headers().add(entry.getKey(), entry.getValue());
+              }
+
+              response.write(rawResponse);
+              end(response);
+            }
+        });
+
+        responseListener.listen();
+    }
+
+    @Override
+    public void endHandler(Handler<Void> endHandler) {
+        this.endHandler = endHandler;
+    }
+
+    private void end(HttpServerResponse response) {
+        response.end();
+        requestExecutor.reset();
+        responseListener.reset();
+
+        if(endHandler != null)
+            endHandler.handle((Void) null);
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/http/HttpGatewayStreamerMultiplexer.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/http/HttpGatewayStreamerMultiplexer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.http;
+
+import io.apiman.gateway.vertx.config.VertxEngineConfig;
+import io.apiman.gateway.vertx.worker.ServiceWorkerQueue;
+
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.Vertx;
+import org.vertx.java.core.http.HttpServerRequest;
+import org.vertx.java.core.logging.Logger;
+import org.vertx.java.platform.Container;
+
+/**
+ * Handles each {@link HttpServerRequest} arriving and dispatches to a {@link HttpGatewayStreamer} worker to deal
+ * with. Once a conversation completes, the worker is made available for subsequent work..
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class HttpGatewayStreamerMultiplexer implements Handler<HttpServerRequest> {
+
+    private Logger logger;
+    private ServiceWorkerQueue workerQueue;
+
+    public HttpGatewayStreamerMultiplexer(Vertx vertx, Container container, String stripString) {
+        logger = container.logger();
+        this.workerQueue = new ServiceWorkerQueue(vertx, container,
+                VertxEngineConfig.APIMAN_RT_EP_GATEWAY_REG_POLICY, stripString);
+    }
+
+    @Override
+    public void handle(final HttpServerRequest request) {
+        // Get a gateway streamer from the queue (or create one).
+        workerQueue.poll(new Handler<HttpGatewayStreamer>() {
+
+            @Override
+            public void handle(final HttpGatewayStreamer gatewayStreamer) {
+
+                gatewayStreamer.endHandler(new Handler<Void>() {
+
+                    @Override
+                    public void handle(Void flag) {
+                        logger.debug("Reinserted worker back into the queue (it has finished!)");
+                        workerQueue.add(gatewayStreamer);
+                    }
+                });
+                logger.debug("Got a request, let's do the business!");
+                gatewayStreamer.handle(request);
+            }
+        });
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/http/HttpServiceFactory.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/http/HttpServiceFactory.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.http;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+
+import org.apache.commons.lang3.StringUtils;
+import org.vertx.java.core.MultiMap;
+import org.vertx.java.core.http.HttpClientResponse;
+import org.vertx.java.core.http.HttpServerRequest;
+import org.vertx.java.core.http.HttpServerResponse;
+
+/**
+ * Construct {@link ServiceRequest} and {@link ServiceResponse} objects from {@link HttpServerRequest},
+ * {@link HttpServerResponse} and {@link HttpClientResponse}
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class HttpServiceFactory {
+    
+    public static ServiceResponse buildResponse(HttpClientResponse response, Set<String> suppressHeaders) {
+        ServiceResponse apimanResponse = new ServiceResponse();
+        apimanResponse.setCode(response.statusCode());
+        parseHeaders(apimanResponse.getHeaders(), response.headers(), suppressHeaders);
+        apimanResponse.setMessage(response.statusMessage());
+        
+        return apimanResponse;
+    }
+    
+    public static ServiceResponse buildResponse(HttpServerResponse response) {
+        return buildResponse(response, new ServiceResponse());
+    }
+    
+    public static ServiceResponse buildResponse(HttpServerResponse response, ServiceResponse amanResponse) {
+        response.headers().add(amanResponse.getHeaders());
+        response.setStatusCode(amanResponse.getCode());
+        response.setStatusMessage(amanResponse.getMessage());
+        
+        return amanResponse;
+    }
+    
+    public static ServiceRequest build(HttpServerRequest req, String stripFromStart) {
+        ServiceRequest apimanRequest = new ServiceRequest();
+        apimanRequest.setApiKey(parseApiKey(req));
+        parseHeaders(apimanRequest.getHeaders(), req.headers(), Collections.<String>emptySet());
+        
+        // Remove the gateway's URI from the start of the path if it's there.
+        apimanRequest.setDestination(StringUtils.removeStart(req.path(), "/" + stripFromStart));
+        apimanRequest.setRemoteAddr(req.remoteAddress().getAddress().getHostAddress());
+        apimanRequest.setType(req.method());
+
+        return apimanRequest;
+    }
+
+    private static void parseHeaders(Map<String, String> map, MultiMap multimap, Set<String> suppressHeaders) {
+        for (Map.Entry<String, String> entry : multimap) {
+            if(!suppressHeaders.contains(entry.getKey())) {
+                map.put(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    private static String parseApiKey(HttpServerRequest req) {
+        String headerKey = req.headers().get("X-API-Key"); //$NON-NLS-1$
+        if (headerKey == null || headerKey.trim().length() == 0) {
+            headerKey = parseApiKeyFromQuery(req);
+        }
+        return headerKey;
+    }
+
+    private static String parseApiKeyFromQuery(HttpServerRequest req) {
+        String queryString = req.query();
+        
+        if(queryString == null)
+            return "<none>";
+        
+        int idx = queryString.indexOf("apikey="); //$NON-NLS-1$
+        if (idx >= 0) {
+            int endIdx = queryString.indexOf('&', idx);
+            if (endIdx == -1) {
+                endIdx = queryString.length();
+            }
+            return queryString.substring(idx + 7, endIdx);
+        } else {
+            return null;
+        }
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/io/IReadyExecute.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/io/IReadyExecute.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.io;
+
+import org.vertx.java.core.Handler;
+
+/**
+ * An object whose main action can be triggered by calling {@link #execute(Object, Handler)}, with a ready
+ * {@link Handler} indicating when it is safe to perform an implementation-specified subsequent action. For
+ * instance, after writing a head object a stream object is returned via the readyHandler once it is ready to
+ * accept data.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ *
+ * @param <H> Head object
+ * @param <S> Succeeding object
+ */
+public interface IReadyExecute<H, S> {
+    /**
+     * @param head object to execute immediately
+     * @param readyHandler called when ready
+     */
+    void execute(H head, Handler<S> readyHandler);
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/io/IResettable.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/io/IResettable.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.io;
+
+/**
+ * Given object is resettable, which implies it can be reused after {@link #reset()} has been invoked.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public interface IResettable {
+    
+    /**
+     * Reset object
+     */
+    void reset();
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/io/ISimpleWriteStream.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/io/ISimpleWriteStream.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.io;
+
+import org.vertx.java.core.buffer.Buffer;
+
+/**
+ * Interface representing simple write/end combination.
+ * 
+ * {@link #write(Buffer)} may be called an undefined number of times before {@link #end()} signals that
+ * transmission has ended. No subsequent data should arrive after {@link #end()} has been signalled.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public interface ISimpleWriteStream {
+    /**
+     * Write a chunk
+     * 
+     * @param buffer data chunk
+     */
+    void write(Buffer chunk);
+    
+    /**
+     * Finished writing chunks. No further calls to {@link #write(Buffer)} should occur.
+     */
+    void end();
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/io/VertxApimanBuffer.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/io/VertxApimanBuffer.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.io;
+
+import java.io.UnsupportedEncodingException;
+
+import org.vertx.java.core.buffer.Buffer;
+
+import io.apiman.gateway.engine.io.IApimanBuffer;
+
+/**
+ * An {@link IApimanBuffer} implementation that wraps Vert.x's native {@link Buffer} format.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class VertxApimanBuffer implements IApimanBuffer {
+
+    private Buffer nativeBuffer;
+    
+    public VertxApimanBuffer(Buffer nativeBuffer) {
+        this.nativeBuffer = nativeBuffer;
+    }
+
+    @Override
+    public Object getNativeBuffer() {
+        return nativeBuffer;
+    }
+
+    @Override
+    public int length() {
+        return nativeBuffer.length();
+    }
+
+    @Override
+    public void insert(int index, IApimanBuffer buffer) {
+       nativeBuffer.setBuffer(index, (Buffer) buffer.getNativeBuffer());
+    }
+
+    @Override
+    public void insert(int index, IApimanBuffer buffer, int offset, int length) {
+        nativeBuffer.setBuffer(index, (Buffer) buffer, offset, length);
+    }
+
+    @Override
+    public void append(IApimanBuffer buffer) {
+        nativeBuffer.appendBuffer((Buffer) buffer);
+    }
+
+    @Override
+    public void append(IApimanBuffer buffer, int offset, int length) {
+        nativeBuffer.appendBuffer((Buffer) buffer, offset, length);
+    }
+
+    @Override
+    public byte get(int index) {
+        return nativeBuffer.getByte(index);
+    }
+
+    @Override
+    public void set(int index, byte b) {
+        nativeBuffer.setByte(index, b);
+    }
+
+    @Override
+    public void append(byte b) {
+        nativeBuffer.appendByte(b);
+    }
+
+    @Override
+    public byte[] getBytes() {
+        return nativeBuffer.getBytes();
+    }
+
+    @Override
+    public byte[] getBytes(int start, int end) {
+        return nativeBuffer.getBytes(start, end);
+    }
+
+    @Override
+    public void insert(int index, byte[] b) {
+        nativeBuffer.setBytes(index, b);
+    }
+
+    @Override
+    public void insert(int index, byte[] b, int offset, int length) {
+        nativeBuffer.setBytes(index, b, offset, length);
+    }
+
+    @Override
+    public void append(byte[] bytes) {
+        nativeBuffer.appendBytes(bytes);
+    }
+
+    @Override
+    public void append(byte[] bytes, int offset, int length) {
+        nativeBuffer.appendBytes(bytes, offset, length);
+    }
+
+    @Override
+    public String getString(int start, int end) {
+        return nativeBuffer.getString(start, end);
+    }
+
+    @Override
+    public String getString(int start, int end, String encoding) throws UnsupportedEncodingException {
+        return nativeBuffer.getString(start, end, encoding);
+    }
+
+    @Override
+    public void insert(int index, String string) {
+        nativeBuffer.setString(index, string);
+    }
+
+    @Override
+    public void insert(int index, String string, String encoding) throws UnsupportedEncodingException {
+        nativeBuffer.setString(index, string, encoding);
+    }
+
+    @Override
+    public void append(String string) {
+        nativeBuffer.appendString(string);
+    }
+
+    @Override
+    public void append(String string, String encoding) throws UnsupportedEncodingException {
+        nativeBuffer.appendString(string, encoding);
+    }
+
+    @Override
+    public String toString(String encoding) throws UnsupportedEncodingException {
+        return nativeBuffer.toString(encoding);
+    }
+    
+    @Override
+    public String toString() {
+        return nativeBuffer.toString();
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/verticles/ApimanVerticleBase.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/verticles/ApimanVerticleBase.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.verticles;
+
+import java.util.UUID;
+
+import io.apiman.gateway.vertx.config.VertxEngineConfig;
+
+import org.vertx.java.busmods.BusModBase;
+
+/**
+ * Standard base for all Apiman verticles.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public abstract class ApimanVerticleBase extends BusModBase {
+
+    protected VertxEngineConfig amanConfig;
+    protected String uuid;
+
+    @Override
+    public void start() {
+        super.start();
+        amanConfig = getEngineConfig();
+        
+        // If someone provides a UUID we use it, else generate one.
+        if(config.containsField("uuid")) {
+            uuid = config.getString("uuid");
+        } else {
+            uuid = UUID.randomUUID().toString();
+        }
+
+        logger.info("Starting verticle: " + this.getClass().getName() + "\n" + 
+                "Type: " + verticleType() + "\n" +
+                "UUID: " + uuid + "\n");
+    }
+
+    /**
+     * Maps to config.
+     * @return Verticle's type
+     */
+    public abstract String verticleType();
+    
+    // Override this for verticle specific config & testing.
+    protected VertxEngineConfig getEngineConfig() {
+       return new VertxEngineConfig(config); 
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/verticles/ApimanVerticleWithEngine.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/verticles/ApimanVerticleWithEngine.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.verticles;
+
+import io.apiman.gateway.engine.IEngine;
+import io.apiman.gateway.vertx.api.ApiListener;
+import io.apiman.gateway.vertx.engine.VertxConfigDrivenEngineFactory;
+
+/**
+ * A base for those verticles that require an instantiated engine, and associated API Listener to receive
+ * updates.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public abstract class ApimanVerticleWithEngine extends ApimanVerticleBase {
+    
+    protected IEngine engine;
+    protected ApiListener apiListener;
+    
+    @Override
+    public void start() {
+        super.start();
+        
+        engine = new VertxConfigDrivenEngineFactory(vertx, container, amanConfig).createEngine();
+        
+        apiListener = new ApiListener(eb, uuid);
+        apiListener.listen(engine);
+    }
+
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/verticles/HttpApiVerticle.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/verticles/HttpApiVerticle.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.verticles;
+
+import io.apiman.gateway.engine.beans.ServiceEndpoint;
+import io.apiman.gateway.engine.beans.SystemStatus;
+import io.apiman.gateway.vertx.api.AuthenticatingRouteMatcher;
+import io.apiman.gateway.vertx.api.GenericError;
+import io.apiman.gateway.vertx.config.VertxEngineConfig;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.vertx.java.core.AsyncResult;
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.eventbus.Message;
+import org.vertx.java.core.http.HttpServer;
+import org.vertx.java.core.http.HttpServerRequest;
+import org.vertx.java.core.http.HttpServerResponse;
+import org.vertx.java.core.http.RouteMatcher;
+import org.vertx.java.core.json.JsonObject;
+import org.vertx.java.core.json.impl.Json;
+
+/**
+ * Verticle implementing apiman's gateway API.
+ *
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class HttpApiVerticle extends ApimanVerticleWithEngine {
+
+    private RouteMatcher routeMatcher;
+    private Set<String> apiSubscriberSet = new HashSet<>();
+
+    @Override
+    public void start() {
+        super.start();
+
+        routeMatcher = new AuthenticatingRouteMatcher(amanConfig, logger);
+        initializeApi();
+        listen();
+    }
+
+    public void listen() {
+        vertx.createHttpServer()
+                .requestHandler(routeMatcher)
+                .listen(amanConfig.getRouteMap().getAddress(verticleType()), amanConfig.hostname(),
+                        new Handler<AsyncResult<HttpServer>>() {
+
+                            @Override
+                            public void handle(AsyncResult<HttpServer> event) {
+                                apiListener.listen(engine);
+                            }
+                        });
+    }
+
+    @Override
+    public String verticleType() {
+        return "api";
+    }
+
+    private void initializeApi() {
+        // Collect verticles that are interested in updates.
+        eb.registerHandler(VertxEngineConfig.APIMAN_API_SUBSCRIBE, new Handler<Message<String>>() {
+
+            @Override
+            public void handle(Message<String> message) {
+                apiSubscriberSet.add(message.body());
+                //logger.info("Adding api subscriber " + message.body());
+            };
+        });
+
+        // Set up routematcher
+        setupRoutes();
+    }
+
+    private void setupRoutes() {
+        applicationApi();
+        serviceApi();
+        systemApi();
+
+        // Default handler
+        routeMatcher.allWithRegEx(".*", new Handler<HttpServerRequest>() {
+
+            @Override
+            public void handle(HttpServerRequest request) {
+                request.response().setStatusCode(HttpResponseStatus.NOT_FOUND.code());
+                request.response().setStatusMessage(HttpResponseStatus.NOT_FOUND.reasonPhrase());
+                request.response().end();
+            }
+        });
+    }
+
+    private void applicationApi() {
+        // Register
+        routeMatcher.put("/api/applications", new Handler<HttpServerRequest>() {
+
+            @Override
+            public void handle(final HttpServerRequest request) {
+                request.bodyHandler(new Handler<Buffer>() {
+
+                    @Override
+                    public void handle(Buffer body) {
+                        logger.debug("Got put request for applications register");
+
+                        sendAll(VertxEngineConfig.APIMAN_API_APPLICATIONS_REGISTER, body.toString(),
+
+                                new ResponseHandler(request.response(), new Handler<Void>() {
+
+                                    @Override
+                                    public void handle(Void event) {
+                                        request.response().setStatusCode(HttpResponseStatus.NO_CONTENT.code());
+                                    }
+                                })
+                        );
+                    }
+                });
+
+            }
+        });
+
+        // Unregister
+        routeMatcher.delete("/api/applications/:organizationId/:applicationId/:version",
+                new Handler<HttpServerRequest>() {
+
+                    @Override
+                    public void handle(final HttpServerRequest request) {
+                        JsonObject json = new JsonObject();
+                        json.putString("organizationId", request.params().get("organizationId"));
+                        json.putString("applicationId", request.params().get("applicationId"));
+                        json.putString("version", request.params().get("version"));
+
+                        logger.debug(json);
+
+                        sendAll(VertxEngineConfig.APIMAN_API_APPLICATIONS_DELETE, json,
+                                new ResponseHandler(request.response(), new Handler<Void>() {
+
+                                    @Override
+                                    public void handle(Void event) {
+                                        request.response().setStatusCode(HttpResponseStatus.NO_CONTENT.code());
+                                    }
+                                }));
+                    }
+                });
+    }
+
+    private void serviceApi() {
+
+        // getServiceEndpoint
+        routeMatcher.get(":organizationId/:serviceId/:version/endpoint", new Handler<HttpServerRequest>() {
+
+            @Override
+            public void handle(HttpServerRequest request) {
+                ServiceEndpoint endpoint = new ServiceEndpoint();
+                endpoint.setEndpoint("http://" + amanConfig.getEndpoint() + ":"
+                        + amanConfig.getRouteMap().getAddress(HttpDispatcherVerticle.VERTICLE_NAME)); //$NON-NLS-N$
+                request.response().end(Json.encode(endpoint));
+            }
+        });
+
+        // Publish
+        routeMatcher.put("/api/services", new Handler<HttpServerRequest>() {
+
+            @Override
+            public void handle(final HttpServerRequest request) {
+                request.bodyHandler(new Handler<Buffer>() {
+
+                    @Override
+                    public void handle(Buffer body) {
+                        sendAll(VertxEngineConfig.APIMAN_API_SERVICES_REGISTER, body.toString(),
+                                new ResponseHandler(request.response(), new Handler<Void>() {
+
+                                    @Override
+                                    public void handle(Void event) {
+                                        request.response().setStatusCode(HttpResponseStatus.NO_CONTENT.code());
+                                    }
+                                }));
+                    }
+                });
+
+            }
+        });
+
+        // Retire
+        routeMatcher.delete("/api/services/:organizationId/:serviceId/:version",
+                new Handler<HttpServerRequest>() {
+
+                    @Override
+                    public void handle(final HttpServerRequest request) {
+                        JsonObject json = new JsonObject();
+                        json.putString("organizationId", request.params().get("organizationId"));
+                        json.putString("serviceId", request.params().get("serviceId"));
+                        json.putString("version", request.params().get("version"));
+
+                        logger.debug(json);
+
+                        sendAll(VertxEngineConfig.APIMAN_API_SERVICES_DELETE, json,
+                                new ResponseHandler(request.response(), new Handler<Void>() {
+
+                                    @Override
+                                    public void handle(Void event) {
+                                        request.response().setStatusCode(HttpResponseStatus.NO_CONTENT.code());
+                                    }
+                                }));
+                    }
+                });
+    }
+
+    private void systemApi() {
+        routeMatcher.get("/api/system", new Handler<HttpServerRequest>() {
+
+            @Override
+            public void handle(HttpServerRequest request) {
+                SystemStatus status = new SystemStatus();// TODO how to get/set global system status? Maybe
+                                                         // the init verticle is in charge of this.
+                status.setUp(true);
+                status.setVersion(engine.getVersion());
+
+                request.response().setChunked(true);
+                request.response().write(Json.encode(status));
+                request.response().end();
+            }
+        });
+    }
+
+    private void sendAll(String address, String message, final Handler<JsonObject> handler) {
+        StatusHandler statusHandler = new StatusHandler(handler);
+
+        for (String uuid : apiSubscriberSet) {
+            eb.send(uuid + address, message, statusHandler);
+        }
+    }
+
+    // TODO consolidate sendAll
+    private void sendAll(String address, JsonObject json, final Handler<JsonObject> handler) {
+        StatusHandler statusHandler = new StatusHandler(handler);
+
+        for (String uuid : apiSubscriberSet) {
+            eb.send(uuid + address, json, statusHandler);
+        }
+    }
+
+    private class StatusHandler implements Handler<Message<JsonObject>> {
+        private boolean collectiveStatus = true;
+        private int respondants = 0;
+        private Handler<JsonObject> responseHandler;
+        private boolean idempotent_flag = false;
+
+        public StatusHandler(Handler<JsonObject> responseHandler) {
+            this.responseHandler = responseHandler;
+        }
+
+        @Override
+        public void handle(Message<JsonObject> message) {
+            JsonObject json = message.body();
+            // Logical and together statuses to ensure all are true.
+            collectiveStatus = collectiveStatus && json.getBoolean("status");
+            // Call only iff: all responses are successful or on *first* failure.
+            // Duplicate failures are ignored to preserve idempotence.
+
+            if ((++respondants == apiSubscriberSet.size() && collectiveStatus)
+                    || (!collectiveStatus && !idempotent_flag)) {
+                idempotent_flag = true;
+                responseHandler.handle(json);
+            }
+        }
+    }
+
+    private class ResponseHandler implements Handler<JsonObject> {
+        private HttpServerResponse response;
+        private Handler<Void> handler;
+
+        public ResponseHandler(HttpServerResponse response, Handler<Void> handler) {
+            this.response = response;
+            this.handler = handler;
+        }
+
+        @Override
+        public void handle(JsonObject status) {
+            if (status.getBoolean("status")) {
+                handler.handle((Void) null);
+            } else {
+                GenericError error = Json.decodeValue(status.getObject("error").toString(),
+                        GenericError.class);
+
+                response.setStatusCode(error.getResponseCode());
+                response.setStatusMessage(error.getMessage());
+            }
+
+            response.end();
+        }
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/verticles/HttpDispatcherVerticle.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/verticles/HttpDispatcherVerticle.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.verticles;
+
+import io.apiman.gateway.vertx.config.RouteMapper;
+
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.VoidHandler;
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.http.HttpClient;
+import org.vertx.java.core.http.HttpClientRequest;
+import org.vertx.java.core.http.HttpClientResponse;
+import org.vertx.java.core.http.HttpServer;
+import org.vertx.java.core.http.HttpServerRequest;
+
+/**
+ * Dispatch incoming HTTP requests to the appropriate verticle. For instance, gateway requests to one place,
+ * and api requests another.
+ *
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class HttpDispatcherVerticle extends ApimanVerticleBase {
+    public static String VERTICLE_NAME = "http-dispatcher";
+    
+    private RouteMapper routeMapper;
+
+    public void start() {
+        super.start();
+
+        routeMapper = amanConfig.getRouteMap();
+        logger.debug("Proxied routes " + routeMapper.getRoutes());
+
+        createDispatcher(routeMapper);
+    }
+
+    protected void createDispatcher(final RouteMapper routeMapper) {
+        final HttpServer httpServer = vertx.createHttpServer();
+
+        httpServer.requestHandler(new Handler<HttpServerRequest>() {
+
+            @Override
+            // Proxy initial request (iRequest -> pRequest)
+            public void handle(final HttpServerRequest iRequest) {
+
+                Integer port = routeMapper.getAddress(iRequest.path());
+
+                if (port == null) {
+                    handleNotFound(iRequest);
+                } else {
+                    handleRequest(iRequest, port);
+                }
+            }
+        });
+
+        httpServer.listen(amanConfig.getRouteMap().getAddress(verticleType()), amanConfig.hostname());
+    }
+
+    private void handleRequest(final HttpServerRequest iRequest, int port) {
+        final HttpClient httpClient = vertx.createHttpClient().setPort(port);
+
+        final HttpClientRequest pRequest = httpClient.request(iRequest.method(), iRequest.uri(),
+                new Handler<HttpClientResponse>() {
+
+            @Override
+            // Proxy response
+            public void handle(HttpClientResponse pResponse) {
+                iRequest.response().setStatusCode(pResponse.statusCode());
+                iRequest.response().headers().set(pResponse.headers());
+                iRequest.response().setChunked(true);
+
+                // Pack the response
+                pResponse.dataHandler(new Handler<Buffer>() {
+                    @Override
+                    public void handle(Buffer contents) {
+                        iRequest.response().write(contents);
+                    }
+                });
+
+                pResponse.endHandler(new VoidHandler() {
+                    public void handle() {
+                        iRequest.response().end();
+                    }
+                });
+            }
+        });
+
+        pRequest.headers().set(iRequest.headers());
+        pRequest.setChunked(true);
+
+        iRequest.dataHandler(new Handler<Buffer>() {
+            public void handle(Buffer data) {
+                pRequest.write(data);
+            }
+        });
+
+        iRequest.endHandler(new VoidHandler() {
+            public void handle() {
+                pRequest.end();
+            }
+        });
+    }
+
+    private void handleNotFound(final HttpServerRequest iRequest) {
+        iRequest.response().setStatusCode(404);
+        iRequest.response().end();
+    }
+
+    @Override
+    public String verticleType() {
+        return VERTICLE_NAME;
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/verticles/HttpGatewayVerticle.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/verticles/HttpGatewayVerticle.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.verticles;
+
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.vertx.config.RouteMapper;
+import io.apiman.gateway.vertx.http.HttpGatewayStreamerMultiplexer;
+
+/**
+ * The main HTTP gateway verticle which translates HTTP requests into the {@link ServiceRequest} and sends the
+ * {@link ServiceResponse} back to the {@link HttpDispatcherVerticle}.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class HttpGatewayVerticle extends ApimanVerticleBase {
+    
+    private HttpGatewayStreamerMultiplexer streamMultiplexer; 
+    private RouteMapper routeMap;
+
+    @Override
+    public void start() {
+        super.start();
+        
+        streamMultiplexer = new HttpGatewayStreamerMultiplexer(vertx, container, verticleType());
+        routeMap = amanConfig.getRouteMap();
+        
+        listen();
+    }
+
+    void listen() {
+        vertx.createHttpServer().
+            requestHandler(streamMultiplexer).
+            listen(routeMap.getAddress(verticleType()), amanConfig.hostname());
+    }
+
+    @Override
+    public String verticleType() {
+        return "http-gateway";
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/verticles/InitializerVerticle.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/verticles/InitializerVerticle.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.verticles;
+
+import org.vertx.java.core.AsyncResult;
+import org.vertx.java.core.Handler;
+
+/**
+ * Start the platform.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class InitializerVerticle extends ApimanVerticleBase {
+
+    @Override
+    public void start() {
+        super.start();
+        
+        container.deployVerticle(HttpApiVerticle.class.getCanonicalName(), container.config(), new Handler<AsyncResult<String>>() {
+            
+            @Override
+            public void handle(AsyncResult<String> event) {
+                container.deployVerticle(HttpDispatcherVerticle.class.getCanonicalName(), container.config());
+                container.deployVerticle(HttpGatewayVerticle.class.getCanonicalName(), container.config(), new Handler<AsyncResult<String>>() {
+
+                    @Override
+                    public void handle(AsyncResult<String> result) {
+                        container.deployVerticle(PolicyVerticle.class.getCanonicalName(), container.config(), 1);
+                    }
+                });
+            }
+        });
+    }
+
+    @Override
+    public String verticleType() {
+        return "initialiser";
+    }  
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/verticles/PolicyVerticle.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/verticles/PolicyVerticle.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.verticles;
+
+import io.apiman.gateway.vertx.config.VertxEngineConfig;
+import io.apiman.gateway.vertx.conversation.ServiceRequestListener;
+import io.apiman.gateway.vertx.conversation.ServiceResponseExecutor;
+import io.apiman.gateway.vertx.io.VertxApimanBuffer;
+import io.apiman.gateway.vertx.worker.WorkerHelper;
+import io.apiman.gateway.engine.IEngine;
+import io.apiman.gateway.engine.IEngineResult;
+import io.apiman.gateway.engine.IServiceRequestExecutor;
+import io.apiman.gateway.engine.async.IAsyncHandler;
+import io.apiman.gateway.engine.async.IAsyncResult;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.io.IApimanBuffer;
+import io.apiman.gateway.engine.io.ISignalWriteStream;
+
+import org.vertx.java.core.AsyncResult;
+import org.vertx.java.core.AsyncResultHandler;
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.VoidHandler;
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.eventbus.Message;
+import org.vertx.java.core.eventbus.ReplyException;
+
+/**
+ * Verticle responsible for executing policies and returning result.
+ *
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class PolicyVerticle extends ApimanVerticleWithEngine {
+    protected WorkerHelper worker;
+    private ServiceRequestListener requestHandler;
+    private ServiceResponseExecutor responseExecutor;
+
+    @Override
+    public void start() {
+        super.start();
+        worker = new WorkerHelper(VertxEngineConfig.APIMAN_RT_EP_GATEWAY_REG_POLICY, uuid, eb, logger);
+
+        requestHandler = new ServiceRequestListener(eb, logger, worker.getUuid() + VertxEngineConfig.APIMAN_RT_EP_SERVICE_REQUEST);
+        responseExecutor = new ServiceResponseExecutor(eb, logger, worker.getUuid() + VertxEngineConfig.APIMAN_RT_EP_SERVICE_RESPONSE);
+
+        setup();
+    }
+
+    private void setup() {
+        requestHandler();
+
+        if(config.containsField("skip_registration") && config.getBoolean("skip_registration")) {
+            logger.debug(uuid + " is not registering (skip_registration flag).");
+        } else {
+            register();
+        }
+    }
+
+    private void register() {
+        worker.register(new AsyncResultHandler<Message<String>>() {
+
+            @Override
+            public void handle(AsyncResult<Message<String>> result) {
+                if (result.failed()) {
+                    ReplyException failure = (ReplyException) result.cause();
+                    logger.error("Unable to register: " + failure.failureType()); //$NON-NLS-1$
+                    logger.error("Failure code: " + failure.failureCode()); //$NON-NLS-1$
+                    logger.error("Failure message: " + failure.getMessage()); //$NON-NLS-1$
+                }
+            }
+        });
+    }
+
+    private void requestHandler() {
+        requestHandler.serviceHandler(new Handler<ServiceRequest>() {
+
+            @Override
+            public void handle(ServiceRequest request) {
+                logger.debug("Received a new ServiceRequest!");
+
+                try {
+                    doRequest(request);
+                }  catch (Throwable e) {
+                    responseExecutor.error(e);
+                }
+            }
+        });
+
+        requestHandler.listen();
+    }
+
+    private void doRequest(ServiceRequest request) {
+
+        final IServiceRequestExecutor requestExecutor = engine.executor(request, new IAsyncResultHandler<IEngineResult>() {
+
+            @Override
+            public void handle(IAsyncResult<IEngineResult> result) {
+                logger.debug("received result!");
+
+                if (result.isSuccess()) {
+                    IEngineResult engineResult = result.getResult();
+
+                    if (engineResult.isResponse()) {
+                        handleSuccessfulResponse(engineResult);
+                    } else {
+                        responseExecutor.failure(engineResult.getPolicyFailure());
+                        reset();
+                    }
+
+                } else {
+                    responseExecutor.error(result.getError());
+                    reset();
+                }
+            }
+
+            private void handleSuccessfulResponse(IEngineResult engineResult) {
+
+                engineResult.bodyHandler(new IAsyncHandler<IApimanBuffer>() {
+
+                    @Override
+                    public void handle(IApimanBuffer chunk) {
+                        responseExecutor.write((Buffer) chunk.getNativeBuffer());
+                    }
+                });
+
+                engineResult.endHandler(new IAsyncHandler<Void>() {
+
+                    @Override
+                    public void handle(Void flag) {
+                        responseExecutor.end();
+                        reset();
+                    }
+                });
+
+                responseExecutor.writeResponse(engineResult.getServiceResponse());
+            }
+        });
+
+        // apiman is ready to receive chunks.
+        requestExecutor.streamHandler(new IAsyncHandler<ISignalWriteStream>() {
+
+            @Override
+            public void handle(final ISignalWriteStream writeStream) {
+
+                // Body handler for vert.x chunks.
+                requestHandler.bodyHandler(new Handler<Buffer>() {
+
+                    @Override
+                    public void handle(Buffer chunk) {
+                        writeStream.write(new VertxApimanBuffer(chunk));
+                    }
+                });
+
+                // End handler for vert.x
+                requestHandler.endHandler(new VoidHandler() {
+
+                    @Override
+                    protected void handle() {
+                        //logger.debug("Sending end flag to ISignalWriteStream");
+                        writeStream.end();
+                    }
+                });
+
+                // Indicate that we're ready to receive chunks.
+                requestHandler.ready();
+            }
+        });
+
+        requestExecutor.execute();
+    }
+
+    // Reset finished flags. TODO verify.
+    private void reset() {
+        requestHandler.reset();
+        responseExecutor.reset();
+    }
+
+    @Override
+    public String verticleType() {
+        return "policy";
+    }
+
+    public IEngine getEngine() {
+        return engine;
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/worker/Registrant.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/worker/Registrant.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.worker;
+
+import org.vertx.java.core.Handler;
+
+/**
+ * A registrant, generally a node which is registered with a queue.
+ * 
+ * A listener of any type may be associated with it, which may be useful if the listeners can be reused.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public interface Registrant {
+    /**
+     * @return Address of registrant
+     */
+    String getAddress();
+    
+    /**
+     * When completed.
+     * 
+     * @param completedHandler
+     */
+    void endHandler(Handler<Void> completedHandler);
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/worker/ServiceWorkerQueue.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/worker/ServiceWorkerQueue.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.worker;
+
+import java.util.UUID;
+
+import io.apiman.gateway.vertx.http.HttpGatewayStreamer;
+import io.apiman.gateway.vertx.verticles.PolicyVerticle;
+
+import org.vertx.java.core.AsyncResult;
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.Vertx;
+import org.vertx.java.core.eventbus.EventBus;
+import org.vertx.java.core.eventbus.Message;
+import org.vertx.java.core.json.JsonObject;
+import org.vertx.java.platform.Container;
+
+/**
+ * A queue of workers ready to handle the execution of some task(s).
+ *
+ * ServiceWorkers are expected to register themselves via the {@link EventBus} at the stated endpoint.
+ *
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class ServiceWorkerQueue extends WorkerQueue<HttpGatewayStreamer> {
+
+    private Container container;
+    private Vertx vertx;
+    private String stripString;
+
+    public ServiceWorkerQueue(Vertx vertx, Container container, String registrationTopic, String stripString) {
+        super(registrationTopic, vertx.eventBus(), container.logger());
+        this.stripString = stripString;
+        this.vertx = vertx;
+        this.container = container;
+    }
+
+    @Override
+    protected void collectRegistrations() {
+        eb.registerHandler(registrationTopic, new Handler<Message<String>>() {
+
+            @Override
+            public void handle(Message<String> policyVerticleUuid) {
+                logger.debug("New registrant on " + registrationTopic + ": " + policyVerticleUuid.body());
+                add(createStreamer(policyVerticleUuid.body()));
+            }
+        });
+    }
+
+    // If a registrant is available, return it, else fire a new one up.
+    public void poll(final Handler<HttpGatewayStreamer> workerHandler) {
+        HttpGatewayStreamer gatewayStreamer = super.poll();
+
+        if (gatewayStreamer != null) {
+            workerHandler.handle(gatewayStreamer);
+        } else {
+            final String uuid = UUID.randomUUID().toString();
+            JsonObject launchConfig = container.config().copy();
+            launchConfig.putBoolean("skip_registration", true);
+            launchConfig.putString("uuid", uuid);
+
+            container.deployVerticle(PolicyVerticle.class.getCanonicalName(), launchConfig,
+                    new Handler<AsyncResult<String>>() {
+
+                @Override
+                public void handle(AsyncResult<String> result) {
+                    if (result.succeeded()) {
+                        logger.info("Didn't have enough PolicyVerticle, so I deployed a new one! " + uuid);
+                        workerHandler.handle(createStreamer(uuid)); // User must return it.
+                    } else {
+                        throw new RuntimeException(result.cause());
+                    }
+                }
+            });
+        }
+    }
+
+    private HttpGatewayStreamer createStreamer(String uuid) {
+        return new HttpGatewayStreamer(vertx, container, uuid, stripString);
+    }
+
+    @Override
+    public void add(HttpGatewayStreamer worker) {
+        super.add(worker);
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/worker/WorkerHelper.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/worker/WorkerHelper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.worker;
+
+import org.vertx.java.core.AsyncResultHandler;
+import org.vertx.java.core.eventbus.EventBus;
+import org.vertx.java.core.eventbus.Message;
+import org.vertx.java.core.logging.Logger;
+
+/**
+ * A worker which will register itself with queue at a given endpoint
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class WorkerHelper {
+    private String endpoint;
+    private String uuid;
+    private EventBus eb;
+
+    public WorkerHelper(String endpoint, String uuid, EventBus eb, Logger logger) {
+        this.endpoint = endpoint;
+        this.uuid = uuid;
+        this.eb = eb;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    /**
+     * Register with a gateway (TODO consider how we handle registration with
+     * many different gw types).
+     */
+    public void register(AsyncResultHandler<Message<String>> handler) {
+        eb.sendWithTimeout(endpoint, uuid, eb.getDefaultReplyTimeout(), handler);
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/worker/WorkerQueue.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/worker/WorkerQueue.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.worker;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.eventbus.EventBus;
+import org.vertx.java.core.logging.Logger;
+
+/**
+ * Contains a queue of {@link Registrant} workers, which are collected by {@link #collectRegistrations()},
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public abstract class WorkerQueue<T extends Registrant> {
+    protected Deque<T> policyWorkers;
+    protected EventBus eb;
+    protected Logger logger;
+    protected String registrationTopic;
+    protected Handler<Void> workerHandler;
+
+    public WorkerQueue(String topic, EventBus eb, Logger logger) {
+        this.registrationTopic = topic;
+        this.policyWorkers = new ArrayDeque<>();
+        this.eb = eb;
+        this.logger = logger;
+        
+        collectRegistrations();
+    }
+    
+    protected abstract void collectRegistrations();
+    
+    protected void workerHandler(Handler<Void> workerHandler) {
+        this.workerHandler = workerHandler;
+    }
+
+    /**
+     * @return Topic being listened to.
+     */
+    public String getTopic() {
+        return registrationTopic;
+    }
+    
+    /**
+     * @return A worker if available, otherwise null.
+     */
+    public T poll() {
+        return policyWorkers.pollFirst();
+    }
+
+    /**
+     * Return a worker to the queue.
+     * 
+     * @param pinnedWorker The worker to return
+     */
+    public void add(T pinnedWorker) {
+        policyWorkers.addLast(pinnedWorker);
+    }
+    
+    /**
+     * @return true if queue is empty; else false.
+     */
+    public boolean isEmpty() {
+        return policyWorkers.isEmpty();
+    }
+}

--- a/gateway/platforms/vertx/src/main/resources/config.json
+++ b/gateway/platforms/vertx/src/main/resources/config.json
@@ -1,0 +1,38 @@
+{
+  "registry": { "class": "io.apiman.gateway.engine.impl.InMemoryRegistry", "config": {} },
+  "connector-factory": { "class": "io.apiman.gateway.vertx.connector.HttpConnectorFactory", "config": {} },
+  "policy-factory": { "class": "io.apiman.gateway.engine.policy.PolicyFactoryImpl", "config": {} },
+  
+  "connectors": {
+    "http-rest": "io.apiman.gateway.connector.HttpConnectorFactory", "config": {}
+  },
+  
+  "components": {
+    "IHttpClientComponent": { "class": "io.apiman.gateway.vertx.components.HttpClientComponentImpl", "config": {} },
+
+    "ISharedStateComponent": { "class": "io.apiman.gateway.engine.impl.InMemorySharedStateComponent", "config": {} },
+    "IRateLimiterComponent": { "class": "io.apiman.gateway.engine.impl.InMemoryRateLimiterComponent", "config": {} },
+    "IPolicyFailureFactoryComponent": { "class": "io.apiman.gateway.vertx.components.PolicyFailureFactoryComponent", "config": {} }
+  },
+  
+  // Host-name to bind to for this machine.
+  "hostname": "localhost",
+  
+  // You can force a particular endpoint here (e.g. if you have some clustered setup with exotic DNS setup) 
+  "endpoint": "localhost",
+  
+  "routes": {
+    "http-dispatcher": 8200,
+    "http-gateway": 8201,
+    "api": 8202
+  },
+  
+  "auth": {
+    "file-basic": {
+      "example" : "NhWA8jbnUXSGDx0+LsTGFLsC6UHykp7kgnRiWF5X8KU="
+    }
+  },
+
+  "authenticated": true,
+  "realm": "apiman-gateway"
+}

--- a/gateway/platforms/vertx/src/main/resources/mod.json
+++ b/gateway/platforms/vertx/src/main/resources/mod.json
@@ -1,0 +1,18 @@
+{
+
+  // Java verticle
+  "main":"io.apiman.gateway.vertx.verticles.InitializerVerticle",
+
+  // If your module is going to be registered in the Vert.x module registry you will also need the following
+  // mandatory fields
+  "description":"Standalone Vert.x implementation of apiman's gateway",
+  "licenses": ["The Apache Software License Version 2.0"],
+  "author": "Marc Savy",
+
+  // Optional fields
+  "developers": ["Marc Savy"],
+  "keywords": ["apiman", "governance", "gateway"],
+  "homepage": "https://github.com/apiman/apiman",
+
+  "auto-redeploy": true
+}

--- a/gateway/platforms/vertx/src/main/resources/platform_lib/README.txt
+++ b/gateway/platforms/vertx/src/main/resources/platform_lib/README.txt
@@ -1,0 +1,5 @@
+If you are using fatjars and you want override the default langs.properties, cluster.xml or any other config for the Vert.x platform (i.e.
+not for the module!) then you can add them in here and they will be added to the platform classpath when running
+your module using Gradle.
+
+The fatjar starter knows to add this directory (and any jars/zips inside it) to the Vert.x platform classpath when executing your module as a fatjar.

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/test/policies/SimpleConversationPolicy.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/test/policies/SimpleConversationPolicy.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.test.policies;
+
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.policy.IPolicy;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+
+/**
+ * A simple policy used to test conversations.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+@SuppressWarnings({ "nls" })
+public class SimpleConversationPolicy implements IPolicy {
+    
+    /**
+     * Constructor.
+     */
+    public SimpleConversationPolicy() {
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#parseConfiguration(java.lang.String)
+     */
+    @Override
+    public Object parseConfiguration(String jsonConfiguration) {
+        return new Object();
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceRequest, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(final ServiceRequest request, final IPolicyContext context, final Object config,
+            final IPolicyChain<ServiceRequest> chain) {
+        context.setAttribute("X-Conversation-Success", "true");
+        chain.doApply(request);
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceResponse, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(ServiceResponse response, IPolicyContext context, Object config,
+            IPolicyChain<ServiceResponse> chain) {
+        response.getHeaders().put("X-Conversation-Success", (String) context.getAttribute("X-Conversation-Success", "NOT-FOUND"));
+        chain.doApply(response);
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/test/policies/SimpleDataPolicy.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/test/policies/SimpleDataPolicy.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.test.policies;
+
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.io.AbstractStream;
+import io.apiman.gateway.engine.io.IApimanBuffer;
+import io.apiman.gateway.engine.io.IReadWriteStream;
+import io.apiman.gateway.engine.policy.IDataPolicy;
+import io.apiman.gateway.engine.policy.IPolicy;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+import io.apiman.gateway.vertx.io.VertxApimanBuffer;
+
+import java.io.UnsupportedEncodingException;
+
+import org.vertx.java.core.buffer.Buffer;
+
+/**
+ * A simple policy used for testing data policies.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+@SuppressWarnings("nls")
+public class SimpleDataPolicy implements IPolicy, IDataPolicy {
+    
+    /**
+     * Constructor.
+     */
+    public SimpleDataPolicy() {
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#parseConfiguration(java.lang.String)
+     */
+    @Override
+    public Object parseConfiguration(String jsonConfiguration) {
+        return new Object();
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceRequest, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(final ServiceRequest request, final IPolicyContext context, final Object config,
+            final IPolicyChain<ServiceRequest> chain) {
+        chain.doApply(request);
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceResponse, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(ServiceResponse response, IPolicyContext context, Object config,
+            IPolicyChain<ServiceResponse> chain) {
+        chain.doApply(response);
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.policy.IDataPolicy#getRequestDataHandler(io.apiman.gateway.engine.beans.ServiceRequest, io.apiman.gateway.engine.policy.IPolicyContext)
+     */
+    @Override
+    public IReadWriteStream<ServiceRequest> getRequestDataHandler(final ServiceRequest request,
+            final IPolicyContext context) {
+        return new AbstractStream<ServiceRequest>() {
+            @Override
+            public ServiceRequest getHead() {
+                return request;
+            }
+            
+            @Override
+            protected void handleHead(ServiceRequest head) {
+            }
+            
+            @Override
+            public void write(IApimanBuffer chunk) {
+                try {
+                    String chunkstr = chunk.toString("UTF-8");
+                    if (chunkstr.contains("$NAME")) {
+                        chunkstr = chunkstr.replaceAll("\\$NAME", "Barry Allen");
+                        //ByteBuffer buffer = new ByteBuffer(chunkstr.length());
+                        //TODO this is wrong, really.
+                        IApimanBuffer newBuffer = new VertxApimanBuffer(new Buffer(chunkstr));                        
+                        super.write(newBuffer);                        
+                    } else {
+                        super.write(chunk);
+                    }
+                } catch (UnsupportedEncodingException e) {
+                    super.write(chunk);
+                }
+            }
+        };
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.policy.IDataPolicy#getResponseDataHandler(io.apiman.gateway.engine.beans.ServiceResponse, io.apiman.gateway.engine.policy.IPolicyContext)
+     */
+    @Override
+    public IReadWriteStream<ServiceResponse> getResponseDataHandler(ServiceResponse response,
+            IPolicyContext context) {
+        return null;
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/test/policies/SimpleHttpClientPolicy.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/test/policies/SimpleHttpClientPolicy.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.test.policies;
+
+import io.apiman.gateway.engine.async.IAsyncResult;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.components.IHttpClientComponent;
+import io.apiman.gateway.engine.components.http.HttpMethod;
+import io.apiman.gateway.engine.components.http.IHttpClientRequest;
+import io.apiman.gateway.engine.components.http.IHttpClientResponse;
+import io.apiman.gateway.engine.policy.IPolicy;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+import io.apiman.gateway.vertx.integration.java.RestTestBase;
+
+/**
+ * A simple policy used to test the http client component.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class SimpleHttpClientPolicy implements IPolicy {
+    
+    /**
+     * Constructor.
+     */
+    public SimpleHttpClientPolicy() {
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#parseConfiguration(java.lang.String)
+     */
+    @Override
+    public Object parseConfiguration(String jsonConfiguration) {
+        return new Object();
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceRequest, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(final ServiceRequest request, final IPolicyContext context, final Object config,
+            final IPolicyChain<ServiceRequest> chain) {
+        final IHttpClientComponent httpClientComponent = context.getComponent(IHttpClientComponent.class);
+        // TODO this won't work with just setting a property because vertx is classloader isolated.
+        String endpoint = RestTestBase.getEchoEndpoint(); //$NON-NLS-1$
+        IHttpClientRequest clientRequest = httpClientComponent.request(endpoint, HttpMethod.GET, new IAsyncResultHandler<IHttpClientResponse>() {
+            @Override
+            public void handle(IAsyncResult<IHttpClientResponse> result) {
+                if (result.isError()) {
+                    request.getHeaders().put("X-HttpClient-Result", "Error"); //$NON-NLS-1$ //$NON-NLS-2$
+                    request.getHeaders().put("X-HttpClient-Error", result.getError().getMessage()); //$NON-NLS-1$
+                } else {
+                    IHttpClientResponse clientResponse = result.getResult();
+                    request.getHeaders().put("X-HttpClient-Result", "Success"); //$NON-NLS-1$ //$NON-NLS-2$
+                    request.getHeaders().put("X-HttpClient-Response-Code", String.valueOf(clientResponse.getResponseCode())); //$NON-NLS-1$
+                    request.getHeaders().put("X-HttpClient-Response-Message", String.valueOf(clientResponse.getResponseMessage())); //$NON-NLS-1$
+                    clientResponse.close();
+                }
+                chain.doApply(request);
+            }
+        });
+        clientRequest.addHeader("X-Test", getClass().getSimpleName()); //$NON-NLS-1$
+        clientRequest.end();
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceResponse, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(ServiceResponse response, IPolicyContext context, Object config,
+            IPolicyChain<ServiceResponse> chain) {
+        chain.doApply(response);
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/test/policies/SimpleHttpHeaderPolicy.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/test/policies/SimpleHttpHeaderPolicy.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.test.policies;
+
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.policy.IPolicy;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+
+/**
+ * A simple policy used to test adding custom headers to the inbound request prior
+ * to proxying to the back end system.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+@SuppressWarnings({ "nls" })
+public class SimpleHttpHeaderPolicy implements IPolicy {
+    
+    /**
+     * Constructor.
+     */
+    public SimpleHttpHeaderPolicy() {
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#parseConfiguration(java.lang.String)
+     */
+    @Override
+    public Object parseConfiguration(String jsonConfiguration) {
+        return new Object();
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceRequest, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(ServiceRequest request, IPolicyContext context, Object config,
+            IPolicyChain<ServiceRequest> chain) {
+        request.getHeaders().put("X-SimpleHttpHeaderPolicy-1", "foo");
+        request.getHeaders().put("X-SimpleHttpHeaderPolicy-2", "bar");
+        chain.doApply(request);
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceResponse, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(ServiceResponse response, IPolicyContext context, Object config,
+            IPolicyChain<ServiceResponse> chain) {
+        chain.doApply(response);
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/test/policies/SimplePolicy.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/test/policies/SimplePolicy.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.test.policies;
+
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.policy.IPolicy;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+
+/**
+ * A simple policy used for testing.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class SimplePolicy implements IPolicy {
+    
+    public static int inboundCallCounter = 0;
+    public static int outboundCallCounter = 0;
+    public static void reset() {
+        inboundCallCounter = 0;
+        outboundCallCounter = 0;
+    }
+    
+    /**
+     * Constructor.
+     */
+    public SimplePolicy() {
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#parseConfiguration(java.lang.String)
+     */
+    @Override
+    public Object parseConfiguration(String jsonConfiguration) {
+        return new Object();
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceRequest, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(final ServiceRequest request, final IPolicyContext context, final Object config,
+            final IPolicyChain<ServiceRequest> chain) {
+        inboundCallCounter++;
+        chain.doApply(request);
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceResponse, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(ServiceResponse response, IPolicyContext context, Object config,
+            IPolicyChain<ServiceResponse> chain) {
+        outboundCallCounter++;
+        chain.doApply(response);
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/test/policies/SimpleSharedStatePolicy.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/test/policies/SimpleSharedStatePolicy.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.test.policies;
+
+import io.apiman.gateway.engine.async.IAsyncResult;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.components.ISharedStateComponent;
+import io.apiman.gateway.engine.policy.IPolicy;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+
+/**
+ * A simple policy used to test conversations.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+@SuppressWarnings({ "nls" })
+public class SimpleSharedStatePolicy implements IPolicy {
+    
+    /**
+     * Constructor.
+     */
+    public SimpleSharedStatePolicy() {
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#parseConfiguration(java.lang.String)
+     */
+    @Override
+    public Object parseConfiguration(String jsonConfiguration) {
+        return new Object();
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceRequest, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(final ServiceRequest request, final IPolicyContext context, final Object config,
+            final IPolicyChain<ServiceRequest> chain) {
+        final ISharedStateComponent sharedState = context.getComponent(ISharedStateComponent.class);
+        final String namespace = "urn:" + getClass().getName();
+        final String propName = "test-property";
+        sharedState.getProperty(namespace, propName, "", new IAsyncResultHandler<String>() {
+            @Override
+            public void handle(IAsyncResult<String> result) {
+                String propVal = result.getResult();
+                String newVal = propVal + "+";
+                sharedState.setProperty(namespace, propName, newVal, new IAsyncResultHandler<String>() {
+                    @Override
+                    public void handle(IAsyncResult<String> result) {
+                        chain.doApply(request);
+                    }
+                });
+            }
+        });
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceResponse, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(final ServiceResponse response, IPolicyContext context, Object config,
+            final IPolicyChain<ServiceResponse> chain) {
+        final ISharedStateComponent sharedState = context.getComponent(ISharedStateComponent.class);
+        final String namespace = "urn:" + getClass().getName();
+        final String propName = "test-property";
+        sharedState.getProperty(namespace, propName, "NOT_FOUND", new IAsyncResultHandler<String>() {
+            @Override
+            public void handle(IAsyncResult<String> result) {
+                String propVal = result.getResult();
+                response.getHeaders().put("X-Shared-State-Value", propVal);
+                chain.doApply(response);
+            }
+        });
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/README.txt
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/README.txt
@@ -1,0 +1,3 @@
+Your integration tests go in here.
+
+Integration tests are run inside the Vert.x container

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/PerfOverheadTest.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/PerfOverheadTest.java
@@ -1,0 +1,112 @@
+///*
+// * Copyright 2013 JBoss Inc
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *      http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+//package io.apiman.gateway.vertx.integration.commontests;
+//
+//import io.apiman.gateway.vertx.integration.java.RestTestBase;
+//
+//import org.apache.commons.io.IOUtils;
+//import org.apache.http.HttpResponse;
+//import org.apache.http.client.methods.HttpGet;
+//import org.apache.http.impl.client.CloseableHttpClient;
+//import org.apache.http.impl.client.HttpClientBuilder;
+//import org.junit.Test;
+//
+///**
+// * Does a simple calculation of the overhead introduced by the War gateway
+// * implementation. This should give a rough measure of how performant the engine
+// * is.
+// * 
+// * @author eric.wittmann@redhat.com
+// */
+//public class PerfOverheadTest extends RestTestBase {
+//
+//    @Test
+//    public void test() throws Exception {
+//        // Configures the gateway
+//        runTestPlan("test-plans/perf/overhead-testPlan.xml"); //$NON-NLS-1$
+//        
+//        // Make a bunch of requests directly to the echo server and measure
+//        // the average response time.
+//        int avgTime_Echo = doTest(getEchoEndpoint(), 1);
+//        avgTime_Echo = doTest(getEchoEndpoint(), 200);
+//        
+//        // Now do the same thing but through the gateway.
+//        int avgTime_Gateway = doTest(getGatewayEndpoint() + "/http-gateway/echo?apikey=12345", 200); //$NON-NLS-1$
+//        
+//        System.out.println("Average echo response time:    " + avgTime_Echo); //$NON-NLS-1$
+//        System.out.println("Average gateway response time: " + avgTime_Gateway); //$NON-NLS-1$
+//    }
+//
+//    /**
+//     * Send a bunch of GET requests to the given endpoint and measure the response
+//     * time in millis.
+//     * @param endpoint
+//     * @param numIterations
+//     * @throws Exception 
+//     */
+//    private static int doTest(String endpoint, int numIterations) throws Exception {
+//        System.out.print("Testing endpoint " + endpoint + ": \n    ["); //$NON-NLS-1$ //$NON-NLS-2$
+//        CloseableHttpClient client = HttpClientBuilder.create().build();
+//        
+//        try {
+//            long totalResponseTime = 0;
+//            for (int i = 0; i < numIterations; i++) {
+//                HttpGet get = new HttpGet(endpoint);
+//                long start = System.currentTimeMillis();
+//                HttpResponse response = client.execute(get);
+//                if (response.getStatusLine().getStatusCode() != 200) {
+//                    throw new Exception("Status Code Error: " + response.getStatusLine().getStatusCode()); //$NON-NLS-1$
+//                }
+//                response.getAllHeaders();
+//                IOUtils.toString(response.getEntity().getContent());
+//                long end = System.currentTimeMillis();
+//                totalResponseTime += (end - start);
+//                System.out.print("-"); //$NON-NLS-1$
+//                if (i % 80 == 0) {
+//                    System.out.println(""); //$NON-NLS-1$
+//                }
+//            }
+//            System.out.println("]  Total=" + totalResponseTime); //$NON-NLS-1$
+//            return (int) (totalResponseTime / numIterations);
+//        } finally {
+//            client.close();
+//        }
+//    }
+//    
+////    /**
+////     * Run the test against a running instance of APIMan instead of the embedded
+////     * unit test environment.
+////     * @param args
+////     */
+////    public static void main(String [] args) throws Exception {
+////        final String rawServiceEndpoint = "http://localhost:8080/services/echo"; //$NON-NLS-1$
+////        final String gatewayEndpoint = "http://localhost:8080/apiman-gateway"; //$NON-NLS-1$
+////        
+////        PerfOverheadTest test = new PerfOverheadTest() {
+////            @Override
+////            protected String getEchoEndpoint() {
+////                return rawServiceEndpoint;
+////            }
+////            @Override
+////            protected String getGatewayEndpoint() {
+////                return gatewayEndpoint;
+////            }
+////        };
+////        test.test();
+////    }
+//
+//}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/Policy_BasicAuthTest.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/Policy_BasicAuthTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.integration.commontests;
+
+import io.apiman.gateway.vertx.integration.java.RestTestBase;
+
+import org.junit.Test;
+
+/**
+ * Make sure the blacklist policy works.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class Policy_BasicAuthTest extends RestTestBase {
+    
+    @Test
+    public void test() throws Exception {
+        runTestPlan("test-plans/policies/basic-auth-testPlan.xml"); //$NON-NLS-1$
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/Policy_IPBlacklistTest.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/Policy_IPBlacklistTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.gateway.vertx.integration.commontests;
+
+import io.apiman.gateway.vertx.integration.java.RestTestBase;
+
+import org.junit.Test;
+
+/**
+ * Make sure the blacklist policy works.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class Policy_IPBlacklistTest extends RestTestBase {
+    
+    @Test
+    public void test() throws Exception {
+        runTestPlan("test-plans/policies/ip-blacklist-testPlan.xml"); //$NON-NLS-1$
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/Policy_IPWhitelistTest.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/Policy_IPWhitelistTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.integration.commontests;
+
+import io.apiman.gateway.vertx.integration.java.RestTestBase;
+
+import org.junit.Test;
+
+/**
+ * Make sure the whitelist policy works.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class Policy_IPWhitelistTest extends RestTestBase {
+    
+    @Test
+    public void test() throws Exception {
+        runTestPlan("test-plans/policies/ip-whitelist-testPlan.xml"); //$NON-NLS-1$
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/Policy_RateLimitingTest.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/Policy_RateLimitingTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.integration.commontests;
+
+import io.apiman.gateway.vertx.integration.java.RestTestBase;
+
+import org.junit.Test;
+
+/**
+ * Make sure the blacklist policy works.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class Policy_RateLimitingTest extends RestTestBase {
+    
+    @Test
+    public void test() throws Exception {
+        runTestPlan("test-plans/policies/rate-limiting-testPlan.xml"); //$NON-NLS-1$
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/SimpleConversationPolicyTest.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/SimpleConversationPolicyTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.integration.commontests;
+
+import io.apiman.gateway.vertx.integration.java.RestTestBase;
+
+import org.junit.Test;
+
+/**
+ * Make sure the gateway and test echo server are working.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class SimpleConversationPolicyTest extends RestTestBase {
+    
+    @Test
+    public void test() throws Exception {
+        runTestPlan("test-plans/simple/simple-conversation-policy-testPlan.xml"); //$NON-NLS-1$
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/SimpleDataPolicyTest.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/SimpleDataPolicyTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.integration.commontests;
+
+import io.apiman.gateway.vertx.integration.java.RestTestBase;
+
+import org.junit.Test;
+
+/**
+ * Make sure the gateway and test echo server are working.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class SimpleDataPolicyTest extends RestTestBase {
+    
+    @Test
+    public void test() throws Exception {
+        runTestPlan("test-plans/simple/simple-data-policy-testPlan.xml"); //$NON-NLS-1$
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/SimpleEchoTest.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/SimpleEchoTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.integration.commontests;
+
+import io.apiman.gateway.vertx.integration.java.RestTestBase;
+
+import org.junit.Test;
+
+/**
+ * Make sure the gateway and test echo server are working.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class SimpleEchoTest extends RestTestBase {
+    
+    @Test
+    public void test() throws Exception {
+        runTestPlan("test-plans/simple/simple-echo-testPlan.xml"); //$NON-NLS-1$
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/SimpleHttpClientPolicyTest.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/SimpleHttpClientPolicyTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.integration.commontests;
+
+import io.apiman.gateway.vertx.integration.java.RestTestBase;
+
+import org.junit.Test;
+
+/**
+ * Make sure the gateway and test echo server are working.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class SimpleHttpClientPolicyTest extends RestTestBase {
+    
+    @Test
+    public void test() throws Exception {
+        runTestPlan("test-plans/simple/simple-httpclient-policy-testPlan.xml"); //$NON-NLS-1$
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/SimpleHttpHeaderPolicyTest.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/SimpleHttpHeaderPolicyTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.gateway.vertx.integration.commontests;
+
+import io.apiman.gateway.vertx.integration.java.RestTestBase;
+
+import org.junit.Test;
+
+/**
+ * Make sure the gateway and test echo server are working.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class SimpleHttpHeaderPolicyTest extends RestTestBase {
+    
+    @Test
+    public void test() throws Exception {
+        runTestPlan("test-plans/simple/simple-httpheader-policy-testPlan.xml"); //$NON-NLS-1$
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/SimplePolicyTest.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/SimplePolicyTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.integration.commontests;
+
+import io.apiman.gateway.vertx.integration.java.RestTestBase;
+import io.apiman.gateway.vertx.unit.SimplePolicy;
+
+import org.junit.Test;
+
+/**
+ * Make sure the gateway and test echo server are working.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class SimplePolicyTest extends RestTestBase {
+    
+    @Test
+    public void test() throws Exception {
+        SimplePolicy.reset();
+        runTestPlan("test-plans/simple/simple-policy-testPlan.xml"); //$NON-NLS-1$
+        // This test invokes the echo service twice, so that should result in two
+        // invokations of the simple policy
+        
+        // TODO: These are being run after #after() is called in runTestPlan, which breaks it.
+        //Assert.assertEquals(2, SimplePolicy.inboundCallCounter);
+        //Assert.assertEquals(2, SimplePolicy.outboundCallCounter);
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/SimpleSharedStatePolicyTest.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/commontests/SimpleSharedStatePolicyTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.integration.commontests;
+
+import io.apiman.gateway.vertx.integration.java.RestTestBase;
+
+import org.junit.Test;
+
+/**
+ * Unit test for the shared state component.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class SimpleSharedStatePolicyTest extends RestTestBase {
+    
+    @Test
+    public void test() throws Exception {
+        runTestPlan("test-plans/simple/simple-shared-state-policy-testPlan.xml"); //$NON-NLS-1$
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/java/ConnectorFactoryTest.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/java/ConnectorFactoryTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.integration.java;
+
+
+
+import io.apiman.gateway.engine.IServiceConnection;
+import io.apiman.gateway.engine.IServiceConnectionResponse;
+import io.apiman.gateway.engine.IServiceConnector;
+import io.apiman.gateway.engine.async.IAsyncHandler;
+import io.apiman.gateway.engine.async.IAsyncResult;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.beans.HeaderHashMap;
+import io.apiman.gateway.engine.beans.Service;
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.io.IApimanBuffer;
+import io.apiman.gateway.vertx.connector.ConnectorFactory;
+import io.apiman.gateway.vertx.io.VertxApimanBuffer;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.vertx.java.core.AsyncResult;
+import org.vertx.java.core.AsyncResultHandler;
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.VoidHandler;
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.http.HttpServer;
+import org.vertx.java.core.http.HttpServerRequest;
+import org.vertx.testtools.TestVerticle;
+import org.vertx.java.core.logging.Logger;
+
+import static org.mockito.BDDMockito.*;
+import static org.vertx.testtools.VertxAssert.*;
+
+/**
+ * Test connector factory using a dummy server on localhost that echoes a fixed response.
+ *
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class ConnectorFactoryTest extends TestVerticle {
+
+    private ConnectorFactory factory;
+    private ServiceRequest mRequest;
+    private Service mService;
+    private HeaderHashMap headers;
+    private Logger logger;
+    private IApimanBuffer bTransmitBuffer;
+
+    @Mock private IAsyncHandler<IApimanBuffer> mBodyHandler;
+    @Mock private Handler<Buffer> mEchoDataHandler;
+
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+
+        logger = container.logger();
+
+        factory = new ConnectorFactory(vertx, container);
+
+        headers = spy(new HeaderHashMap());
+        headers.put("zaphod", "beeblebrox");
+
+        mRequest = mock(ServiceRequest.class);
+        given(mRequest.getType()).willReturn("GET");
+        given(mRequest.getDestination()).willReturn("/");
+        given(mRequest.getHeaders()).willReturn(headers);
+
+        mService = mock(Service.class);
+        given(mService.getEndpoint()).willReturn("http://localhost:8999/");
+
+        bTransmitBuffer = new VertxApimanBuffer(new Buffer("hitchhiker"));
+    }
+
+    @Test
+    public void testHttpConnector() {
+        before();
+
+        vertx.createHttpServer().requestHandler(new Handler<HttpServerRequest>() {
+
+            @Override
+            public void handle(final HttpServerRequest req) {
+                assertEquals(req.headers().get("zaphod"), "beeblebrox");
+
+                req.dataHandler(mEchoDataHandler);
+
+                // We can't do any of our assertions until the end handler, else they are hit too early.
+                req.endHandler(new VoidHandler() {
+                    @Override
+                    protected void handle() {
+                        ArgumentCaptor<Buffer> buffCaptor = ArgumentCaptor.forClass(Buffer.class);
+                        verify(mEchoDataHandler).handle(buffCaptor.capture());
+
+                        assertEquals("hitchhiker", buffCaptor.getValue().toString());
+                        assertEquals("beeblebrox", req.headers().get("zaphod"));
+
+                        // Do the baked response.
+                        req.response().setChunked(true);
+                        req.response().setStatusCode(200);
+                        req.response().putHeader("vogon", "bypass");
+                        req.response().setStatusMessage("everything-is-fine");
+                        req.response().write("lipwig");
+                        req.response().end();
+                    }
+                });
+            }
+        }).listen(8999, new AsyncResultHandler<HttpServer>() {
+
+            @Override
+            public void handle(AsyncResult<HttpServer> event) {
+                logger.info("Dummy server is listening. Testing proceeding:");
+
+                assertTrue(event.succeeded());
+
+                IServiceConnector connector = factory.createConnector(mRequest, mService);
+                IServiceConnection writeStream = connector.connect(mRequest,
+                        new IAsyncResultHandler<IServiceConnectionResponse>() {
+
+                    @Override
+                    public void handle(IAsyncResult<IServiceConnectionResponse> result) {
+                        logger.info("Received a result.");
+
+                        assertTrue(result.isSuccess());
+
+                        IServiceConnectionResponse stream = result.getResult();
+
+                        assertEquals(200, stream.getHead().getCode());
+                        assertEquals("everything-is-fine", stream.getHead().getMessage());
+                        assertEquals("bypass", stream.getHead().getHeaders().get("vogon"));
+
+                        stream.bodyHandler(mBodyHandler);
+
+                        stream.endHandler(new IAsyncHandler<Void>() {
+
+                            @Override
+                            public void handle(Void signal) {
+                                ArgumentCaptor<IApimanBuffer> buffCaptor = ArgumentCaptor.forClass(IApimanBuffer.class);
+                                verify(mBodyHandler).handle(buffCaptor.capture());
+                                assertEquals("lipwig", buffCaptor.getValue().toString());
+
+                                testComplete();
+                            }
+                        });
+
+                        // It's okay to send body chunks now (real usage more sophisticated than this!).
+                        stream.transmit();
+                    }
+                });
+
+                writeStream.write(bTransmitBuffer);
+                writeStream.end();
+            }
+        });
+    }
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/java/PolicyVerticleTest.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/java/PolicyVerticleTest.java
@@ -1,0 +1,114 @@
+//package io.apiman.gateway.vertx.integration.java;
+//
+//import java.util.HashMap;
+//import java.util.Map;
+//
+//import io.apiman.gateway.engine.IConnectorFactory;
+//import io.apiman.gateway.engine.IRegistry;
+//import io.apiman.gateway.engine.impl.InMemoryRegistry;
+//import io.apiman.gateway.engine.policy.IPolicyFactory;
+//import io.apiman.gateway.engine.policy.PolicyFactoryImpl;
+//import io.apiman.gateway.vertx.PolicyVerticle;
+//import io.apiman.gateway.vertx.config.VertxEngineConfig;
+//
+//import org.junit.Test;
+//import org.mockito.Mock;
+//import org.mockito.MockitoAnnotations;
+//import org.vertx.java.core.AsyncResult;
+//import org.vertx.java.core.AsyncResultHandler;
+//import org.vertx.java.core.Handler;
+//import org.vertx.java.core.eventbus.EventBus;
+//import org.vertx.java.core.eventbus.Message;
+//import org.vertx.testtools.TestVerticle;
+//
+//import static org.vertx.testtools.VertxAssert.*;
+//
+///**
+// * @author Marc Savy <msavy@redhat.com>
+// */
+//public class PolicyVerticleTest extends TestVerticle {
+//
+//    private EventBus eb;
+//    private VertxEngineConfig bVertxEngineConfig;
+//    @Mock private Class<? extends IConnectorFactory> mConnectorFactory;
+//
+//    class TestablePolicyVerticle extends PolicyVerticle {
+//        public void start() {
+//            super.start();
+//        }
+//
+//        protected VertxEngineConfig getEngineConfig() {
+//            return bVertxEngineConfig;
+//        }
+//    }
+//
+//    public void setup() {
+//        this.eb = vertx.eventBus();
+//
+//        // Sensible defaults for mVertxEngineConfig
+//        bVertxEngineConfig = new VertxEngineConfig(container.config()) {
+//            Map<String, String> emptyMap = new HashMap<>();
+//
+//            @Override
+//            public Class<? extends IRegistry> getRegistryClass() {
+//                return InMemoryRegistry.class;
+//            }
+//
+//            @Override
+//            public Map<String, String> getRegistryConfig() { return emptyMap; }
+//
+//            @Override
+//            public Class<? extends IConnectorFactory> getConnectorFactoryClass() {
+//                return mConnectorFactory;
+//            }
+//
+//            @Override
+//            public Map<String, String> getConnectorFactoryConfig() { return emptyMap; }
+//
+//            @Override
+//            public Class<? extends IPolicyFactory> getPolicyFactoryClass() {
+//                return PolicyFactoryImpl.class;
+//            }
+//
+//            @Override
+//            public Map<String, String> getPolicyFactoryConfig() { return emptyMap; }
+//        };
+//
+//        eb.registerHandler(VertxEngineConfig.APIMAN_RT_EP_GATEWAY_REG_POLICY,
+//                new Handler<Message<String>>() {
+//
+//            @Override
+//            public void handle(Message<String> message) {
+//                System.out.println(message.toString());
+//            }
+//
+//        });
+//    }
+//
+//    public void before() {
+//        MockitoAnnotations.initMocks(this);
+//    }
+//
+//    @Override
+//    public void start() {
+//        initialize();
+//        setup();
+//
+//        container.deployVerticle(TestablePolicyVerticle.class.getCanonicalName(),
+//                new AsyncResultHandler<String>() {
+//
+//            @Override
+//            public void handle(AsyncResult<String> asyncResult) {
+//                assertTrue(asyncResult.succeeded());
+//                System.out.println(asyncResult.cause());
+//
+//                startTests();
+//            }
+//        });
+//    }
+//
+//    @Test
+//    public void testRequestResponse() {
+//        before();
+//    }
+//}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/java/README.txt
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/java/README.txt
@@ -1,0 +1,18 @@
+Put your Java integration tests in here or sub directories.
+
+To create a Java integration test in Vert.x - that's a test that runs *inside* the Vert.x container, you should
+create a class like this which extends `TestVerticle`.
+
+`TestVerticle` acts as both a Verticle which can run inside the Vert.x container and as a JUnit test.
+
+We use a custom JUnit test runner so that when this test is run it auto-magically creates a Vert.x container
+and runs it in that whilst communicating the test results back to the runner so they can be collated as
+normal.
+
+You should annotate your test methods with @Test as normal, and you can use the standard JUnit API
+inside the test to assert stuff.
+
+@Before and @After annotations currently don't work, but you can put any shared startup code that inside the
+standard verticle `start()` method.
+
+You can use the standard JUnit Assert API in your test by using the VertxAssert class

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/java/RestTestBase.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/integration/java/RestTestBase.java
@@ -1,0 +1,150 @@
+package io.apiman.gateway.vertx.integration.java;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.vertx.java.core.AsyncResult;
+import org.vertx.java.core.AsyncResultHandler;
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.json.JsonObject;
+import org.vertx.java.core.logging.Logger;
+import org.vertx.testtools.TestVerticle;
+
+import io.apiman.gateway.test.server.EchoServer;
+import io.apiman.gateway.vertx.verticles.InitializerVerticle;
+import io.apiman.test.common.util.TestPlanRunner;
+import static org.vertx.testtools.VertxAssert.*;
+
+public abstract class RestTestBase extends TestVerticle {
+
+    protected static final int ECHO_PORT = 7654;
+    protected static final int GATEWAY_PORT = 8200;
+    protected static final int API_PORT = 8202;
+
+    private EchoServer echoServer = new EchoServer(ECHO_PORT);
+    private String deploymentId;
+    private Logger logger;
+
+    private abstract class DeploymentAsyncResultHandler implements AsyncResultHandler<String> {
+
+        @Override
+        public final void handle(AsyncResult<String> result) {
+            if(result.succeeded()) {
+                deploymentId = result.result();
+            }
+
+            handleDeployment(result);
+        }
+
+        public abstract void handleDeployment(AsyncResult<String> result);
+    }
+
+    private JsonObject getConfig() {
+
+        URL url = this.getClass().getResource("/testConfig.json");
+        byte[] bytes;
+
+        try {
+            bytes = Files.readAllBytes(Paths.get(url.toURI()));
+        } catch (IOException | URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+
+        return new JsonObject(new String(bytes));
+    }
+
+    @Override
+    public void start() {
+        super.start();
+        this.logger = container.logger();
+
+        try {
+            echoServer.start();
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.exit(-1);
+        }
+    }
+
+    @Override
+    public void stop() {
+        echoServer.stop();
+    }
+
+    public void before(JsonObject config, AsyncResultHandler<String> resultHandler) {
+        container.deployVerticle(InitializerVerticle.class.getCanonicalName(),
+                config,
+                resultHandler);
+    }
+
+    public void after() {
+        container.undeployVerticle(deploymentId, new Handler<AsyncResult<Void>>() {
+
+            @Override
+            public void handle(AsyncResult<Void> flag) {
+                testComplete();
+            }
+        });
+    }
+
+    /**
+     * Runs the given test plan.
+     * @param planPath
+     */
+    public void runTestPlan(final String planPath) {
+
+        // Start up the echo server
+        before(getConfig(), new DeploymentAsyncResultHandler() {
+
+            @Override
+            public void handleDeployment(AsyncResult<String> result) {
+                assertTrue(result.succeeded());
+                
+                
+                
+                System.setProperty("apiman-gateway-test.endpoints.echo", getEchoEndpoint()); //$NON-NLS-1$
+
+                runTestPlan(planPath, getClass().getClassLoader());
+
+                logger.info("Finished running the test plan");
+
+                after();
+            }
+        });
+    }
+
+    /**
+     * Runs the given test plan.
+     * @param planPath
+     * @param classLoader
+     */
+    protected void runTestPlan(String planPath, ClassLoader classLoader) {
+        String baseApiUrl = getApiEndpoint();
+        TestPlanRunner runner = new TestPlanRunner(baseApiUrl);
+        runner.runTestPlan(planPath, classLoader);
+    }
+
+    /**
+     * @return the api endpoint
+     */
+    public static String getApiEndpoint() {
+        return "http://localhost:" + GATEWAY_PORT; //$NON-NLS-1$
+    }
+
+    /**
+     * @return the gateway endpoint
+     */
+    protected static String getGatewayEndpoint() {
+        return "http://localhost:" + GATEWAY_PORT; //$NON-NLS-1$
+    }
+
+    /**
+     * @return the echo server endpoint
+     */
+    public static String getEchoEndpoint() {
+        return "http://localhost:" + ECHO_PORT; //$NON-NLS-1$
+    }
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/unit/PassthroughPolicy.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/unit/PassthroughPolicy.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.unit;
+
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.beans.exceptions.ConfigurationParseException;
+import io.apiman.gateway.engine.policy.IPolicy;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+
+/**
+ * A pass-through {@link AbstractPolicy} impl for testing purposes.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+@SuppressWarnings("nls")
+public class PassthroughPolicy implements IPolicy {
+    
+    public static final String QUALIFIED_NAME = "class:" + PassthroughPolicy.class.getCanonicalName();
+    private Object config;
+    private String name;
+    
+    public PassthroughPolicy(){}
+
+    public PassthroughPolicy(String name) {
+        this.name = name;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    @Override
+    public Object parseConfiguration(String jsonConfiguration) throws ConfigurationParseException {
+        this.config = (Object) jsonConfiguration;
+        return config;
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceRequest, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(ServiceRequest request, IPolicyContext context, Object config,
+            IPolicyChain<ServiceRequest> chain) {
+        chain.doApply(request);
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceResponse, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(ServiceResponse response, IPolicyContext context, Object config,
+            IPolicyChain<ServiceResponse> chain) {
+        chain.doApply(response);
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/unit/SimplePolicy.java
+++ b/gateway/platforms/vertx/src/test/java/io/apiman/gateway/vertx/unit/SimplePolicy.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.unit;
+
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.policy.IPolicy;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+
+/**
+ * A simple policy used for testing.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class SimplePolicy implements IPolicy {
+    
+    public static int inboundCallCounter = 0;
+    public static int outboundCallCounter = 0;
+    public static void reset() {
+        inboundCallCounter = 0;
+        outboundCallCounter = 0;
+    }
+    
+    /**
+     * Constructor.
+     */
+    public SimplePolicy() {
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#parseConfiguration(java.lang.String)
+     */
+    @Override
+    public Object parseConfiguration(String jsonConfiguration) {
+        return new Object();
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceRequest, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(final ServiceRequest request, final IPolicyContext context, final Object config,
+            final IPolicyChain<ServiceRequest> chain) {
+        inboundCallCounter++;
+        chain.doApply(request);
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceResponse, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(ServiceResponse response, IPolicyContext context, Object config,
+            IPolicyChain<ServiceResponse> chain) {
+        outboundCallCounter++;
+        chain.doApply(response);
+    }
+
+}

--- a/gateway/platforms/vertx/src/test/resources/log4j.properties
+++ b/gateway/platforms/vertx/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %m%n
+
+# Root logger option
+log4j.rootLogger=INFO, stdout

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/perf/overhead/001-publish-service.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/perf/overhead/001-publish-service.resttest
@@ -1,0 +1,12 @@
+PUT /api/services admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "PerfOverheadTest",
+  "serviceId" : "echo",
+  "version" : "1.0.0",
+  "endpointType" : "REST",
+  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/perf/overhead/002-register-app.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/perf/overhead/002-register-app.resttest
@@ -1,0 +1,18 @@
+PUT /api/applications admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "PerfOverheadTest",
+  "applicationId" : "test",
+  "version" : "1.0.0",
+  "contracts" : [
+    {
+      "apiKey" : "12345",
+      "serviceOrgId" : "PerfOverheadTest",
+      "serviceId" : "echo",
+      "serviceVersion" : "1.0.0"
+    }
+  ]
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/basic-auth-static/001-publish-service.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/basic-auth-static/001-publish-service.resttest
@@ -1,0 +1,12 @@
+PUT /api/services admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "Policy_BasicAuthStatic",
+  "serviceId" : "echo",
+  "version" : "1.0.0",
+  "endpointType" : "REST",
+  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/basic-auth-static/002-register-app.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/basic-auth-static/002-register-app.resttest
@@ -1,0 +1,24 @@
+PUT /api/applications admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "Policy_BasicAuthStatic",
+  "applicationId" : "test",
+  "version" : "1.0.0",
+  "contracts" : [
+    {
+      "apiKey" : "12345",
+      "serviceOrgId" : "Policy_BasicAuthStatic",
+      "serviceId" : "echo",
+      "serviceVersion" : "1.0.0",
+      "policies" : [
+        {
+          "policyImpl" : "class:io.apiman.gateway.engine.policies.BasicAuthenticationPolicy",
+          "policyJsonConfig" : "{ \"realm\" : \"Test\", \"forwardIdentityHttpHeader\" : \"X-Authenticated-Identity\", \"staticIdentity\" : { \"identities\" : [ { \"username\" : \"bwayne\", \"password\" : \"bwayne\" } ] }  }"
+        }
+      ]
+    }
+  ]
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/basic-auth-static/003-success.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/basic-auth-static/003-success.resttest
@@ -1,0 +1,15 @@
+GET /http-gateway/path/to/app/resource bwayne/bwayne
+X-API-Key: 12345
+
+----
+200
+Content-Type: application/json
+
+{
+  "method" : "GET",
+  "resource" : "/path/to/app/resource",
+  "uri" : "/path/to/app/resource",
+  "headers" : {
+    "X-Authenticated-Identity" : "bwayne"
+  }
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/basic-auth-static/004-failure.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/basic-auth-static/004-failure.resttest
@@ -1,0 +1,14 @@
+GET /http-gateway/path/to/app/resource bwayne/invalid-password
+X-API-Key: 12345
+
+----
+401
+Content-Type: application/json
+X-Policy-Failure-Type: Authentication
+X-Policy-Failure-Code: 10003
+WWW-Authenticate: BASIC realm="Test"
+
+{
+    "type" : "Authentication",
+    "failureCode" : 10003
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/ip-blacklist/001-publish-service.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/ip-blacklist/001-publish-service.resttest
@@ -1,0 +1,12 @@
+PUT /api/services admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "Policy_IPBlacklistTest",
+  "serviceId" : "echo",
+  "version" : "1.0.0",
+  "endpointType" : "REST",
+  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/ip-blacklist/002-register-app.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/ip-blacklist/002-register-app.resttest
@@ -1,0 +1,36 @@
+PUT /api/applications admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "Policy_IPBlacklistTest",
+  "applicationId" : "test",
+  "version" : "1.0.0",
+  "contracts" : [
+    {
+      "apiKey" : "12345",
+      "serviceOrgId" : "Policy_IPBlacklistTest",
+      "serviceId" : "echo",
+      "serviceVersion" : "1.0.0",
+      "policies" : [
+        {
+          "policyImpl" : "class:io.apiman.gateway.engine.policies.IPBlacklistPolicy",
+          "policyJsonConfig" : "{ \"ipList\" : [ \"1.2.3.4\" ] }"
+        }
+      ]
+    },
+    {
+      "apiKey" : "54321",
+      "serviceOrgId" : "Policy_IPBlacklistTest",
+      "serviceId" : "echo",
+      "serviceVersion" : "1.0.0",
+      "policies" : [
+        {
+          "policyImpl" : "class:io.apiman.gateway.engine.policies.IPBlacklistPolicy",
+          "policyJsonConfig" : "{ \"ipList\": [ \"127.0.0.1\" ] }"
+        }
+      ]
+    }
+  ]
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/ip-blacklist/003-success.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/ip-blacklist/003-success.resttest
@@ -1,0 +1,12 @@
+GET /http-gateway/path/to/app/resource admin/admin
+X-API-Key: 12345
+
+----
+200
+Content-Type: application/json
+
+{
+  "method" : "GET",
+  "resource" : "/path/to/app/resource",
+  "uri" : "/path/to/app/resource"
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/ip-blacklist/004-failure.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/ip-blacklist/004-failure.resttest
@@ -1,0 +1,13 @@
+GET /http-gateway/path/to/app/resource admin/admin
+X-API-Key: 54321
+
+----
+500
+Content-Type: application/json
+X-Policy-Failure-Type: Other
+X-Policy-Failure-Code: 10002
+
+{
+    "type" : "Other",
+    "failureCode" : 10002
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/ip-whitelist/001-publish-service.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/ip-whitelist/001-publish-service.resttest
@@ -1,0 +1,12 @@
+PUT /api/services admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "Policy_IPWhitelistTest",
+  "serviceId" : "echo",
+  "version" : "1.0.0",
+  "endpointType" : "REST",
+  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/ip-whitelist/002-register-app.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/ip-whitelist/002-register-app.resttest
@@ -1,0 +1,36 @@
+PUT /api/applications admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "Policy_IPWhitelistTest",
+  "applicationId" : "test",
+  "version" : "1.0.0",
+  "contracts" : [
+    {
+      "apiKey" : "12345",
+      "serviceOrgId" : "Policy_IPWhitelistTest",
+      "serviceId" : "echo",
+      "serviceVersion" : "1.0.0",
+      "policies" : [
+        {
+          "policyImpl" : "class:io.apiman.gateway.engine.policies.IPWhitelistPolicy",
+          "policyJsonConfig" : "{ \"ipList\" : [ \"1.2.3.4\" ] }"
+        }
+      ]
+    },
+    {
+      "apiKey" : "54321",
+      "serviceOrgId" : "Policy_IPWhitelistTest",
+      "serviceId" : "echo",
+      "serviceVersion" : "1.0.0",
+      "policies" : [
+        {
+          "policyImpl" : "class:io.apiman.gateway.engine.policies.IPWhitelistPolicy",
+          "policyJsonConfig" : "{ \"ipList\": [ \"127.0.0.1\" ] }"
+        }
+      ]
+    }
+  ]
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/ip-whitelist/003-success.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/ip-whitelist/003-success.resttest
@@ -1,0 +1,12 @@
+GET /http-gateway/path/to/app/resource admin/admin
+X-API-Key: 54321
+
+----
+200
+Content-Type: application/json
+
+{
+  "method" : "GET",
+  "resource" : "/path/to/app/resource",
+  "uri" : "/path/to/app/resource"
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/ip-whitelist/004-failure.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/ip-whitelist/004-failure.resttest
@@ -1,0 +1,13 @@
+GET /http-gateway/path/to/app/resource admin/admin
+X-API-Key: 12345
+
+----
+500
+Content-Type: application/json
+X-Policy-Failure-Type: Other
+X-Policy-Failure-Code: 10001
+
+{
+    "type" : "Other",
+    "failureCode" : 10001
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/rate-limiting/001-publish-service.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/rate-limiting/001-publish-service.resttest
@@ -1,0 +1,12 @@
+PUT /api/services admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "Policy_RateLimitingTest",
+  "serviceId" : "echo",
+  "version" : "1.0.0",
+  "endpointType" : "REST",
+  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/rate-limiting/002-register-app.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/rate-limiting/002-register-app.resttest
@@ -1,0 +1,24 @@
+PUT /api/applications admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "Policy_RateLimitingTest",
+  "applicationId" : "test",
+  "version" : "1.0.0",
+  "contracts" : [
+    {
+      "apiKey" : "12345",
+      "serviceOrgId" : "Policy_RateLimitingTest",
+      "serviceId" : "echo",
+      "serviceVersion" : "1.0.0",
+      "policies" : [
+        {
+          "policyImpl" : "class:io.apiman.gateway.engine.policies.RateLimitingPolicy",
+          "policyJsonConfig" : "{ \"limit\" : 5, \"granularity\" : \"Application\", \"period\" : \"Minute\" }"
+        }
+      ]
+    }
+  ]
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/rate-limiting/003-success.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/rate-limiting/003-success.resttest
@@ -1,0 +1,12 @@
+GET /http-gateway/path/to/app/resource admin/admin
+X-API-Key: 12345
+
+----
+200
+Content-Type: application/json
+
+{
+  "method" : "GET",
+  "resource" : "/path/to/app/resource",
+  "uri" : "/path/to/app/resource"
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/rate-limiting/004-failure.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/policies/rate-limiting/004-failure.resttest
@@ -1,0 +1,13 @@
+GET /http-gateway/path/to/app/resource admin/admin
+X-API-Key: 12345
+
+----
+500
+Content-Type: application/json
+X-Policy-Failure-Type: Other
+X-Policy-Failure-Code: 10005
+
+{
+    "type" : "Other",
+    "failureCode" : 10005
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-conversation-policy/convo/001.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-conversation-policy/convo/001.resttest
@@ -1,0 +1,17 @@
+GET /http-gateway/path/to/app/resource admin/admin
+X-Custom-Header: MyValue
+X-API-Key: 12345
+
+----
+200
+Content-Type: application/json
+X-Conversation-Success: true
+
+{
+  "method" : "GET",
+  "resource" : "/path/to/app/resource",
+  "uri" : "/path/to/app/resource",
+  "headers" : {
+    "X-Custom-Header" : "MyValue"
+  }
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-conversation-policy/setup/001-publish-service.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-conversation-policy/setup/001-publish-service.resttest
@@ -1,0 +1,12 @@
+PUT /api/services admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "SimpleConversationPolicyTest",
+  "serviceId" : "echo",
+  "version" : "1.0.0",
+  "endpointType" : "REST",
+  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-conversation-policy/setup/002-register-app.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-conversation-policy/setup/002-register-app.resttest
@@ -1,0 +1,24 @@
+PUT /api/applications admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "SimpleConversationPolicyTest",
+  "applicationId" : "test",
+  "version" : "1.0.0",
+  "contracts" : [
+    {
+      "apiKey" : "12345",
+      "serviceOrgId" : "SimpleConversationPolicyTest",
+      "serviceId" : "echo",
+      "serviceVersion" : "1.0.0",
+      "policies" : [
+        {
+          "policyImpl" : "class:io.apiman.gateway.test.policies.SimpleConversationPolicy",
+          "policyJsonConfig" : ""
+        }
+      ]
+    }
+  ]
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-data-policy/datap/001.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-data-policy/datap/001.resttest
@@ -1,0 +1,94 @@
+PUT /http-gateway/path/to/app/resource admin/admin
+Content-Type: text/plain
+X-API-Key: 12345
+
+Hello $NAME,
+
+Bacon ipsum dolor amet t-bone ad cow jowl ex, flank ham tongue ground round. Sunt commodo 
+beef ribs kielbasa ball tip tri-tip qui veniam reprehenderit jowl. Filet mignon magna meatloaf 
+labore ipsum tongue. Drumstick cupim ribeye jerky ham. Excepteur laborum shankle capicola leberkas 
+in, cillum aute nulla. Sunt boudin salami, ball tip duis doner brisket deserunt incididunt 
+hamburger quis.
+
+Pork belly incididunt flank, laboris short loin ea qui leberkas beef ut laborum. Do tongue irure 
+proident short ribs ullamco occaecat frankfurter cillum in. Flank incididunt ham qui. Nostrud 
+brisket officia tail laborum chuck corned beef nisi ham.
+
+Occaecat strip steak eu t-bone prosciutto. Leberkas drumstick t-bone irure shank short loin 
+chicken sirloin laborum id. Consequat dolore cow, fugiat proident duis ut in pork loin chuck. Et 
+labore officia, capicola chicken venison nulla prosciutto.
+
+Ut turkey ipsum kevin cillum. Tongue sausage meatball pancetta pork chop corned beef sunt strip 
+steak. Salami voluptate elit eiusmod ut. Filet mignon voluptate turkey tri-tip prosciutto cillum. 
+Ribeye commodo boudin shoulder t-bone. Quis esse ea qui, chuck eiusmod minim shank pork loin sed 
+irure aliquip sirloin. Sirloin cow non chicken consequat sausage short loin capicola reprehenderit 
+eiusmod.
+
+Landjaeger pancetta aliquip magna, consequat nisi shankle officia pork. Sirloin pariatur eiusmod, 
+rump filet mignon in aliqua beef ribs duis commodo. Flank ham landjaeger consectetur aliqua pork 
+venison andouille aute veniam cillum. Boudin ham hock beef ribs, incididunt ullamco hamburger 
+chicken beef. Mollit ut elit, sunt pork belly leberkas qui brisket labore kielbasa in irure dolor 
+ipsum veniam. Doner id porchetta andouille ut. Mollit eu ut sausage kevin esse nulla tongue do 
+beef shankle corned beef.
+
+Pork belly incididunt flank, laboris short loin ea qui leberkas beef ut laborum. Do tongue irure 
+proident short ribs ullamco occaecat frankfurter cillum in. Flank incididunt ham qui. Nostrud 
+brisket officia tail laborum chuck corned beef nisi ham.
+
+Occaecat strip steak eu t-bone prosciutto. Leberkas drumstick t-bone irure shank short loin 
+chicken sirloin laborum id. Consequat dolore cow, fugiat proident duis ut in pork loin chuck. Et 
+labore officia, capicola chicken venison nulla prosciutto.
+
+Ut turkey ipsum kevin cillum. Tongue sausage meatball pancetta pork chop corned beef sunt strip 
+steak. Salami voluptate elit eiusmod ut. Filet mignon voluptate turkey tri-tip prosciutto cillum. 
+Ribeye commodo boudin shoulder t-bone. Quis esse ea qui, chuck eiusmod minim shank pork loin sed 
+irure aliquip sirloin. Sirloin cow non chicken consequat sausage short loin capicola reprehenderit 
+eiusmod.
+
+Landjaeger pancetta aliquip magna, consequat nisi shankle officia pork. Sirloin pariatur eiusmod, 
+rump filet mignon in aliqua beef ribs duis commodo. Flank ham landjaeger consectetur aliqua pork 
+venison andouille aute veniam cillum. Boudin ham hock beef ribs, incididunt ullamco hamburger 
+chicken beef. Mollit ut elit, sunt pork belly leberkas qui brisket labore kielbasa in irure dolor 
+ipsum veniam. Doner id porchetta andouille ut. Mollit eu ut sausage kevin esse nulla tongue do 
+beef shankle corned beef.
+
+Pork belly incididunt flank, laboris short loin ea qui leberkas beef ut laborum. Do tongue irure 
+proident short ribs ullamco occaecat frankfurter cillum in. Flank incididunt ham qui. Nostrud 
+brisket officia tail laborum chuck corned beef nisi ham.
+
+Occaecat strip steak eu t-bone prosciutto. Leberkas drumstick t-bone irure shank short loin 
+chicken sirloin laborum id. Consequat dolore cow, fugiat proident duis ut in pork loin chuck. Et 
+labore officia, capicola chicken venison nulla prosciutto.
+
+Ut turkey ipsum kevin cillum. Tongue sausage meatball pancetta pork chop corned beef sunt strip 
+steak. Salami voluptate elit eiusmod ut. Filet mignon voluptate turkey tri-tip prosciutto cillum. 
+Ribeye commodo boudin shoulder t-bone. Quis esse ea qui, chuck eiusmod minim shank pork loin sed 
+irure aliquip sirloin. Sirloin cow non chicken consequat sausage short loin capicola reprehenderit 
+eiusmod.
+
+Landjaeger pancetta aliquip magna, consequat nisi shankle officia pork. Sirloin pariatur eiusmod, 
+rump filet mignon in aliqua beef ribs duis commodo. Flank ham landjaeger consectetur aliqua pork 
+venison andouille aute veniam cillum. Boudin ham hock beef ribs, incididunt ullamco hamburger 
+chicken beef. Mollit ut elit, sunt pork belly leberkas qui brisket labore kielbasa in irure dolor 
+ipsum veniam. Doner id porchetta andouille ut. Mollit eu ut sausage kevin esse nulla tongue do 
+beef shankle corned beef.
+
+So thank you, $NAME, for your interest.
+
+Regards,
+
+The Company
+----
+200
+Content-Type: application/json
+
+{
+  "method" : "PUT",
+  "resource" : "/path/to/app/resource",
+  "uri" : "/path/to/app/resource",
+  "headers" : {
+    "Content-Type":"text/plain"
+  },
+  "bodyLength" : 4745,
+  "bodySha1" : "1dd43072f7ac27dc3bb83620bd4a1b43c6d9d17d"
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-data-policy/setup/001-publish-service.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-data-policy/setup/001-publish-service.resttest
@@ -1,0 +1,12 @@
+PUT /api/services admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "SimpleDataPolicyTest",
+  "serviceId" : "echo",
+  "version" : "1.0.0",
+  "endpointType" : "REST",
+  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-data-policy/setup/002-register-app.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-data-policy/setup/002-register-app.resttest
@@ -1,0 +1,24 @@
+PUT /api/applications admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "SimpleDataPolicyTest",
+  "applicationId" : "test",
+  "version" : "1.0.0",
+  "contracts" : [
+    {
+      "apiKey" : "12345",
+      "serviceOrgId" : "SimpleDataPolicyTest",
+      "serviceId" : "echo",
+      "serviceVersion" : "1.0.0",
+      "policies" : [
+        {
+          "policyImpl" : "class:io.apiman.gateway.test.policies.SimpleDataPolicy",
+          "policyJsonConfig" : ""
+        }
+      ]
+    }
+  ]
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-echo/echo/001.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-echo/echo/001.resttest
@@ -1,0 +1,16 @@
+GET /http-gateway/path/to/app/resource admin/admin
+X-Custom-Header: MyValue
+X-API-Key: 12345
+
+----
+200
+Content-Type: application/json
+
+{
+  "method" : "GET",
+  "resource" : "/path/to/app/resource",
+  "uri" : "/path/to/app/resource",
+  "headers" : {
+    "X-Custom-Header" : "MyValue"
+  }
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-echo/echo/002.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-echo/echo/002.resttest
@@ -1,0 +1,22 @@
+PUT /http-gateway/path/to/app/resource admin/admin
+Content-Type: application/json
+X-API-Key: 12345
+
+{
+  "key" : "value",
+  "key" : "value"
+}
+----
+200
+Content-Type: application/json
+
+{
+  "method" : "PUT",
+  "resource" : "/path/to/app/resource",
+  "uri" : "/path/to/app/resource",
+  "headers" : {
+    "Content-Type":"application/json"
+  },
+  "bodyLength" : 41,
+  "bodySha1" : "9a09002951d1e09e8268b5f0cb4fb89f7f9deb3f"
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-echo/echo/003.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-echo/echo/003.resttest
@@ -1,0 +1,99 @@
+POST /http-gateway/path/to/app/resource admin/admin
+Content-Type: text/plain
+X-API-Key: 12345
+
+Lorem ipsum dolor sit amet, liber ocurreret suscipiantur has in. Nec nibh luptatum te, et vix option iisque, ne mazim voluptaria mediocritatem est. Summo movet salutandi no sed, in unum labore forensibus usu, ex putant omnium appellantur pri. Sed nominati praesent te, an his sint case incorrupte. Hinc reprehendunt at est, errem impedit no qui. Ad atomorum rationibus constituto has.
+
+Iisque conceptam ad vim, nec ex maluisset imperdiet. Nam ut ridens disputationi, ne natum voluptua mei. Tollit tacimates iudicabit in est, ne est augue iuvaret vituperata, ex mea deserunt vituperata. No per tale inermis, vis cu oporteat quaerendum.
+
+Numquam honestatis dissentiunt mel eu, accusam maluisset dignissim et mel, ut civibus tibique delicata cum. Duo ea audire impedit, id eum possim aliquam scribentur, diam solum no has. Ad nisl partem offendit qui, eu pro dicat nulla ridens. Vim ex eros paulo constituam, quis feugait interesset ad mea, vis et ipsum debet putant. No ridens docendi ponderum per, omnis admodum sea in, vel et prima error noster. At pri elit graecis, mea dictas delenit intellegebat eu.
+
+In debet viris sit. Dicunt nominavi has ex, ea possit utroque copiosae quo, vix cu everti moderatius quaerendum. No amet everti repudiandae sea. Cu natum volumus apeirian vel, id nam legere accumsan, vel ex dolore legere argumentum. Primis vituperata eum ei, falli errem volutpat et duo, nulla mundi necessitatibus per te.
+
+Ne eos alia meliore, mel iudico tantas latine et. Laudem possim te eos, sit sumo fastidii no, ea consul antiopam salutatus nam. Tantas putant eloquentiam eu mei, mei id wisi feugiat. Alii singulis pri te, vim eu solet similique. Quis deterruisset te eos. Case assum insolens est ut, duo ut soluta doctus assueverit, aperiam aperiri elaboraret ius an.
+Lorem ipsum dolor sit amet, liber ocurreret suscipiantur has in. Nec nibh luptatum te, et vix option iisque, ne mazim voluptaria mediocritatem est. Summo movet salutandi no sed, in unum labore forensibus usu, ex putant omnium appellantur pri. Sed nominati praesent te, an his sint case incorrupte. Hinc reprehendunt at est, errem impedit no qui. Ad atomorum rationibus constituto has.
+
+Iisque conceptam ad vim, nec ex maluisset imperdiet. Nam ut ridens disputationi, ne natum voluptua mei. Tollit tacimates iudicabit in est, ne est augue iuvaret vituperata, ex mea deserunt vituperata. No per tale inermis, vis cu oporteat quaerendum.
+
+Numquam honestatis dissentiunt mel eu, accusam maluisset dignissim et mel, ut civibus tibique delicata cum. Duo ea audire impedit, id eum possim aliquam scribentur, diam solum no has. Ad nisl partem offendit qui, eu pro dicat nulla ridens. Vim ex eros paulo constituam, quis feugait interesset ad mea, vis et ipsum debet putant. No ridens docendi ponderum per, omnis admodum sea in, vel et prima error noster. At pri elit graecis, mea dictas delenit intellegebat eu.
+
+In debet viris sit. Dicunt nominavi has ex, ea possit utroque copiosae quo, vix cu everti moderatius quaerendum. No amet everti repudiandae sea. Cu natum volumus apeirian vel, id nam legere accumsan, vel ex dolore legere argumentum. Primis vituperata eum ei, falli errem volutpat et duo, nulla mundi necessitatibus per te.
+
+Ne eos alia meliore, mel iudico tantas latine et. Laudem possim te eos, sit sumo fastidii no, ea consul antiopam salutatus nam. Tantas putant eloquentiam eu mei, mei id wisi feugiat. Alii singulis pri te, vim eu solet similique. Quis deterruisset te eos. Case assum insolens est ut, duo ut soluta doctus assueverit, aperiam aperiri elaboraret ius an.
+Lorem ipsum dolor sit amet, liber ocurreret suscipiantur has in. Nec nibh luptatum te, et vix option iisque, ne mazim voluptaria mediocritatem est. Summo movet salutandi no sed, in unum labore forensibus usu, ex putant omnium appellantur pri. Sed nominati praesent te, an his sint case incorrupte. Hinc reprehendunt at est, errem impedit no qui. Ad atomorum rationibus constituto has.
+
+Iisque conceptam ad vim, nec ex maluisset imperdiet. Nam ut ridens disputationi, ne natum voluptua mei. Tollit tacimates iudicabit in est, ne est augue iuvaret vituperata, ex mea deserunt vituperata. No per tale inermis, vis cu oporteat quaerendum.
+
+Numquam honestatis dissentiunt mel eu, accusam maluisset dignissim et mel, ut civibus tibique delicata cum. Duo ea audire impedit, id eum possim aliquam scribentur, diam solum no has. Ad nisl partem offendit qui, eu pro dicat nulla ridens. Vim ex eros paulo constituam, quis feugait interesset ad mea, vis et ipsum debet putant. No ridens docendi ponderum per, omnis admodum sea in, vel et prima error noster. At pri elit graecis, mea dictas delenit intellegebat eu.
+
+In debet viris sit. Dicunt nominavi has ex, ea possit utroque copiosae quo, vix cu everti moderatius quaerendum. No amet everti repudiandae sea. Cu natum volumus apeirian vel, id nam legere accumsan, vel ex dolore legere argumentum. Primis vituperata eum ei, falli errem volutpat et duo, nulla mundi necessitatibus per te.
+
+Ne eos alia meliore, mel iudico tantas latine et. Laudem possim te eos, sit sumo fastidii no, ea consul antiopam salutatus nam. Tantas putant eloquentiam eu mei, mei id wisi feugiat. Alii singulis pri te, vim eu solet similique. Quis deterruisset te eos. Case assum insolens est ut, duo ut soluta doctus assueverit, aperiam aperiri elaboraret ius an.
+Lorem ipsum dolor sit amet, liber ocurreret suscipiantur has in. Nec nibh luptatum te, et vix option iisque, ne mazim voluptaria mediocritatem est. Summo movet salutandi no sed, in unum labore forensibus usu, ex putant omnium appellantur pri. Sed nominati praesent te, an his sint case incorrupte. Hinc reprehendunt at est, errem impedit no qui. Ad atomorum rationibus constituto has.
+
+Iisque conceptam ad vim, nec ex maluisset imperdiet. Nam ut ridens disputationi, ne natum voluptua mei. Tollit tacimates iudicabit in est, ne est augue iuvaret vituperata, ex mea deserunt vituperata. No per tale inermis, vis cu oporteat quaerendum.
+
+Numquam honestatis dissentiunt mel eu, accusam maluisset dignissim et mel, ut civibus tibique delicata cum. Duo ea audire impedit, id eum possim aliquam scribentur, diam solum no has. Ad nisl partem offendit qui, eu pro dicat nulla ridens. Vim ex eros paulo constituam, quis feugait interesset ad mea, vis et ipsum debet putant. No ridens docendi ponderum per, omnis admodum sea in, vel et prima error noster. At pri elit graecis, mea dictas delenit intellegebat eu.
+
+In debet viris sit. Dicunt nominavi has ex, ea possit utroque copiosae quo, vix cu everti moderatius quaerendum. No amet everti repudiandae sea. Cu natum volumus apeirian vel, id nam legere accumsan, vel ex dolore legere argumentum. Primis vituperata eum ei, falli errem volutpat et duo, nulla mundi necessitatibus per te.
+
+Ne eos alia meliore, mel iudico tantas latine et. Laudem possim te eos, sit sumo fastidii no, ea consul antiopam salutatus nam. Tantas putant eloquentiam eu mei, mei id wisi feugiat. Alii singulis pri te, vim eu solet similique. Quis deterruisset te eos. Case assum insolens est ut, duo ut soluta doctus assueverit, aperiam aperiri elaboraret ius an.
+Lorem ipsum dolor sit amet, liber ocurreret suscipiantur has in. Nec nibh luptatum te, et vix option iisque, ne mazim voluptaria mediocritatem est. Summo movet salutandi no sed, in unum labore forensibus usu, ex putant omnium appellantur pri. Sed nominati praesent te, an his sint case incorrupte. Hinc reprehendunt at est, errem impedit no qui. Ad atomorum rationibus constituto has.
+
+Iisque conceptam ad vim, nec ex maluisset imperdiet. Nam ut ridens disputationi, ne natum voluptua mei. Tollit tacimates iudicabit in est, ne est augue iuvaret vituperata, ex mea deserunt vituperata. No per tale inermis, vis cu oporteat quaerendum.
+
+Numquam honestatis dissentiunt mel eu, accusam maluisset dignissim et mel, ut civibus tibique delicata cum. Duo ea audire impedit, id eum possim aliquam scribentur, diam solum no has. Ad nisl partem offendit qui, eu pro dicat nulla ridens. Vim ex eros paulo constituam, quis feugait interesset ad mea, vis et ipsum debet putant. No ridens docendi ponderum per, omnis admodum sea in, vel et prima error noster. At pri elit graecis, mea dictas delenit intellegebat eu.
+
+In debet viris sit. Dicunt nominavi has ex, ea possit utroque copiosae quo, vix cu everti moderatius quaerendum. No amet everti repudiandae sea. Cu natum volumus apeirian vel, id nam legere accumsan, vel ex dolore legere argumentum. Primis vituperata eum ei, falli errem volutpat et duo, nulla mundi necessitatibus per te.
+
+Ne eos alia meliore, mel iudico tantas latine et. Laudem possim te eos, sit sumo fastidii no, ea consul antiopam salutatus nam. Tantas putant eloquentiam eu mei, mei id wisi feugiat. Alii singulis pri te, vim eu solet similique. Quis deterruisset te eos. Case assum insolens est ut, duo ut soluta doctus assueverit, aperiam aperiri elaboraret ius an.
+Lorem ipsum dolor sit amet, liber ocurreret suscipiantur has in. Nec nibh luptatum te, et vix option iisque, ne mazim voluptaria mediocritatem est. Summo movet salutandi no sed, in unum labore forensibus usu, ex putant omnium appellantur pri. Sed nominati praesent te, an his sint case incorrupte. Hinc reprehendunt at est, errem impedit no qui. Ad atomorum rationibus constituto has.
+
+Iisque conceptam ad vim, nec ex maluisset imperdiet. Nam ut ridens disputationi, ne natum voluptua mei. Tollit tacimates iudicabit in est, ne est augue iuvaret vituperata, ex mea deserunt vituperata. No per tale inermis, vis cu oporteat quaerendum.
+
+Numquam honestatis dissentiunt mel eu, accusam maluisset dignissim et mel, ut civibus tibique delicata cum. Duo ea audire impedit, id eum possim aliquam scribentur, diam solum no has. Ad nisl partem offendit qui, eu pro dicat nulla ridens. Vim ex eros paulo constituam, quis feugait interesset ad mea, vis et ipsum debet putant. No ridens docendi ponderum per, omnis admodum sea in, vel et prima error noster. At pri elit graecis, mea dictas delenit intellegebat eu.
+
+In debet viris sit. Dicunt nominavi has ex, ea possit utroque copiosae quo, vix cu everti moderatius quaerendum. No amet everti repudiandae sea. Cu natum volumus apeirian vel, id nam legere accumsan, vel ex dolore legere argumentum. Primis vituperata eum ei, falli errem volutpat et duo, nulla mundi necessitatibus per te.
+
+Ne eos alia meliore, mel iudico tantas latine et. Laudem possim te eos, sit sumo fastidii no, ea consul antiopam salutatus nam. Tantas putant eloquentiam eu mei, mei id wisi feugiat. Alii singulis pri te, vim eu solet similique. Quis deterruisset te eos. Case assum insolens est ut, duo ut soluta doctus assueverit, aperiam aperiri elaboraret ius an.
+Lorem ipsum dolor sit amet, liber ocurreret suscipiantur has in. Nec nibh luptatum te, et vix option iisque, ne mazim voluptaria mediocritatem est. Summo movet salutandi no sed, in unum labore forensibus usu, ex putant omnium appellantur pri. Sed nominati praesent te, an his sint case incorrupte. Hinc reprehendunt at est, errem impedit no qui. Ad atomorum rationibus constituto has.
+
+Iisque conceptam ad vim, nec ex maluisset imperdiet. Nam ut ridens disputationi, ne natum voluptua mei. Tollit tacimates iudicabit in est, ne est augue iuvaret vituperata, ex mea deserunt vituperata. No per tale inermis, vis cu oporteat quaerendum.
+
+Numquam honestatis dissentiunt mel eu, accusam maluisset dignissim et mel, ut civibus tibique delicata cum. Duo ea audire impedit, id eum possim aliquam scribentur, diam solum no has. Ad nisl partem offendit qui, eu pro dicat nulla ridens. Vim ex eros paulo constituam, quis feugait interesset ad mea, vis et ipsum debet putant. No ridens docendi ponderum per, omnis admodum sea in, vel et prima error noster. At pri elit graecis, mea dictas delenit intellegebat eu.
+
+In debet viris sit. Dicunt nominavi has ex, ea possit utroque copiosae quo, vix cu everti moderatius quaerendum. No amet everti repudiandae sea. Cu natum volumus apeirian vel, id nam legere accumsan, vel ex dolore legere argumentum. Primis vituperata eum ei, falli errem volutpat et duo, nulla mundi necessitatibus per te.
+
+Ne eos alia meliore, mel iudico tantas latine et. Laudem possim te eos, sit sumo fastidii no, ea consul antiopam salutatus nam. Tantas putant eloquentiam eu mei, mei id wisi feugiat. Alii singulis pri te, vim eu solet similique. Quis deterruisset te eos. Case assum insolens est ut, duo ut soluta doctus assueverit, aperiam aperiri elaboraret ius an.
+Lorem ipsum dolor sit amet, liber ocurreret suscipiantur has in. Nec nibh luptatum te, et vix option iisque, ne mazim voluptaria mediocritatem est. Summo movet salutandi no sed, in unum labore forensibus usu, ex putant omnium appellantur pri. Sed nominati praesent te, an his sint case incorrupte. Hinc reprehendunt at est, errem impedit no qui. Ad atomorum rationibus constituto has.
+
+Iisque conceptam ad vim, nec ex maluisset imperdiet. Nam ut ridens disputationi, ne natum voluptua mei. Tollit tacimates iudicabit in est, ne est augue iuvaret vituperata, ex mea deserunt vituperata. No per tale inermis, vis cu oporteat quaerendum.
+
+Numquam honestatis dissentiunt mel eu, accusam maluisset dignissim et mel, ut civibus tibique delicata cum. Duo ea audire impedit, id eum possim aliquam scribentur, diam solum no has. Ad nisl partem offendit qui, eu pro dicat nulla ridens. Vim ex eros paulo constituam, quis feugait interesset ad mea, vis et ipsum debet putant. No ridens docendi ponderum per, omnis admodum sea in, vel et prima error noster. At pri elit graecis, mea dictas delenit intellegebat eu.
+
+In debet viris sit. Dicunt nominavi has ex, ea possit utroque copiosae quo, vix cu everti moderatius quaerendum. No amet everti repudiandae sea. Cu natum volumus apeirian vel, id nam legere accumsan, vel ex dolore legere argumentum. Primis vituperata eum ei, falli errem volutpat et duo, nulla mundi necessitatibus per te.
+
+Ne eos alia meliore, mel iudico tantas latine et. Laudem possim te eos, sit sumo fastidii no, ea consul antiopam salutatus nam. Tantas putant eloquentiam eu mei, mei id wisi feugiat. Alii singulis pri te, vim eu solet similique. Quis deterruisset te eos. Case assum insolens est ut, duo ut soluta doctus assueverit, aperiam aperiri elaboraret ius an.
+Lorem ipsum dolor sit amet, liber ocurreret suscipiantur has in. Nec nibh luptatum te, et vix option iisque, ne mazim voluptaria mediocritatem est. Summo movet salutandi no sed, in unum labore forensibus usu, ex putant omnium appellantur pri. Sed nominati praesent te, an his sint case incorrupte. Hinc reprehendunt at est, errem impedit no qui. Ad atomorum rationibus constituto has.
+
+Iisque conceptam ad vim, nec ex maluisset imperdiet. Nam ut ridens disputationi, ne natum voluptua mei. Tollit tacimates iudicabit in est, ne est augue iuvaret vituperata, ex mea deserunt vituperata. No per tale inermis, vis cu oporteat quaerendum.
+
+Numquam honestatis dissentiunt mel eu, accusam maluisset dignissim et mel, ut civibus tibique delicata cum. Duo ea audire impedit, id eum possim aliquam scribentur, diam solum no has. Ad nisl partem offendit qui, eu pro dicat nulla ridens. Vim ex eros paulo constituam, quis feugait interesset ad mea, vis et ipsum debet putant. No ridens docendi ponderum per, omnis admodum sea in, vel et prima error noster. At pri elit graecis, mea dictas delenit intellegebat eu.
+
+In debet viris sit. Dicunt nominavi has ex, ea possit utroque copiosae quo, vix cu everti moderatius quaerendum. No amet everti repudiandae sea. Cu natum volumus apeirian vel, id nam legere accumsan, vel ex dolore legere argumentum. Primis vituperata eum ei, falli errem volutpat et duo, nulla mundi necessitatibus per te.
+
+Ne eos alia meliore, mel iudico tantas latine et. Laudem possim te eos, sit sumo fastidii no, ea consul antiopam salutatus nam. Tantas putant eloquentiam eu mei, mei id wisi feugiat. Alii singulis pri te, vim eu solet similique. Quis deterruisset te eos. Case assum insolens est ut, duo ut soluta doctus assueverit, aperiam aperiri elaboraret ius an.
+----
+200
+Content-Type: application/json
+
+{
+  "method" : "POST",
+  "resource" : "/path/to/app/resource",
+  "uri" : "/path/to/app/resource",
+  "headers" : {
+    "Content-Type":"text/plain"
+  },
+  "bodyLength" : 16011,
+  "bodySha1" : "c6c38fb58b3731498d705cb64c288c6cca367222"
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-echo/setup/001-publish-service.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-echo/setup/001-publish-service.resttest
@@ -1,0 +1,12 @@
+PUT /api/services admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "SimpleEchoTest",
+  "serviceId" : "echo",
+  "version" : "1.0.0",
+  "endpointType" : "REST",
+  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-echo/setup/002-register-app.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-echo/setup/002-register-app.resttest
@@ -1,0 +1,18 @@
+PUT /api/applications admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "SimpleEchoTest",
+  "applicationId" : "test",
+  "version" : "1.0.0",
+  "contracts" : [
+    {
+      "apiKey" : "12345",
+      "serviceOrgId" : "SimpleEchoTest",
+      "serviceId" : "echo",
+      "serviceVersion" : "1.0.0"
+    }
+  ]
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-httpclient-policy/setup/001-publish-service.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-httpclient-policy/setup/001-publish-service.resttest
@@ -1,0 +1,12 @@
+PUT /api/services admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "SimpleHttpClientPolicyTest",
+  "serviceId" : "echo",
+  "version" : "1.0.0",
+  "endpointType" : "REST",
+  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-httpclient-policy/setup/002-register-app.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-httpclient-policy/setup/002-register-app.resttest
@@ -1,0 +1,24 @@
+PUT /api/applications admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "SimpleHttpClientPolicyTest",
+  "applicationId" : "test",
+  "version" : "1.0.0",
+  "contracts" : [
+    {
+      "apiKey" : "12345",
+      "serviceOrgId" : "SimpleHttpClientPolicyTest",
+      "serviceId" : "echo",
+      "serviceVersion" : "1.0.0",
+      "policies" : [
+        {
+          "policyImpl" : "class:io.apiman.gateway.test.policies.SimpleHttpClientPolicy",
+          "policyJsonConfig" : ""
+        }
+      ]
+    }
+  ]
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-httpclient-policy/shp/001.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-httpclient-policy/shp/001.resttest
@@ -1,0 +1,17 @@
+GET /http-gateway/path/to/app/resource
+X-API-Key: 12345
+
+----
+200
+Content-Type: application/json
+
+{
+  "method" : "GET",
+  "resource" : "/path/to/app/resource",
+  "uri" : "/path/to/app/resource",
+  "headers" : {
+      "X-HttpClient-Response-Code" : "200",
+      "X-HttpClient-Response-Message" : "OK",
+      "X-HttpClient-Result" : "Success"
+  }
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-httpheader-policy/setup/001-publish-service.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-httpheader-policy/setup/001-publish-service.resttest
@@ -1,0 +1,12 @@
+PUT /api/services admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "SimpleHttpHeaderPolicyTest",
+  "serviceId" : "echo",
+  "version" : "1.0.0",
+  "endpointType" : "REST",
+  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-httpheader-policy/setup/002-register-app.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-httpheader-policy/setup/002-register-app.resttest
@@ -1,0 +1,24 @@
+PUT /api/applications admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "SimpleHttpHeaderPolicyTest",
+  "applicationId" : "test",
+  "version" : "1.0.0",
+  "contracts" : [
+    {
+      "apiKey" : "12345",
+      "serviceOrgId" : "SimpleHttpHeaderPolicyTest",
+      "serviceId" : "echo",
+      "serviceVersion" : "1.0.0",
+      "policies" : [
+        {
+          "policyImpl" : "class:io.apiman.gateway.test.policies.SimpleHttpHeaderPolicy",
+          "policyJsonConfig" : ""
+        }
+      ]
+    }
+  ]
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-httpheader-policy/shp/001.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-httpheader-policy/shp/001.resttest
@@ -1,0 +1,18 @@
+GET /http-gateway/path/to/app/resource admin/admin
+X-Custom-Header: MyValue
+X-API-Key: 12345
+
+----
+200
+Content-Type: application/json
+
+{
+  "method" : "GET",
+  "resource" : "/path/to/app/resource",
+  "uri" : "/path/to/app/resource",
+  "headers" : {
+    "X-Custom-Header" : "MyValue",
+    "X-SimpleHttpHeaderPolicy-1" : "foo",
+    "X-SimpleHttpHeaderPolicy-2" : "bar"
+  }
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-policy/policy/001.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-policy/policy/001.resttest
@@ -1,0 +1,16 @@
+GET /http-gateway/path/to/app/resource admin/admin
+X-Custom-Header: MyValue
+X-API-Key: 12345
+
+----
+200
+Content-Type: application/json
+
+{
+  "method" : "GET",
+  "resource" : "/path/to/app/resource",
+  "uri" : "/path/to/app/resource",
+  "headers" : {
+    "X-Custom-Header" : "MyValue"
+  }
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-policy/policy/002.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-policy/policy/002.resttest
@@ -1,0 +1,21 @@
+PUT /http-gateway/path/to/app/resource admin/admin
+Content-Type: application/json
+X-API-Key: 12345
+
+{
+  "key" : "value",
+  "key" : "value"
+}
+----
+200
+Content-Type: application/json
+
+{
+  "method" : "PUT",
+  "resource" : "/path/to/app/resource",
+  "bodyLength" : 41,
+  "uri" : "/path/to/app/resource",
+  "headers" : {
+    "Content-Type":"application/json"
+  }
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-policy/setup/001-publish-service.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-policy/setup/001-publish-service.resttest
@@ -1,0 +1,12 @@
+PUT /api/services admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "SimplePolicyTest",
+  "serviceId" : "echo",
+  "version" : "1.0.0",
+  "endpointType" : "REST",
+  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-policy/setup/002-register-app.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-policy/setup/002-register-app.resttest
@@ -1,0 +1,24 @@
+PUT /api/applications admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "SimplePolicyTest",
+  "applicationId" : "test",
+  "version" : "1.0.0",
+  "contracts" : [
+    {
+      "apiKey" : "12345",
+      "serviceOrgId" : "SimplePolicyTest",
+      "serviceId" : "echo",
+      "serviceVersion" : "1.0.0",
+      "policies" : [
+        {
+          "policyImpl" : "class:io.apiman.gateway.test.policies.SimplePolicy",
+          "policyJsonConfig" : ""
+        }
+      ]
+    }
+  ]
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-shared-state-policy/setup/001-publish-service.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-shared-state-policy/setup/001-publish-service.resttest
@@ -1,0 +1,12 @@
+PUT /api/services admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "SimpleSharedStatePolicyTest",
+  "serviceId" : "echo",
+  "version" : "1.0.0",
+  "endpointType" : "REST",
+  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-shared-state-policy/setup/002-register-app.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-shared-state-policy/setup/002-register-app.resttest
@@ -1,0 +1,24 @@
+PUT /api/applications admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "SimpleSharedStatePolicyTest",
+  "applicationId" : "test",
+  "version" : "1.0.0",
+  "contracts" : [
+    {
+      "apiKey" : "12345",
+      "serviceOrgId" : "SimpleSharedStatePolicyTest",
+      "serviceId" : "echo",
+      "serviceVersion" : "1.0.0",
+      "policies" : [
+        {
+          "policyImpl" : "class:io.apiman.gateway.test.policies.SimpleSharedStatePolicy",
+          "policyJsonConfig" : ""
+        }
+      ]
+    }
+  ]
+}
+----
+204

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-shared-state-policy/state/001.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-shared-state-policy/state/001.resttest
@@ -1,0 +1,17 @@
+GET /http-gateway/path/to/app/resource admin/admin
+X-Custom-Header: MyValue
+X-API-Key: 12345
+
+----
+200
+Content-Type: application/json
+X-Shared-State-Value: +
+
+{
+  "method" : "GET",
+  "resource" : "/path/to/app/resource",
+  "uri" : "/path/to/app/resource",
+  "headers" : {
+    "X-Custom-Header" : "MyValue"
+  }
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-shared-state-policy/state/002.resttest
+++ b/gateway/platforms/vertx/src/test/resources/test-plan-data/simple/simple-shared-state-policy/state/002.resttest
@@ -1,0 +1,22 @@
+PUT /http-gateway/path/to/app/resource admin/admin
+Content-Type: application/json
+X-API-Key: 12345
+
+{
+  "key" : "value",
+  "key" : "value"
+}
+----
+200
+Content-Type: application/json
+X-Shared-State-Value: ++
+
+{
+  "method" : "PUT",
+  "resource" : "/path/to/app/resource",
+  "bodyLength" : 41,
+  "uri" : "/path/to/app/resource",
+  "headers" : {
+    "Content-Type":"application/json"
+  }
+}

--- a/gateway/platforms/vertx/src/test/resources/test-plans/perf/overhead-testPlan.xml
+++ b/gateway/platforms/vertx/src/test/resources/test-plans/perf/overhead-testPlan.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan">
+
+  <testGroup name="Test Policy">
+    <test name="Publish Service">test-plan-data/perf/overhead/001-publish-service.resttest</test>
+    <test name="Register Application">test-plan-data/perf/overhead/002-register-app.resttest</test>
+  </testGroup>
+
+</testPlan>

--- a/gateway/platforms/vertx/src/test/resources/test-plans/policies/basic-auth-testPlan.xml
+++ b/gateway/platforms/vertx/src/test/resources/test-plans/policies/basic-auth-testPlan.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan">
+
+  <testGroup name="Test BASIC Auth (Static)">
+    <test name="Publish Service">test-plan-data/policies/basic-auth-static/001-publish-service.resttest</test>
+    <test name="Register Application">test-plan-data/policies/basic-auth-static/002-register-app.resttest</test>
+    <test name="Success">test-plan-data/policies/basic-auth-static/003-success.resttest</test>
+    <test name="Failure">test-plan-data/policies/basic-auth-static/004-failure.resttest</test>
+  </testGroup>
+
+</testPlan>

--- a/gateway/platforms/vertx/src/test/resources/test-plans/policies/ip-blacklist-testPlan.xml
+++ b/gateway/platforms/vertx/src/test/resources/test-plans/policies/ip-blacklist-testPlan.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan">
+
+  <testGroup name="Test Policy">
+    <test name="Publish Service">test-plan-data/policies/ip-blacklist/001-publish-service.resttest</test>
+    <test name="Register Application">test-plan-data/policies/ip-blacklist/002-register-app.resttest</test>
+    <test name="Success">test-plan-data/policies/ip-blacklist/003-success.resttest</test>
+    <test name="Failure">test-plan-data/policies/ip-blacklist/004-failure.resttest</test>
+  </testGroup>
+
+</testPlan>

--- a/gateway/platforms/vertx/src/test/resources/test-plans/policies/ip-whitelist-testPlan.xml
+++ b/gateway/platforms/vertx/src/test/resources/test-plans/policies/ip-whitelist-testPlan.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan">
+
+  <testGroup name="Test Policy">
+    <test name="Publish Service">test-plan-data/policies/ip-whitelist/001-publish-service.resttest</test>
+    <test name="Register Application">test-plan-data/policies/ip-whitelist/002-register-app.resttest</test>
+    <test name="Success">test-plan-data/policies/ip-whitelist/003-success.resttest</test>
+    <test name="Failure">test-plan-data/policies/ip-whitelist/004-failure.resttest</test>
+  </testGroup>
+
+</testPlan>

--- a/gateway/platforms/vertx/src/test/resources/test-plans/policies/rate-limiting-testPlan.xml
+++ b/gateway/platforms/vertx/src/test/resources/test-plans/policies/rate-limiting-testPlan.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan">
+
+  <testGroup name="Test Policy">
+    <test name="Publish Service">test-plan-data/policies/rate-limiting/001-publish-service.resttest</test>
+    <test name="Register Application">test-plan-data/policies/rate-limiting/002-register-app.resttest</test>
+    <test name="Success">test-plan-data/policies/rate-limiting/003-success.resttest</test>
+    <test name="Success">test-plan-data/policies/rate-limiting/003-success.resttest</test>
+    <test name="Success">test-plan-data/policies/rate-limiting/003-success.resttest</test>
+    <test name="Success">test-plan-data/policies/rate-limiting/003-success.resttest</test>
+    <test name="Success">test-plan-data/policies/rate-limiting/003-success.resttest</test>
+    <test name="Failure">test-plan-data/policies/rate-limiting/004-failure.resttest</test>
+  </testGroup>
+
+</testPlan>

--- a/gateway/platforms/vertx/src/test/resources/test-plans/simple/simple-conversation-policy-testPlan.xml
+++ b/gateway/platforms/vertx/src/test/resources/test-plans/simple/simple-conversation-policy-testPlan.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan">
+
+  <testGroup name="Configure the Gateway">
+    <test name="Publish Service">test-plan-data/simple/simple-conversation-policy/setup/001-publish-service.resttest</test>
+    <test name="Register Application">test-plan-data/simple/simple-conversation-policy/setup/002-register-app.resttest</test>
+  </testGroup>
+
+  <testGroup name="Test the Echo Server through the Gateway">
+    <test name="Echo 1">test-plan-data/simple/simple-conversation-policy/convo/001.resttest</test>
+  </testGroup>
+
+</testPlan>

--- a/gateway/platforms/vertx/src/test/resources/test-plans/simple/simple-data-policy-testPlan.xml
+++ b/gateway/platforms/vertx/src/test/resources/test-plans/simple/simple-data-policy-testPlan.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan">
+
+  <testGroup name="Configure the Gateway">
+    <test name="Publish Service">test-plan-data/simple/simple-data-policy/setup/001-publish-service.resttest</test>
+    <test name="Register Application">test-plan-data/simple/simple-data-policy/setup/002-register-app.resttest</test>
+  </testGroup>
+
+  <testGroup name="Test the Echo Server through the Gateway">
+    <test name="Echo 1">test-plan-data/simple/simple-data-policy/datap/001.resttest</test>
+  </testGroup>
+
+</testPlan>

--- a/gateway/platforms/vertx/src/test/resources/test-plans/simple/simple-echo-testPlan.xml
+++ b/gateway/platforms/vertx/src/test/resources/test-plans/simple/simple-echo-testPlan.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan">
+
+  <testGroup name="Configure the Gateway">
+    <test name="Publish Service">test-plan-data/simple/simple-echo/setup/001-publish-service.resttest</test>
+    <test name="Register Application">test-plan-data/simple/simple-echo/setup/002-register-app.resttest</test>
+  </testGroup>
+
+  <testGroup name="Test the Echo Server through the Gateway">
+       <test name="Echo 1 (GET)">test-plan-data/simple/simple-echo/echo/001.resttest</test>
+       <test name="Echo 2 (PUT)">test-plan-data/simple/simple-echo/echo/002.resttest</test>
+       <test name="Echo 3 (POST)">test-plan-data/simple/simple-echo/echo/003.resttest</test>
+  </testGroup>
+
+</testPlan>

--- a/gateway/platforms/vertx/src/test/resources/test-plans/simple/simple-httpclient-policy-testPlan.xml
+++ b/gateway/platforms/vertx/src/test/resources/test-plans/simple/simple-httpclient-policy-testPlan.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan">
+
+  <testGroup name="Configure the Gateway">
+    <test name="Publish Service">test-plan-data/simple/simple-httpclient-policy/setup/001-publish-service.resttest</test>
+    <test name="Register Application">test-plan-data/simple/simple-httpclient-policy/setup/002-register-app.resttest</test>
+  </testGroup>
+
+  <testGroup name="Test the Echo Server through the Gateway">
+    <test name="Echo 1">test-plan-data/simple/simple-httpclient-policy/shp/001.resttest</test>
+  </testGroup>
+
+</testPlan>

--- a/gateway/platforms/vertx/src/test/resources/test-plans/simple/simple-httpheader-policy-testPlan.xml
+++ b/gateway/platforms/vertx/src/test/resources/test-plans/simple/simple-httpheader-policy-testPlan.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan">
+
+  <testGroup name="Configure the Gateway">
+    <test name="Publish Service">test-plan-data/simple/simple-httpheader-policy/setup/001-publish-service.resttest</test>
+    <test name="Register Application">test-plan-data/simple/simple-httpheader-policy/setup/002-register-app.resttest</test>
+  </testGroup>
+
+  <testGroup name="Test the Echo Server through the Gateway">
+    <test name="Echo 1">test-plan-data/simple/simple-httpheader-policy/shp/001.resttest</test>
+  </testGroup>
+
+</testPlan>

--- a/gateway/platforms/vertx/src/test/resources/test-plans/simple/simple-policy-testPlan.xml
+++ b/gateway/platforms/vertx/src/test/resources/test-plans/simple/simple-policy-testPlan.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan">
+
+  <testGroup name="Configure the Gateway">
+    <test name="Publish Service">test-plan-data/simple/simple-policy/setup/001-publish-service.resttest</test>
+    <test name="Register Application">test-plan-data/simple/simple-policy/setup/002-register-app.resttest</test>
+  </testGroup>
+
+  <testGroup name="Test the Echo Server through the Gateway">
+    <test name="Echo 1">test-plan-data/simple/simple-policy/policy/001.resttest</test>
+    <test name="Echo 2">test-plan-data/simple/simple-policy/policy/002.resttest</test>
+  </testGroup>
+
+</testPlan>

--- a/gateway/platforms/vertx/src/test/resources/test-plans/simple/simple-shared-state-policy-testPlan.xml
+++ b/gateway/platforms/vertx/src/test/resources/test-plans/simple/simple-shared-state-policy-testPlan.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan">
+
+  <testGroup name="Configure the Gateway">
+    <test name="Publish Service">test-plan-data/simple/simple-shared-state-policy/setup/001-publish-service.resttest</test>
+    <test name="Register Application">test-plan-data/simple/simple-shared-state-policy/setup/002-register-app.resttest</test>
+  </testGroup>
+
+  <testGroup name="Test the Echo Server through the Gateway">
+    <test name="Echo 1">test-plan-data/simple/simple-shared-state-policy/state/001.resttest</test>
+    <test name="Echo 2">test-plan-data/simple/simple-shared-state-policy/state/002.resttest</test>
+  </testGroup>
+
+</testPlan>

--- a/gateway/platforms/vertx/src/test/resources/testConfig.json
+++ b/gateway/platforms/vertx/src/test/resources/testConfig.json
@@ -1,0 +1,29 @@
+{
+  "registry": { "class": "io.apiman.gateway.engine.impl.InMemoryRegistry", "config": {} },
+  "connector-factory": { "class": "io.apiman.gateway.vertx.connector.HttpConnectorFactory", "config": {} },
+  "policy-factory": { "class": "io.apiman.gateway.engine.policy.PolicyFactoryImpl", "config": {} },
+  "routes": {
+    "http-dispatcher": 8200,
+    "http-gateway": 8201,
+    "api": 8202
+  },
+  "connectors": {
+    "http-rest": "io.apiman.gateway.connector.HttpConnectorFactory", "config": {}
+
+  },
+  "components": {
+    "IHttpClientComponent": { "class": "io.apiman.gateway.vertx.components.HttpClientComponentImpl", "config": {} },
+
+    "ISharedStateComponent": { "class": "io.apiman.gateway.engine.impl.InMemorySharedStateComponent", "config": {} },
+    "IRateLimiterComponent": { "class": "io.apiman.gateway.engine.impl.InMemoryRateLimiterComponent", "config": {} },
+    "IPolicyFailureFactoryComponent": { "class": "io.apiman.gateway.vertx.components.PolicyFailureFactoryComponent", "config": {} }
+  },
+  "auth": {
+    "file-basic": {
+      "admin" : "jGl25bVBBBW96Qi9Te4V37Fnqchz/Eu4qB9vKrRIqRg="
+    }
+  },
+
+  "authenticated": true,
+  "realm": "apiman-gateway"
+}

--- a/gateway/platforms/vertx/vertx_classpath.txt
+++ b/gateway/platforms/vertx/vertx_classpath.txt
@@ -1,0 +1,11 @@
+# This file contains information on where to find the resources of your module during development
+# This file is used when running your module as you develop - it tells Vert.x where to find
+# the resources of your module
+
+# Feel free to edit it if you have a non standard project structure and put the resources of your
+# module elsewhere
+
+src/main/resources
+target/classes
+target/dependencies
+bin

--- a/gateway/test/src/test/java/io/apiman/gateway/test/IGatewayTest.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/IGatewayTest.java
@@ -1,0 +1,5 @@
+package io.apiman.gateway.test;
+
+public interface IGatewayTest {
+
+}


### PR DESCRIPTION
This is the initial version of an apiman gateway implemented as a Vert.x [module](http://vertx.io/mods_manual.html) .

The system is composed of several small verticles which run independently and asynchronously; communicating with each other primarily over a distributed bus (event bus). This is reminiscent of the actor model, and is designed to be highly scalable, the extent of which which should be fully exposed in the next release:

Whilst this first rendition uses mostly simple in-memory components which don't fully exercise the platform's distributed scaling potential, the underlying architecture of the gateway is prepared for it; hence, the next release will implement the necessary distributed components and we will fully expose clustered, multi-verticle configurations. It is, however, fully functional.

An example configuration file is provided in README.me and src/main/resources/config.json

Tests pass as of this commit. They can be run using vert'x test harness via: `mvn integration-test`
