### PR TITLE
Added a profile to create a docker image on the latest code

### DIFF
--- a/distro/wildfly8/pom.xml
+++ b/distro/wildfly8/pom.xml
@@ -153,4 +153,38 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+        <id>docker</id>
+        <build>
+            <finalName>${project.artifactId}</finalName>
+            <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>0.1.1</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <imageName>${project.artifactId}:${project.version}</imageName>
+              <dockerDirectory>${project.basedir}/src/main/docker</dockerDirectory>
+              <resources>
+                <resource>
+                  <targetPath>/</targetPath>
+                  <directory>${project.build.directory}</directory>
+                  <include>${project.artifactId}-overlay.zip</include>
+                </resource>
+              </resources>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/distro/wildfly8/src/main/docker/Dockerfile
+++ b/distro/wildfly8/src/main/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM jboss/wildfly
+
+ADD apiman-distro-wildfly8-overlay.zip /tmp/
+
+RUN unzip -o /tmp/apiman-distro-wildfly8-overlay.zip -d /opt/jboss/wildfly
+
+CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0", "-bmanagement", "0.0.0.0", "-c", "standalone-apiman.xml"]


### PR DESCRIPTION
run mvn clean install -P docker. You'll have a docker image that can be run with:

```
docker run -it --rm -p 8080:8080 -p 9990:9990 apiman-distro-wildfly8:1.0.1-SNAPSHOT
```

This is using this plugin, and can be enhanced, worked with: https://github.com/spotify/docker-maven-plugin 
I've tried different plugins, and this is the one that best fits this needs.
