### PR TITLE
Implementation of the Caching Policiy - APIMAN-219

### DIFF
--- a/distro/data/src/main/resources/data/all-policyDefs.json
+++ b/distro/data/src/main/resources/data/all-policyDefs.json
@@ -58,5 +58,17 @@
           "template" : "Requests matching any of the @{pathsToIgnore.size()} regular expressions provided will receive a 404 error code."
         }
       ]
+    },
+    {
+      "name" : "Caching Policy",
+      "description" : "Enables caching for back-end responses.",
+      "policyImpl" : "class:io.apiman.gateway.engine.policies.CachingPolicy",
+      "icon" : "database",
+      "templates" : [
+        {
+          "language" : null,
+          "template" : "Back-end responses will be cached for @{ttl} seconds."
+        }
+      ]
     }
 ]

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/components/IDataStoreComponent.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/components/IDataStoreComponent.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.components;
+
+import io.apiman.gateway.engine.IComponent;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.impl.CachedResponse;
+
+/**
+ * A Component that allows policies to share data across invocations and potentially
+ * across nodes (depending on the implementation). The data managed will be related to
+ * requests and/or responses such as {@link CachedResponse} instances
+ *
+ * It is up to the implementation of this component to determine how transactional
+ * it might be (there are time vs. accuracy tradeoffs to be made here).  Users
+ * of API Management will need to ensure they use an appropriate implementation
+ * of this component based on the data integrity/accuracy guarantees they require.
+ * 
+ * All operations in this component are assumed to be asyncrhonous, so a handler
+ * must be provided if the policy implementation needs the operation to finish
+ * prior to moving on.
+ * 
+ * @author rubenrm1@gmail.com
+ */
+public interface IDataStoreComponent extends IComponent {
+
+    /**
+     * Checks whether the requested property exists in the Data Store
+     * @param namespace
+     * @param propertyName
+     * @return
+     */
+    <T> boolean hasProperty(String namespace, String propertyName); 
+    
+    /**
+     * Gets the value of a single property stored in the shared state 
+     * environment.  Null is returned if the property is not set.
+     * @param namespace
+     * @param propertyName
+     * @param defaultValue
+     * @param handler
+     */
+     <T> void getProperty(String namespace, String propertyName, T defaultValue, IAsyncResultHandler<T> handler);
+    
+    /**
+     * Sets a single property in the shared state environment, returning
+     * the previous value of the property or null if it was not previously set.
+     * @param namespace
+     * @param propertyName
+     * @param value
+     * @param handler
+     */
+    <T> void setProperty(String namespace, String propertyName, T value, IAsyncResultHandler<T> handler);
+    
+    /**
+     * Sets a single property in the shared state environment for the given period of time, 
+     * returning the previous value of the property or null if it was not previously set.
+     * @param namespace
+     * @param propertyName
+     * @param value
+     * @param expiration time for the property to be kept in the DataStore before being considered as expired
+     * @param handler
+     */
+    <T> void setProperty(String namespace, String propertyName, T value, Long expiration, IAsyncResultHandler<T> handler);
+    
+    /**
+     * Clears a property from the shared state environment, returning the previous 
+     * value of the property or null if it was not previously set.
+     * @param namespace
+     * @param propertyName
+     * @param handler
+     */
+    <T> void clearProperty(String namespace, String propertyName, IAsyncResultHandler<T> handler);
+    
+}

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/components/ISharedStateComponent.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/components/ISharedStateComponent.java
@@ -19,7 +19,7 @@ import io.apiman.gateway.engine.IComponent;
 import io.apiman.gateway.engine.async.IAsyncResultHandler;
 
 /**
- * A component that allows policies to share information across invokations
+ * A component that allows policies to share information across invocations
  * and potentially across nodes in a cluster.  The expectation is that policies
  * will use this component to track aggregation information such as metrics,
  * billing, or for throttling.

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/CachedResponse.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/CachedResponse.java
@@ -1,0 +1,110 @@
+package io.apiman.gateway.engine.impl;
+
+import io.apiman.gateway.engine.io.IApimanBuffer;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+
+/**
+ * This class aims to embody all the data related to a service response. The instance will contain 
+ * the response headers, code, message and body. The body will be persisted as a file in a temporary
+ * folder
+ * 
+ * @author rubenrm1@gmail.com
+ *
+ */
+public class CachedResponse {
+
+    private static final Path tmpDir;
+    
+    static {
+        try {
+            tmpDir = Files.createTempDirectory(null);
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+    
+    private String id;
+    private Map<String, String> headers;
+    private int code;
+    private String message;
+    private boolean writeFailed = false;
+    
+    private File tmpFile;
+    private FileOutputStream fileOS;
+    private FileInputStream fileIS;
+
+    public CachedResponse(String id) {
+        this.id = id;
+        tmpFile = new File(tmpDir.toFile(), "response" + id.hashCode() + ".apiman");
+    }
+    
+    public String getId() {
+        return id;
+    }
+    
+    public void setHeaders(Map<String, String> headers) {
+        this.headers = new HashMap<String, String>(headers.size());
+        for(Map.Entry<String, String> entry : headers.entrySet()) {
+            this.headers.put(entry.getKey(), entry.getValue());
+        }
+    }
+    
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+    
+    public int getCode() {
+        return code;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+    
+    public String getMessage() {
+        return message;
+    }
+    
+    public void write(IApimanBuffer chunk) {
+        if (fileOS == null) {
+            try {
+                fileOS = new FileOutputStream(tmpFile);
+                fileOS.write(chunk.getBytes());
+            } catch (IOException e) {
+                // TODO: Log the error. 
+                // The response will not be cached as it might not contain a valid body
+                writeFailed = true;
+            }
+        }
+    }
+    
+    public void endWrite() {
+        IOUtils.closeQuietly(fileOS);
+        fileOS = null;
+    }
+    
+    public InputStream getInputStream() throws IOException {
+        fileIS = new FileInputStream(tmpFile);
+        return fileIS;
+    }
+    
+    public boolean isWriteFailed() {
+        return writeFailed;
+    }
+    
+}

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/DefaultComponentRegistry.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/DefaultComponentRegistry.java
@@ -18,6 +18,7 @@ package io.apiman.gateway.engine.impl;
 import io.apiman.gateway.engine.IComponent;
 import io.apiman.gateway.engine.IComponentRegistry;
 import io.apiman.gateway.engine.beans.exceptions.ComponentNotFoundException;
+import io.apiman.gateway.engine.components.IDataStoreComponent;
 import io.apiman.gateway.engine.components.IPolicyFailureFactoryComponent;
 import io.apiman.gateway.engine.components.IRateLimiterComponent;
 import io.apiman.gateway.engine.components.ISharedStateComponent;
@@ -40,6 +41,7 @@ public class DefaultComponentRegistry implements IComponentRegistry {
      */
     public DefaultComponentRegistry() {
         components.put(ISharedStateComponent.class, new InMemorySharedStateComponent());
+        components.put(IDataStoreComponent.class, new InMemoryDataStoreComponent());
         components.put(IRateLimiterComponent.class, new InMemoryRateLimiterComponent());
         components.put(IPolicyFailureFactoryComponent.class, new DefaultPolicyFailureFactoryComponent());
     }

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/InMemoryDataStoreComponent.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/InMemoryDataStoreComponent.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.impl;
+
+import io.apiman.gateway.engine.async.AsyncResultImpl;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.components.IDataStoreComponent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+
+/**
+ * An in-memory only implementation of the data store component. This
+ * implementation is generally used for testing and embedded situations. It does
+ * not work in a cluster and is not persistent across server restarts.
+ *
+ * @author rubenrm1@gmail.com
+ */
+public class InMemoryDataStoreComponent implements IDataStoreComponent {
+
+    private Map<QName, Object> sharedState = new HashMap<QName, Object>();
+
+    /**
+     * Constructor.
+     */
+    public InMemoryDataStoreComponent() {
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.components.IDataStoreComponent#hasProperty(java.lang.String, java.lang.String)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> boolean hasProperty(String namespace, String propertyName) {
+        T value = null;
+        synchronized (sharedState) {
+            QName key = new QName(namespace, propertyName);
+            value = (T) sharedState.get(key);
+        }
+        return value != null;
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.components.IDataStoreComponent#getProperty(java.lang.String, java.lang.String, java.lang.Object, io.apiman.gateway.engine.async.IAsyncResultHandler)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> void getProperty(String namespace, String propertyName, T defaultValue,
+            IAsyncResultHandler<T> handler) {
+        T value = null;
+        synchronized (sharedState) {
+            QName key = new QName(namespace, propertyName);
+            value = (T) sharedState.get(key);
+        }
+        if (value == null) {
+            value = defaultValue;
+        }
+        handler.handle(AsyncResultImpl.create(value));
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.components.IDataStoreComponent#setProperty(java.lang.String, java.lang.String, java.lang.Object, io.apiman.gateway.engine.async.IAsyncResultHandler)
+     */
+    @Override
+    public <T> void setProperty(String namespace, String propertyName, T value, IAsyncResultHandler<T> handler) {
+        setProperty(namespace, propertyName, value, null, handler);
+    }
+
+    /**
+     * This implementation will ignore the expiration time
+     * 
+     * @see io.apiman.gateway.engine.components.IDataStoreComponent#setProperty(java.lang.String, java.lang.String, java.lang.Object, java.lang.Long, IAsyncResultHandler)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> void setProperty(String namespace, String propertyName, T value, Long expiration,
+            IAsyncResultHandler<T> handler) {
+        QName key = new QName(namespace, propertyName);
+        T oldValue = null;
+        synchronized (sharedState) {
+            oldValue = (T) sharedState.get(key);
+            sharedState.put(key, value);
+        }
+        handler.handle(AsyncResultImpl.create(oldValue));
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.components.IDataStoreComponent#clearProperty(java.lang.String, java.lang.String, io.apiman.gateway.engine.async.IAsyncResultHandler)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> void clearProperty(String namespace, String propertyName, IAsyncResultHandler<T> handler) {
+        QName key = new QName(namespace, propertyName);
+        T oldValue = null;
+        synchronized (sharedState) {
+            oldValue = (T) sharedState.remove(key);
+        }
+        handler.handle(AsyncResultImpl.create(oldValue));
+    }
+
+}

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/io/ByteBuffer.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/io/ByteBuffer.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+
+/**
+ * A simple {@link IApimanBuffer} from a byte array.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+@SuppressWarnings("nls") // TODO finish the implementation of this class!
+public class ByteBuffer implements IApimanBuffer {
+
+    private byte [] buffer;
+    private int bytesInBuffer = 0;
+    
+    /**
+     * Constructor.
+     */
+    public ByteBuffer(int size) {
+        buffer = new byte[size];
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#getNativeBuffer()
+     */
+    @Override
+    public Object getNativeBuffer() {
+        return buffer;
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#length()
+     */
+    @Override
+    public int length() {
+        return bytesInBuffer;
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#insert(int, io.apiman.gateway.engine.io.IApimanBuffer)
+     */
+    @Override
+    public void insert(int index, IApimanBuffer buffer) {
+        throw new RuntimeException("Not yet implemented");
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#insert(int, io.apiman.gateway.engine.io.IApimanBuffer, int, int)
+     */
+    @Override
+    public void insert(int index, IApimanBuffer buffer, int offset, int length) {
+        throw new RuntimeException("Not yet implemented");
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#append(io.apiman.gateway.engine.io.IApimanBuffer)
+     */
+    @Override
+    public void append(IApimanBuffer buffer) {
+        throw new RuntimeException("Not yet implemented");
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#append(io.apiman.gateway.engine.io.IApimanBuffer, int, int)
+     */
+    @Override
+    public void append(IApimanBuffer buffer, int offset, int length) {
+        throw new RuntimeException("Not yet implemented");
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#getByte(int)
+     */
+    @Override
+    public byte get(int index) {
+        return buffer[index];
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#set(int, byte)
+     */
+    @Override
+    public void set(int index, byte b) {
+        buffer[index] = b;
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#append(byte)
+     */
+    @Override
+    public void append(byte b) {
+        byte [] bytes = new byte[1];
+        bytes[0] = b;
+        append(bytes);
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#getBytes()
+     */
+    @Override
+    public byte[] getBytes() {
+        byte [] rval = new byte[bytesInBuffer];
+        System.arraycopy(buffer, 0, rval, 0, bytesInBuffer);
+        return rval;
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#getBytes(int, int)
+     */
+    @Override
+    public byte[] getBytes(int start, int end) {
+        int size = (end - start) - 1;
+        byte [] rval = new byte[bytesInBuffer];
+        System.arraycopy(buffer, start, rval, 0, size);
+        return rval;
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#insert(int, byte[])
+     */
+    @Override
+    public void insert(int index, byte[] b) {
+        throw new RuntimeException("Not yet implemented");
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#insert(int, byte[], int, int)
+     */
+    @Override
+    public void insert(int index, byte[] b, int offset, int length) {
+        throw new RuntimeException("Not yet implemented");
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#append(byte[])
+     */
+    @Override
+    public void append(byte[] bytes) {
+        int requiredBytes = bytesInBuffer + bytes.length;
+        if (requiredBytes > buffer.length) {
+            byte [] oldbuffer = buffer;
+            buffer = new byte[requiredBytes];
+            System.arraycopy(oldbuffer, 0, buffer, 0, bytesInBuffer);
+        }
+        System.arraycopy(bytes, 0, buffer, bytesInBuffer, bytes.length);
+        bytesInBuffer = requiredBytes;
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#append(byte[], int, int)
+     */
+    @Override
+    public void append(byte[] bytes, int offset, int length) {
+        int requiredBytes = bytesInBuffer + length;
+        if (requiredBytes > buffer.length) {
+            byte [] oldbuffer = buffer;
+            buffer = new byte[requiredBytes];
+            System.arraycopy(oldbuffer, 0, buffer, 0, bytesInBuffer);
+        }
+        System.arraycopy(bytes, offset, buffer, bytesInBuffer, length);
+        bytesInBuffer = requiredBytes;
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#getString(int, int)
+     */
+    @Override
+    public String getString(int start, int end) {
+        return new String(getBytes(start, end));
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#getString(int, int, java.lang.String)
+     */
+    @Override
+    public String getString(int start, int end, String encoding) {
+        try {
+            return new String(getBytes(start, end), encoding);
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#insert(int, java.lang.String)
+     */
+    @Override
+    public void insert(int index, String string) {
+        throw new RuntimeException("Not yet implemented");
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#insert(int, java.lang.String, java.lang.String)
+     */
+    @Override
+    public void insert(int index, String string, String encoding) {
+        throw new RuntimeException("Not yet implemented");
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#append(java.lang.String)
+     */
+    @Override
+    public void append(String string) {
+        byte[] bytes = string.getBytes();
+        append(bytes);
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#append(java.lang.String, java.lang.String)
+     */
+    @Override
+    public void append(String string, String encoding) throws UnsupportedEncodingException {
+        byte [] bytes = string.getBytes(encoding);
+        append(bytes);
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.IApimanBuffer#toString(java.lang.String)
+     */
+    @Override
+    public String toString(String encoding) {
+        try {
+            return new String(buffer, 0, bytesInBuffer, encoding);
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    /**
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return new String(buffer, 0, bytesInBuffer);
+    }
+
+    /**
+     * @return the bytesInBuffer
+     */
+    public int getBytesInBuffer() {
+        return bytesInBuffer;
+    }
+    
+    /**
+     * Reads from the input stream.
+     * @param stream
+     * @throws IOException
+     */
+    public int readFrom(InputStream stream) throws IOException {
+        bytesInBuffer = stream.read(buffer);
+        return bytesInBuffer;
+    }
+
+}

--- a/gateway/engine/ispn/src/main/java/io/apiman/gateway/engine/ispn/InfinispanDataStoreComponent.java
+++ b/gateway/engine/ispn/src/main/java/io/apiman/gateway/engine/ispn/InfinispanDataStoreComponent.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.ispn;
+
+import io.apiman.gateway.engine.async.AsyncResultImpl;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.components.IDataStoreComponent;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.xml.namespace.QName;
+
+import org.infinispan.Cache;
+import org.infinispan.manager.CacheContainer;
+
+/**
+ * Data Store component backed by an ISPN cache. This allows the data store
+ * to be easily clusterable and the data evictable.
+ *
+ * @author rubenrm1@gmail.com
+ */
+public class InfinispanDataStoreComponent implements IDataStoreComponent {
+
+    private static final String DEFAULT_CACHE_CONTAINER = "java:jboss/infinispan/container/apiman-gateway"; //$NON-NLS-1$
+    private static final String DEFAULT_CACHE = "data-store"; //$NON-NLS-1$
+
+    private String cacheContainer;
+    private String cacheName;
+    
+    private Cache<Object, Object> cache;
+    
+    /**
+     * Constructor.
+     */
+    public InfinispanDataStoreComponent() {
+        cacheContainer = DEFAULT_CACHE_CONTAINER;
+        cacheName = DEFAULT_CACHE;
+    }
+
+    /**
+     * Constructor.
+     * @param config
+     */
+    public InfinispanDataStoreComponent(Map<String, String> config) {
+        cacheContainer = DEFAULT_CACHE_CONTAINER;
+        cacheName = DEFAULT_CACHE;
+        
+        if (config.containsKey("cache-container")) { //$NON-NLS-1$
+            cacheContainer = config.get("cache-container"); //$NON-NLS-1$
+        }
+        if (config.containsKey("cache")) { //$NON-NLS-1$
+            cacheName = config.get("cache"); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.components.IDataStoreComponent#hasProperty(java.lang.String, java.lang.String)
+     */
+    @Override
+    public <T> boolean hasProperty(String namespace, String propertyName) {
+        QName qname = new QName(namespace, propertyName);
+        return getCache().containsKey(qname);
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.components.IDataStoreComponent#getProperty(java.lang.String, java.lang.String, java.lang.Object, io.apiman.gateway.engine.async.IAsyncResultHandler)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> void getProperty(String namespace, String propertyName, T defaultValue,
+            IAsyncResultHandler<T> handler) {
+        QName qname = new QName(namespace, propertyName);
+        if (getCache().containsKey(qname)) {
+            try {
+                T rval = (T) getCache().get(qname);
+                handler.handle(AsyncResultImpl.create(rval));
+            } catch (Exception e) {
+                handler.handle(AsyncResultImpl.<T>create(e));
+            }
+            
+        } else {
+            handler.handle(AsyncResultImpl.create(defaultValue));
+        }
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.components.IDataStoreComponent#setProperty(java.lang.String, java.lang.String, java.lang.Object, io.apiman.gateway.engine.async.IAsyncResultHandler)
+     */
+    @Override
+    public <T> void setProperty(String namespace, String propertyName, T value, IAsyncResultHandler<T> handler) {
+        setProperty(namespace, propertyName, value, null, handler);
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.components.IDataStoreComponent#setProperty(java.lang.String, java.lang.String, java.lang.Object, java.lang.Long, io.apiman.gateway.engine.async.IAsyncResultHandler)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> void setProperty(String namespace, String propertyName, T value, Long expiration, IAsyncResultHandler<T> handler) {
+        QName qname = new QName(namespace, propertyName);
+        try {
+            T oldValue = null;
+            if(expiration == null) {
+                oldValue = (T) getCache().put(qname, value);
+            } else {
+                oldValue = (T) getCache().put(qname, value, expiration, TimeUnit.SECONDS);
+            }
+            handler.handle(AsyncResultImpl.create(oldValue));
+        } catch (Exception e) {
+            handler.handle(AsyncResultImpl.<T>create(e));
+        }
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.components.IDataStoreComponent#clearProperty(java.lang.String, java.lang.String, io.apiman.gateway.engine.async.IAsyncResultHandler)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> void clearProperty(String namespace, String propertyName, IAsyncResultHandler<T> handler) {
+        QName qname = new QName(namespace, propertyName);
+        try {
+            T oldValue = (T) getCache().remove(qname);
+            handler.handle(AsyncResultImpl.create(oldValue));
+        } catch (Exception e) {
+            handler.handle(AsyncResultImpl.<T>create(e));
+        }
+    }
+
+    /**
+     * @return gets the registry cache
+     */
+    private Cache<Object, Object> getCache() {
+        if (cache != null) {
+            return cache;
+        }
+        
+        try {
+            InitialContext ic = new InitialContext();
+            CacheContainer container = (CacheContainer) ic.lookup(cacheContainer);
+            cache = container.getCache(cacheName);
+            return cache;
+        } catch (NamingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/CachingPolicy.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/CachingPolicy.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.policies;
+
+import io.apiman.gateway.engine.IServiceConnection;
+import io.apiman.gateway.engine.IServiceConnectionResponse;
+import io.apiman.gateway.engine.IServiceConnector;
+import io.apiman.gateway.engine.async.AsyncResultImpl;
+import io.apiman.gateway.engine.async.IAsyncResult;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.beans.exceptions.ConnectorException;
+import io.apiman.gateway.engine.components.IDataStoreComponent;
+import io.apiman.gateway.engine.impl.CachedResponse;
+import io.apiman.gateway.engine.io.AbstractStream;
+import io.apiman.gateway.engine.io.IApimanBuffer;
+import io.apiman.gateway.engine.io.IReadWriteStream;
+import io.apiman.gateway.engine.policies.config.CachingConfig;
+import io.apiman.gateway.engine.policies.connectors.CachedResponseConnection;
+import io.apiman.gateway.engine.policy.IConnectorInterceptor;
+import io.apiman.gateway.engine.policy.IDataPolicy;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Policy that enables caching for back-end services responses.
+ *
+ * @author rubenrm1@gmail.com
+ */
+public class CachingPolicy extends AbstractMappedPolicy<CachingConfig> implements IDataPolicy {
+    
+    public static final String CACHED_RESPONSE = "apiman.policy.CachedResponse";
+    private static final String KEY_SEPARATOR = ":";
+    private static final String NAMESPACE = "urn:" + CachingPolicy.class.getName();
+    
+    /**
+     * Constructor.
+     */
+    public CachingPolicy() {
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.AbstractPolicy#getConfigurationClass()
+     */
+    @Override
+    protected Class<CachingConfig> getConfigurationClass() {
+        return CachingConfig.class;
+    }
+    
+    /**
+     * If the request is cached an {@link IConnectorInterceptor} is set in order to prevent the back-end connection to be established.
+     * Otherwise an empty {@link CachedResponse} will be added to the context, this will be used to cache the response once it has been
+     * received from the back-end service
+     * 
+     * @see io.apiman.gateway.engine.policies.AbstractMappedPolicy#doApply(io.apiman.gateway.engine.beans.ServiceRequest, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    protected void doApply(final ServiceRequest request, final IPolicyContext context, final CachingConfig config,
+            final IPolicyChain<ServiceRequest> chain) {
+        configuration = config;
+        IDataStoreComponent dataStore = context.getComponent(IDataStoreComponent.class);
+        String requestID = buildRequestID(request);
+        if(dataStore.hasProperty(NAMESPACE, requestID)) {
+            context.setConnectorInterceptor(getCachedResponseInterceptor(context));
+            dataStore.getProperty(NAMESPACE, requestID, null, new IAsyncResultHandler<CachedResponse>() {
+                @Override
+                public void handle(IAsyncResult<CachedResponse> result) {
+                    context.setAttribute(CACHED_RESPONSE, result.getResult());
+                    chain.doApply(request);
+                }
+            });
+            
+        } else {
+            context.setAttribute(CACHED_RESPONSE, new CachedResponse(requestID));
+            chain.doApply(request);
+        }
+    }
+    
+    /**
+     * @see AbstractMappedPolicy#doApply(ServiceResponse, IPolicyContext, Object, IPolicyChain)
+     */
+    @Override
+    protected void doApply(ServiceResponse response, IPolicyContext context, CachingConfig config,
+            IPolicyChain<ServiceResponse> chain) {
+        chain.doApply(response);
+    }
+    
+    /**
+     * Builds a cached request id composed by the API key followed by the HTTP
+     * verb and the destination. In the case where there's no API key the ID
+     * will contain ServiceOrgId + ServiceId + Service Version
+     */
+    private String buildRequestID(ServiceRequest request) {
+        StringBuilder req = new StringBuilder();
+        if (StringUtils.isNotBlank(request.getApiKey())) {
+            req.append(request.getApiKey());
+        } else {
+            req.append(request.getServiceOrgId()).append(KEY_SEPARATOR)
+                .append(request.getServiceId()).append(KEY_SEPARATOR)
+                .append(request.getServiceVersion());
+        }
+        req.append(KEY_SEPARATOR)
+            .append(request.getType()).append(KEY_SEPARATOR)
+            .append(request.getDestination());
+        return req.toString();
+    }
+    
+    /**
+     * The request will not be altered.
+     * 
+     * @see IDataPolicy#getRequestDataHandler(ServiceRequest, IPolicyContext)
+     */
+    @Override
+    public IReadWriteStream<ServiceRequest> getRequestDataHandler(final ServiceRequest request,
+            IPolicyContext context) {
+        return null;
+    }
+    
+    /**
+     * The response is received from the back-end service and needs to be written into the {@link CachedResponse}.
+     * The headers, response code and message should be written at this point and once the {@link CachedResponse}
+     * is set, can be stored into the {@link IDataStoreComponent}
+     * 
+     * @see IDataPolicy#getResponseDataHandler(ServiceResponse, IPolicyContext)
+     */
+    @Override
+    public IReadWriteStream<ServiceResponse> getResponseDataHandler(final ServiceResponse response,
+            final IPolicyContext context) {
+        return new AbstractStream<ServiceResponse>() {
+            
+            private CachedResponse cachedResponse = context.getAttribute(CACHED_RESPONSE, null);
+            
+            @Override
+            public ServiceResponse getHead() {
+                return response;
+            }
+
+            @Override
+            protected void handleHead(ServiceResponse head) {
+            }
+            
+            @Override
+            public void write(IApimanBuffer chunk) {
+                super.write(chunk);
+                if(context.getConnectorInterceptor() == null && isSuccess()) {
+                    cachedResponse.write(chunk);
+                }
+            }
+            
+            @Override
+            public void end() {
+                super.end();
+                if(context.getConnectorInterceptor() == null) {
+                    if(isSuccess() && !cachedResponse.isWriteFailed()) {
+                        cachedResponse.endWrite();
+                        cachedResponse.setCode(response.getCode());
+                        cachedResponse.setMessage(response.getMessage());
+                        cachedResponse.setHeaders(response.getHeaders());
+                        IDataStoreComponent dataStore = context.getComponent(IDataStoreComponent.class);
+                        dataStore.setProperty(NAMESPACE, cachedResponse.getId(), cachedResponse, configuration.getTtl(), new IAsyncResultHandler<CachedResponse>() {
+                
+                            @Override
+                            public void handle(IAsyncResult<CachedResponse> result) {
+                                // Nothing to do with the old value
+                            }
+                        });
+                    }
+                }
+            }
+            
+            private boolean isSuccess() {
+                return response.getCode() >= 200 && response.getCode() < 300;
+            }
+        };
+    }
+    
+    private IConnectorInterceptor getCachedResponseInterceptor(final IPolicyContext context) {
+        
+        return new IConnectorInterceptor() {
+            
+            @Override
+            public IServiceConnector createConnector() {
+                return new IServiceConnector() {
+                    
+                    @Override
+                    public IServiceConnection connect(ServiceRequest request,
+                            IAsyncResultHandler<IServiceConnectionResponse> handler) throws ConnectorException {
+                        final CachedResponseConnection cachedConnectionResponse = new CachedResponseConnection(context);
+                        handler.handle(AsyncResultImpl.<IServiceConnectionResponse>create(cachedConnectionResponse));
+                        return cachedConnectionResponse;
+                    }
+                    
+                };
+            }
+
+        };
+    }
+
+}

--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/config/CachingConfig.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/config/CachingConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.policies.config;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+
+/**
+ * Configuration object for the Caching policy.
+ *
+ * @author rubenrm1@gmail.com
+ */
+@Portable
+public class CachingConfig {
+    
+    private long ttl;
+    
+    /**
+     * Constructor.
+     */
+    public CachingConfig() {
+    }
+
+    /**
+     * @return the ttl
+     */
+    public long getTtl() {
+        return ttl;
+    }
+    
+    /**
+     * @param ttl the ttl to set
+     */
+    public void setTtl(long ttl) {
+        this.ttl = ttl;
+    }
+
+}

--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/connectors/CachedResponseConnection.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/connectors/CachedResponseConnection.java
@@ -1,0 +1,116 @@
+package io.apiman.gateway.engine.policies.connectors;
+
+import io.apiman.gateway.engine.IServiceConnection;
+import io.apiman.gateway.engine.IServiceConnectionResponse;
+import io.apiman.gateway.engine.async.IAsyncHandler;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.components.IDataStoreComponent;
+import io.apiman.gateway.engine.impl.CachedResponse;
+import io.apiman.gateway.engine.io.ByteBuffer;
+import io.apiman.gateway.engine.io.IApimanBuffer;
+import io.apiman.gateway.engine.policies.CachingPolicy;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+
+import java.io.InputStream;
+
+import org.apache.commons.io.IOUtils;
+
+/**
+ * This {@link IServiceConnection} implementation aims to simulate a back-end
+ * connection but what will do is to retrieve an existing
+ * {@link CachedResponse} from the {@link IDataStoreComponent} and generate
+ * the {@link IServiceConnectionResponse}
+ * 
+ * @author rubenrm1@gmail.com
+ *
+ */
+public class CachedResponseConnection implements IServiceConnection, IServiceConnectionResponse {
+    
+    private CachedResponse cachedResponse;
+    private IAsyncHandler<IApimanBuffer> bodyHandler;
+    private IAsyncHandler<Void> endHandler;
+    private boolean connected;
+    private ServiceResponse response;
+    
+    public CachedResponseConnection(IPolicyContext context) {
+        connected = true;
+        cachedResponse = context.getAttribute(CachingPolicy.CACHED_RESPONSE, null);
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.io.IReadStream#getHead()
+     */
+    @Override
+    public ServiceResponse getHead() {
+        response = new ServiceResponse();
+        response.setHeaders(cachedResponse.getHeaders());
+        response.setCode(cachedResponse.getCode());
+        response.setMessage(cachedResponse.getMessage());
+
+        return response;
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.io.IReadStream#bodyHandler(io.apiman.gateway.engine.async.IAsyncHandler)
+     */
+    @Override
+    public void bodyHandler(IAsyncHandler<IApimanBuffer> bodyHandler) {
+        this.bodyHandler = bodyHandler;
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.io.IReadStream#endHandler(io.apiman.gateway.engine.async.IAsyncHandler)
+     */
+    @Override
+    public void endHandler(IAsyncHandler<Void> endHandler) {
+        this.endHandler = endHandler;
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.io.IStream#isFinished()
+     */
+    @Override
+    public boolean isFinished() {
+        return !connected;
+    }
+    
+    /**
+     * @see io.apiman.gateway.engine.io.IAbortable#abort()
+     */
+    @Override
+    public void abort() {
+        connected = false;
+    }
+   
+    public void transmit() {
+        try {
+            InputStream is = cachedResponse.getInputStream();
+            ByteBuffer buffer = new ByteBuffer(2048);
+            int numBytes = buffer.readFrom(is);
+            while (numBytes != -1) {
+                bodyHandler.handle(buffer);
+                numBytes = buffer.readFrom(is);
+            }
+            IOUtils.closeQuietly(is);
+            connected = false;
+            endHandler.handle(null);
+        } catch (Throwable e) {
+            // At this point we're sort of screwed, because we've already sent the response to
+            // the originating client - and we're in the process of sending the body data.  So
+            // I guess the only thing to do is abort() the connection and cross our fingers.
+            if (connected) {
+                abort();
+            }
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void write(IApimanBuffer chunk) {
+    }
+
+    @Override
+    public void end() {
+    }
+    
+}

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/GatewayServlet.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/GatewayServlet.java
@@ -25,10 +25,10 @@ import io.apiman.gateway.engine.beans.PolicyFailure;
 import io.apiman.gateway.engine.beans.PolicyFailureType;
 import io.apiman.gateway.engine.beans.ServiceRequest;
 import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.io.ByteBuffer;
 import io.apiman.gateway.engine.io.IApimanBuffer;
 import io.apiman.gateway.engine.io.ISignalWriteStream;
 import io.apiman.gateway.platforms.servlet.i18n.Messages;
-import io.apiman.gateway.platforms.servlet.io.ByteBuffer;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpServiceConnection.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpServiceConnection.java
@@ -24,9 +24,9 @@ import io.apiman.gateway.engine.beans.Service;
 import io.apiman.gateway.engine.beans.ServiceRequest;
 import io.apiman.gateway.engine.beans.ServiceResponse;
 import io.apiman.gateway.engine.beans.exceptions.ConnectorException;
+import io.apiman.gateway.engine.io.ByteBuffer;
 import io.apiman.gateway.engine.io.IApimanBuffer;
 import io.apiman.gateway.platforms.servlet.GatewayThreadContext;
-import io.apiman.gateway.platforms.servlet.io.ByteBuffer;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/gateway/platforms/vertx/README.md
+++ b/gateway/platforms/vertx/README.md
@@ -21,6 +21,9 @@ The following is the standard configuration that should be [provided to the modu
 	
 	    "ISharedStateComponent": { "class": "io.apiman.gateway.engine.impl.InMemorySharedStateComponent", 
 	    	"config": {} },
+	
+	    "IDataStoreComponent": { "class": "io.apiman.gateway.engine.impl.InMemoryDataStoreComponent", 
+	    	"config": {} },
 	    	
 	    "IRateLimiterComponent": { "class": "io.apiman.gateway.engine.impl.InMemoryRateLimiterComponent", 
 	    	"config": {} },

--- a/gateway/platforms/vertx/src/main/resources/config.json
+++ b/gateway/platforms/vertx/src/main/resources/config.json
@@ -11,6 +11,7 @@
     "IHttpClientComponent": { "class": "io.apiman.gateway.vertx.components.HttpClientComponentImpl", "config": {} },
 
     "ISharedStateComponent": { "class": "io.apiman.gateway.engine.impl.InMemorySharedStateComponent", "config": {} },
+    "IDataStoreComponent": { "class": "io.apiman.gateway.engine.impl.InMemoryDataStoreComponent", "config": {} },
     "IRateLimiterComponent": { "class": "io.apiman.gateway.engine.impl.InMemoryRateLimiterComponent", "config": {} },
     "IPolicyFailureFactoryComponent": { "class": "io.apiman.gateway.vertx.components.PolicyFailureFactoryComponent", "config": {} }
   },

--- a/gateway/platforms/vertx/src/test/resources/testConfig.json
+++ b/gateway/platforms/vertx/src/test/resources/testConfig.json
@@ -15,6 +15,7 @@
     "IHttpClientComponent": { "class": "io.apiman.gateway.vertx.components.HttpClientComponentImpl", "config": {} },
 
     "ISharedStateComponent": { "class": "io.apiman.gateway.engine.impl.InMemorySharedStateComponent", "config": {} },
+    "IDataStoreComponent": { "class": "io.apiman.gateway.engine.impl.InMemoryDataStoreComponent", "config": {} },
     "IRateLimiterComponent": { "class": "io.apiman.gateway.engine.impl.InMemoryRateLimiterComponent", "config": {} },
     "IPolicyFailureFactoryComponent": { "class": "io.apiman.gateway.vertx.components.PolicyFailureFactoryComponent", "config": {} }
   },

--- a/gateway/test/src/test/java/io/apiman/gateway/test/AbstractGatewayTest.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/AbstractGatewayTest.java
@@ -15,11 +15,13 @@
  */
 package io.apiman.gateway.test;
 
+import io.apiman.gateway.engine.components.IDataStoreComponent;
 import io.apiman.gateway.engine.components.IHttpClientComponent;
 import io.apiman.gateway.engine.components.IPolicyFailureFactoryComponent;
 import io.apiman.gateway.engine.components.IRateLimiterComponent;
 import io.apiman.gateway.engine.components.ISharedStateComponent;
 import io.apiman.gateway.engine.impl.DefaultPluginRegistry;
+import io.apiman.gateway.engine.impl.InMemoryDataStoreComponent;
 import io.apiman.gateway.engine.impl.InMemoryRateLimiterComponent;
 import io.apiman.gateway.engine.impl.InMemoryRegistry;
 import io.apiman.gateway.engine.impl.InMemorySharedStateComponent;
@@ -76,6 +78,8 @@ public class AbstractGatewayTest {
         // Register test components
         System.setProperty(WarEngineConfig.APIMAN_GATEWAY_COMPONENT_PREFIX + ISharedStateComponent.class.getSimpleName(), 
                 InMemorySharedStateComponent.class.getName());
+        System.setProperty(WarEngineConfig.APIMAN_GATEWAY_COMPONENT_PREFIX + IDataStoreComponent.class.getSimpleName(), 
+                InMemoryDataStoreComponent.class.getName());
         System.setProperty(WarEngineConfig.APIMAN_GATEWAY_COMPONENT_PREFIX + IRateLimiterComponent.class.getSimpleName(), 
                 InMemoryRateLimiterComponent.class.getName());
         System.setProperty(WarEngineConfig.APIMAN_GATEWAY_COMPONENT_PREFIX + IPolicyFailureFactoryComponent.class.getSimpleName(), 

--- a/gateway/test/src/test/java/io/apiman/gateway/test/Policy_CachingPolicyTest.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/Policy_CachingPolicyTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.test;
+
+import org.junit.Test;
+
+/**
+ * Make sure the caching policy works.
+ *
+ * @author rubenrm1@gmail.com
+ */
+public class Policy_CachingPolicyTest extends AbstractGatewayTest {
+    
+    @Test
+    public void test() throws Exception {
+        runTestPlan("test-plans/simple/simple-caching-policy-testPlan.xml"); //$NON-NLS-1$
+    }
+
+}

--- a/gateway/test/src/test/java/io/apiman/gateway/test/policies/SimpleDataPolicy.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/policies/SimpleDataPolicy.java
@@ -18,13 +18,13 @@ package io.apiman.gateway.test.policies;
 import io.apiman.gateway.engine.beans.ServiceRequest;
 import io.apiman.gateway.engine.beans.ServiceResponse;
 import io.apiman.gateway.engine.io.AbstractStream;
+import io.apiman.gateway.engine.io.ByteBuffer;
 import io.apiman.gateway.engine.io.IApimanBuffer;
 import io.apiman.gateway.engine.io.IReadWriteStream;
 import io.apiman.gateway.engine.policy.IDataPolicy;
 import io.apiman.gateway.engine.policy.IPolicy;
 import io.apiman.gateway.engine.policy.IPolicyChain;
 import io.apiman.gateway.engine.policy.IPolicyContext;
-import io.apiman.gateway.platforms.servlet.io.ByteBuffer;
 
 import java.io.UnsupportedEncodingException;
 

--- a/gateway/test/src/test/java/io/apiman/gateway/test/policies/connectors/CannedResponseServiceConnection.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/policies/connectors/CannedResponseServiceConnection.java
@@ -22,9 +22,9 @@ import io.apiman.gateway.engine.async.IAsyncHandler;
 import io.apiman.gateway.engine.async.IAsyncResultHandler;
 import io.apiman.gateway.engine.beans.ServiceResponse;
 import io.apiman.gateway.engine.beans.exceptions.ConnectorException;
+import io.apiman.gateway.engine.io.ByteBuffer;
 import io.apiman.gateway.engine.io.IApimanBuffer;
 import io.apiman.gateway.platforms.servlet.GatewayThreadContext;
-import io.apiman.gateway.platforms.servlet.io.ByteBuffer;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -128,12 +128,9 @@ public class CannedResponseServiceConnection implements IServiceConnection, ISer
     public void transmit() {
         try {
             InputStream is = new ByteArrayInputStream(CANNED_RESPONSE);
-            ByteBuffer buffer = new ByteBuffer(2048);
-            int numBytes = buffer.readFrom(is);
-            while (numBytes != -1) {
-                bodyHandler.handle(buffer);
-                numBytes = buffer.readFrom(is);
-            }
+            ByteBuffer buffer = new ByteBuffer(CANNED_RESPONSE.length);
+            buffer.readFrom(is);
+            bodyHandler.handle(buffer);
             IOUtils.closeQuietly(is);
             connected = false;
             endHandler.handle(null);

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-caching-policy/caching/001-first-request.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-caching-policy/caching/001-first-request.resttest
@@ -1,0 +1,10 @@
+GET /gateway/Policy_CachingPolicyTest/echo/1.0/path/to/app/resource
+
+----
+200
+Content-Type: application/json
+Response-Counter: 1
+
+{
+  "counter" : 1
+}

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-caching-policy/caching/002-first-cached-response.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-caching-policy/caching/002-first-cached-response.resttest
@@ -1,0 +1,10 @@
+GET /gateway/Policy_CachingPolicyTest/echo/1.0/path/to/app/resource
+
+----
+200
+Content-Type: application/json
+Response-Counter: 1
+
+{
+  "counter" : 1
+}

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-caching-policy/caching/003-error-code.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-caching-policy/caching/003-error-code.resttest
@@ -1,0 +1,4 @@
+GET /gateway/Policy_CachingPolicyTest/echo/1.0.0/path/to/error
+
+----
+500

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-caching-policy/caching/004-second-request.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-caching-policy/caching/004-second-request.resttest
@@ -1,0 +1,14 @@
+POST /gateway/Policy_CachingPolicyTest/echo/1.0/path/to/app/resources
+
+{
+  "TEST" : "Hello World"
+}
+
+----
+200
+Content-Type: application/json
+Response-Counter: 2
+
+{
+  "counter" : 2
+}

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-caching-policy/caching/005-second-cached-response.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-caching-policy/caching/005-second-cached-response.resttest
@@ -1,0 +1,14 @@
+POST /gateway/Policy_CachingPolicyTest/echo/1.0/path/to/app/resources
+
+{
+  "TEST" : "Hello World"
+}
+
+----
+200
+Content-Type: application/json
+Response-Counter: 2
+
+{
+  "counter" : 2
+}

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-caching-policy/setup/001-publish-service.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-caching-policy/setup/001-publish-service.resttest
@@ -1,0 +1,19 @@
+PUT /api/services admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "Policy_CachingPolicyTest",
+  "serviceId" : "echo",
+  "version" : "1.0",
+  "publicService" : true,
+  "endpointType" : "REST",
+  "endpoint" : "${apiman-gateway-test.endpoints.echo}/",
+  "servicePolicies" : [
+        {
+          "policyImpl" : "class:io.apiman.gateway.engine.policies.CachingPolicy",
+          "policyJsonConfig" : "{ \"ttl\" : 1 }"
+        }
+      ]
+}
+----
+204

--- a/gateway/test/src/test/resources/test-plans/simple/simple-caching-policy-testPlan.xml
+++ b/gateway/test/src/test/resources/test-plans/simple/simple-caching-policy-testPlan.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan">
+
+  <testGroup name="Test Policy">
+    <test name="Publish Service">test-plan-data/simple/simple-caching-policy/setup/001-publish-service.resttest</test>
+    <test name="First Remote Request">test-plan-data/simple/simple-caching-policy/caching/001-first-request.resttest</test>
+    <test name="First Cached Response">test-plan-data/simple/simple-caching-policy/caching/002-first-cached-response.resttest</test>
+    <test name="Error Response">test-plan-data/simple/simple-caching-policy/caching/003-error-code.resttest</test>
+    <test name="Second Remote Request">test-plan-data/simple/simple-caching-policy/caching/004-second-request.resttest</test>
+    <test name="First Cached Response">test-plan-data/simple/simple-caching-policy/caching/002-first-cached-response.resttest</test>
+    <test name="Second Cached Response">test-plan-data/simple/simple-caching-policy/caching/005-second-cached-response.resttest</test>
+  </testGroup>
+
+</testPlan>

--- a/manager/ui/war/src/main/java/io/apiman/manager/ui/client/local/pages/policy/forms/CachingPolicyConfigForm.java
+++ b/manager/ui/war/src/main/java/io/apiman/manager/ui/client/local/pages/policy/forms/CachingPolicyConfigForm.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.manager.ui.client.local.pages.policy.forms;
+
+import io.apiman.gateway.engine.policies.config.CachingConfig;
+import io.apiman.manager.ui.client.local.events.IsFormValidEvent;
+import io.apiman.manager.ui.client.local.pages.policy.IPolicyConfigurationForm;
+import io.apiman.manager.ui.client.local.services.BeanMarshallingService;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+
+import com.google.gwt.event.dom.client.KeyUpEvent;
+import com.google.gwt.event.dom.client.KeyUpHandler;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.TextBox;
+
+/**
+ * A policy configuration form used for the Caching Policy.
+ *
+ * @author rubenrm1@gmail.com
+ */
+@Templated("/io/apiman/manager/ui/client/local/site/policyconfig-caching.html#form")
+@Dependent
+public class CachingPolicyConfigForm extends Composite implements IPolicyConfigurationForm {
+
+    @Inject
+    BeanMarshallingService marshaller;
+    
+    @Inject @DataField
+    TextBox ttl;
+
+    /**
+     * Constructor.
+     */
+    public CachingPolicyConfigForm() {
+    }
+
+    @PostConstruct
+    protected void postConstruct() {
+        KeyUpHandler keyUpValidityHandler = new KeyUpHandler() {
+            @Override
+            public void onKeyUp(KeyUpEvent event) {
+                checkValidity();
+            }
+        };
+        ttl.addKeyUpHandler(keyUpValidityHandler);
+    }
+    
+    /**
+     * @see com.google.gwt.user.client.ui.HasValue#getValue()
+     */
+    @Override
+    public String getValue() {
+        CachingConfig config = new CachingConfig();
+        try { config.setTtl(new Long(ttl.getValue())); } catch (Throwable t) {}
+        return marshaller.marshal(config);
+    }
+
+    /**
+     * @see com.google.gwt.user.client.ui.HasValue#setValue(java.lang.Object)
+     */
+    @Override
+    public void setValue(String value) {
+        setValue(value, false);
+    }
+
+    /**
+     * @see com.google.gwt.user.client.ui.HasValue#setValue(java.lang.Object, boolean)
+     */
+    @Override
+    public void setValue(String value, boolean fireEvents) {
+        ttl.setValue(""); //$NON-NLS-1$
+        checkValidity();
+        if (value != null && !value.trim().isEmpty()) {
+            CachingConfig config = marshaller.unmarshal(value, CachingConfig.class);
+            ttl.setValue(String.valueOf(config.getTtl()));
+        }
+        if (fireEvents) {
+            ValueChangeEvent.fire(this, value);
+        }
+    }
+
+    /**
+     * Determine whether the form is valid (the user has completed filling out the form).
+     */
+    protected void checkValidity() {
+        Boolean validity = Boolean.TRUE;
+        try {
+            validity = Long.parseLong(ttl.getValue()) >= 0;
+        } catch (Exception e) {
+            validity = Boolean.FALSE;
+        }
+        IsFormValidEvent.fire(this, validity);
+    }
+
+    /**
+     * @see com.google.gwt.event.logical.shared.HasValueChangeHandlers#addValueChangeHandler(com.google.gwt.event.logical.shared.ValueChangeHandler)
+     */
+    @Override
+    public HandlerRegistration addValueChangeHandler(ValueChangeHandler<String> handler) {
+        return addHandler(handler, ValueChangeEvent.getType());
+    }
+
+    /**
+     * @see io.apiman.manager.ui.client.local.events.IsFormValidEvent.HasIsFormValidHandlers#addIsFormValidHandler(io.apiman.manager.ui.client.local.events.IsFormValidEvent.Handler)
+     */
+    @Override
+    public HandlerRegistration addIsFormValidHandler(IsFormValidEvent.Handler handler) {
+        return addHandler(handler, IsFormValidEvent.getType());
+    }
+    
+}

--- a/manager/ui/war/src/main/java/io/apiman/manager/ui/client/local/services/PolicyConfigurationFormFactory.java
+++ b/manager/ui/war/src/main/java/io/apiman/manager/ui/client/local/services/PolicyConfigurationFormFactory.java
@@ -20,6 +20,7 @@ import io.apiman.manager.api.beans.summary.PolicyFormType;
 import io.apiman.manager.ui.client.local.pages.policy.DefaultPolicyConfigurationForm;
 import io.apiman.manager.ui.client.local.pages.policy.IPolicyConfigurationForm;
 import io.apiman.manager.ui.client.local.pages.policy.forms.BasicAuthPolicyConfigForm;
+import io.apiman.manager.ui.client.local.pages.policy.forms.CachingPolicyConfigForm;
 import io.apiman.manager.ui.client.local.pages.policy.forms.IPListPolicyConfigForm;
 import io.apiman.manager.ui.client.local.pages.policy.forms.IgnoredResourcesPolicyConfigForm;
 import io.apiman.manager.ui.client.local.pages.policy.forms.JsonSchemaPolicyConfigurationForm;
@@ -54,6 +55,8 @@ public class PolicyConfigurationFormFactory {
     Instance<DefaultPolicyConfigurationForm> defaultFormFactory;
     @Inject
     Instance<IgnoredResourcesPolicyConfigForm> ignoredResourcesFormFactory;
+    @Inject
+    Instance<CachingPolicyConfigForm> cachingPolicyFormFactory;
     
     private Map<PolicyDefinitionSummaryBean, String> policyDefSchemas = new HashMap<PolicyDefinitionSummaryBean, String>();
     
@@ -90,6 +93,8 @@ public class PolicyConfigurationFormFactory {
                 handler.onFormLoaded(rateLimitingFormFactory.get());
             } else if ("IgnoredResourcesPolicy".equals(policyDefId)) { //$NON-NLS-1$
                 handler.onFormLoaded(ignoredResourcesFormFactory.get());
+            } else if ("CachingPolicy".equals(policyDefId)) { //$NON-NLS-1$
+               handler.onFormLoaded(cachingPolicyFormFactory.get());
             } else {
                 handler.onFormLoaded(defaultFormFactory.get());
             }

--- a/manager/ui/war/src/main/java/io/apiman/manager/ui/client/local/site/policyconfig-caching.html
+++ b/manager/ui/war/src/main/java/io/apiman/manager/ui/client/local/site/policyconfig-caching.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
+    <script type="text/javascript" src="site.js"></script>
+  </head>
+
+  <body>
+
+    <!-- Top header/nav bar -->
+    <div id="apiman-header">
+      <div class="main-header container">
+        <div class="row">
+          <div class="col-md-12">
+            <div class="logo"></div>
+            <input class="search no-phone" type="text" placeholder="Quick service search..."></input>
+            <ul class="user-menu pull-right">
+              <li class="dropdown">
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                  <span class="pficon pficon-user"></span>
+                  <span>Bruce Wayne</span>
+                  <b class="caret"></b>
+                </a>
+                <ul class="dropdown-menu">
+                  <li>
+                    <a href="user-orgs.html">Home</a>
+                  </li>
+                  <li class="divider"></li>
+                  <li>
+                    <a data-field="toProfile" href="settings-profile.html" data-i18n-key="profile">Profile</a>
+                  </li>
+                  <li>
+                    <a href="#">Logout</a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div id="form-page" class="container apiman-new-policy apiman-entity-new page">
+      <!-- Policy Type-specific config -->
+      <div class="row">
+        <h3 data-field="policyHeading">Configure Rate Limits</i></h3>
+        <div class="box col-md-9 container">
+        
+          <div class="form policy-config caching" data-field="form">
+            <div>
+              <span data-i18n-key="config-sentence-preamble">I want to cache back-end responses for </span>
+              <input data-field="ttl" class="form-control inline-form-control" style="width: 100px" type="text" placeholder="time-to-live"></input>
+              <span data-i18n-key="seconds">seconds.</span>
+            </div>
+          </div>
+          
+        </div>
+      </div>
+    </div> <!-- /container -->
+  </body>
+</html>

--- a/test/common/src/main/java/io/apiman/test/common/mock/EchoResponse.java
+++ b/test/common/src/main/java/io/apiman/test/common/mock/EchoResponse.java
@@ -84,13 +84,14 @@ public class EchoResponse {
         }
         return response;
     }
-
+    
     private String method;
     private String resource;
     private String uri;
     private Map<String, String> headers = new HashMap<String, String>();
     private Long bodyLength;
     private String bodySha1;
+    private Long counter;
     
     /**
      * Constructor.
@@ -181,4 +182,13 @@ public class EchoResponse {
     public void setBodySha1(String bodySha1) {
         this.bodySha1 = bodySha1;
     }
+    
+    public Long getCounter() {
+        return counter;
+    }
+
+    public void setCounter(Long counter) {
+        this.counter = counter;
+    }
+    
 }

--- a/test/common/src/main/java/io/apiman/test/common/mock/EchoServlet.java
+++ b/test/common/src/main/java/io/apiman/test/common/mock/EchoServlet.java
@@ -38,6 +38,8 @@ public class EchoServlet extends HttpServlet {
         mapper.enable(SerializationConfig.Feature.INDENT_OUTPUT);
     }
     
+    private long servletCounter = 0L;
+    
     /**
      * Constructor.
      */
@@ -90,13 +92,14 @@ public class EchoServlet extends HttpServlet {
      */
     protected void doEchoResponse(HttpServletRequest req, HttpServletResponse resp, boolean withBody) {
         EchoResponse response = EchoResponse.from(req, withBody);
-        
+        response.setCounter(++servletCounter);
         resp.setContentType("application/json"); //$NON-NLS-1$
+        resp.setHeader("Response-Counter", response.getCounter().toString()); //$NON-NLS-1$
         try {
             mapper.writeValue(resp.getOutputStream(), response);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
-    
+
 }

--- a/tools/dev-server/gateway/src/main/java/io/apiman/tools/devsvr/gateway/GatewayDevServer.java
+++ b/tools/dev-server/gateway/src/main/java/io/apiman/tools/devsvr/gateway/GatewayDevServer.java
@@ -16,10 +16,12 @@
 
 package io.apiman.tools.devsvr.gateway;
 
+import io.apiman.gateway.engine.components.IDataStoreComponent;
 import io.apiman.gateway.engine.components.IPolicyFailureFactoryComponent;
 import io.apiman.gateway.engine.components.IRateLimiterComponent;
 import io.apiman.gateway.engine.components.ISharedStateComponent;
 import io.apiman.gateway.engine.impl.DefaultPluginRegistry;
+import io.apiman.gateway.engine.impl.InMemoryDataStoreComponent;
 import io.apiman.gateway.engine.impl.InMemoryRateLimiterComponent;
 import io.apiman.gateway.engine.impl.InMemoryRegistry;
 import io.apiman.gateway.engine.impl.InMemorySharedStateComponent;
@@ -65,6 +67,8 @@ public class GatewayDevServer {
         // Register test components
         System.setProperty(WarEngineConfig.APIMAN_GATEWAY_COMPONENT_PREFIX + ISharedStateComponent.class.getSimpleName(), 
                 InMemorySharedStateComponent.class.getName());
+        System.setProperty(WarEngineConfig.APIMAN_GATEWAY_COMPONENT_PREFIX + IDataStoreComponent.class.getSimpleName(), 
+                InMemoryDataStoreComponent.class.getName());
         System.setProperty(WarEngineConfig.APIMAN_GATEWAY_COMPONENT_PREFIX + IRateLimiterComponent.class.getSimpleName(), 
                 InMemoryRateLimiterComponent.class.getName());
         System.setProperty(WarEngineConfig.APIMAN_GATEWAY_COMPONENT_PREFIX + IPolicyFailureFactoryComponent.class.getSimpleName(), 


### PR DESCRIPTION
Implementation of the Caching Policy.
The EchoServlet now includes a counter in the JSON response object and in a header.

Note: I have tried to test it but apparently I'm missing something in the configuration because the IDataStoreComponent is not found in runtime.

The changes includes a merge with the current master.