### PR TITLE
Remove stray unused class

### DIFF
--- a/gateway/test/src/test/java/io/apiman/gateway/test/IGatewayTest.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/IGatewayTest.java
@@ -1,5 +1,0 @@
-package io.apiman.gateway.test;
-
-public interface IGatewayTest {
-
-}


### PR DESCRIPTION
You correctly noted that this class wasn't necessary. I'd have rolled it into the last PR but I didn't see your comment until now. GH notification was spam binned.
