### PR TITLE
Idea for transport secure: Concept 1

### DIFF
--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/IEngine.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/IEngine.java
@@ -41,7 +41,8 @@ public interface IEngine {
      * @param handler an async handler called when a response is returned or an
      *            exception is captured.
      */
-    IServiceRequestExecutor executor(ServiceRequest request, IAsyncResultHandler<IEngineResult> resultHandler);
+    IServiceRequestExecutor executor(ServiceRequest request, boolean isTransportSecure,
+            IAsyncResultHandler<IEngineResult> resultHandler);
     
     /**
      * Returns the registry that can be used to publish/retire services and

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/IServiceRequestExecutor.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/IServiceRequestExecutor.java
@@ -3,6 +3,8 @@ package io.apiman.gateway.engine;
 import io.apiman.gateway.engine.async.IAsyncHandler;
 import io.apiman.gateway.engine.impl.ServiceRequestExecutorImpl;
 import io.apiman.gateway.engine.io.ISignalWriteStream;
+import io.apiman.gateway.engine.io.ITransportSecurityStatus;
+import io.apiman.gateway.engine.io.ITransportSecurityStatusSet;
 
 /**
  * IPolicyRequestExecutor interface.
@@ -31,5 +33,4 @@ public interface IServiceRequestExecutor {
      * @param handler
      */
     void streamHandler(IAsyncHandler<ISignalWriteStream> handler);
-
 }

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/EngineImpl.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/EngineImpl.java
@@ -83,11 +83,11 @@ public class EngineImpl implements IEngine {
      * @see io.apiman.gateway.engine.IEngine#request()
      */
     @Override
-    public IServiceRequestExecutor executor(ServiceRequest request, final IAsyncResultHandler<IEngineResult> resultHandler) {
+    public IServiceRequestExecutor executor(ServiceRequest request, boolean isTransportSecure, final IAsyncResultHandler<IEngineResult> resultHandler) {
         return new ServiceRequestExecutorImpl(request, 
                 resultHandler,
                 registry,
-                new PolicyContextImpl(getComponentRegistry()),
+                new PolicyContextImpl(getComponentRegistry(), isTransportSecure),
                 policyFactory,
                 getConnectorFactory(),
                 getMetrics());

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/ServiceRequestExecutorImpl.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/ServiceRequestExecutorImpl.java
@@ -43,8 +43,8 @@ import io.apiman.gateway.engine.metrics.RequestMetric;
 import io.apiman.gateway.engine.policy.Chain;
 import io.apiman.gateway.engine.policy.IConnectorInterceptor;
 import io.apiman.gateway.engine.policy.IPolicy;
-import io.apiman.gateway.engine.policy.IPolicyContext;
 import io.apiman.gateway.engine.policy.IPolicyFactory;
+import io.apiman.gateway.engine.policy.ISettablePolicyContext;
 import io.apiman.gateway.engine.policy.PolicyWithConfiguration;
 import io.apiman.gateway.engine.policy.RequestChain;
 import io.apiman.gateway.engine.policy.ResponseChain;
@@ -77,7 +77,7 @@ public class ServiceRequestExecutorImpl implements IServiceRequestExecutor {
     private IRegistry registry;
     private ServiceRequest request;
     private Service service;
-    private IPolicyContext context;
+    private ISettablePolicyContext context;
     private List<Policy> policies;
     private IPolicyFactory policyFactory;
     private IConnectorFactory connectorFactory;
@@ -111,7 +111,7 @@ public class ServiceRequestExecutorImpl implements IServiceRequestExecutor {
      * @param metrics 
      */
     public ServiceRequestExecutorImpl(ServiceRequest serviceRequest,
-            IAsyncResultHandler<IEngineResult> resultHandler, IRegistry registry, IPolicyContext context,
+            IAsyncResultHandler<IEngineResult> resultHandler, IRegistry registry, ISettablePolicyContext context,
             IPolicyFactory policyFactory, IConnectorFactory connectorFactory, IMetrics metrics) {
         this.request = serviceRequest;
         this.registry = registry;

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/io/ITransportSecurityStatus.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/io/ITransportSecurityStatus.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.io;
+
+/**
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public interface ITransportSecurityStatus {
+    
+    /**
+     * Indicates whether the transport layer is secure (e.g. TLS, SSL).
+     * 
+     * @return true if transport layer is secure; else false.
+     */
+    boolean isTransportSecure();
+}

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/io/ITransportSecurityStatusSet.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/io/ITransportSecurityStatusSet.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.io;
+
+/**
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public interface ITransportSecurityStatusSet {
+    /**
+     * Set whether the transport layer is secure. Default is false.
+     * 
+     * @param isSecure true if transport layer is secure, else false.
+     */
+    void setTransportSecure(boolean isSecure);
+}

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/policy/IPolicyContext.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/policy/IPolicyContext.java
@@ -18,14 +18,14 @@ package io.apiman.gateway.engine.policy;
 import io.apiman.gateway.engine.IComponent;
 import io.apiman.gateway.engine.beans.exceptions.ComponentNotFoundException;
 import io.apiman.gateway.engine.beans.exceptions.InterceptorAlreadyRegisteredException;
-
+import io.apiman.gateway.engine.io.ITransportSecurityStatus;
 
 /**
  * Context information provided to an executing policy.
  * 
  * @author Marc Savy <msavy@redhat.com>
  */
-public interface IPolicyContext {
+public interface IPolicyContext extends ITransportSecurityStatus {
 
     /**
      * Sets a conversation-scoped attribute, allowing policies to pass interesting

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/policy/ISettablePolicyContext.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/policy/ISettablePolicyContext.java
@@ -1,0 +1,7 @@
+package io.apiman.gateway.engine.policy;
+
+import io.apiman.gateway.engine.io.ITransportSecurityStatusSet;
+
+public interface ISettablePolicyContext extends IPolicyContext, ITransportSecurityStatusSet {
+
+}

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/policy/PolicyContextImpl.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/policy/PolicyContextImpl.java
@@ -29,18 +29,20 @@ import java.util.Map;
  *
  * @author eric.wittmann@redhat.com
  */
-public class PolicyContextImpl implements IPolicyContext {
+public class PolicyContextImpl implements ISettablePolicyContext {
     
     private final IComponentRegistry componentRegistry;
     private final Map<String, Object> conversation = new HashMap<String, Object>();
     private IConnectorInterceptor connectorInterceptor;
+    private boolean transportSecurity = false;
     
     /**
      * Constructor.
      * @param componentRegistry
      */
-    public PolicyContextImpl(IComponentRegistry componentRegistry) {
+    public PolicyContextImpl(IComponentRegistry componentRegistry, boolean transportSecurity) {
         this.componentRegistry = componentRegistry;
+        this.transportSecurity = transportSecurity;
     }
 
     /**
@@ -100,4 +102,19 @@ public class PolicyContextImpl implements IPolicyContext {
         return connectorInterceptor;
     }
 
+    /**
+     * @see io.apiman.gateway.engine.io.ITransportSecurityStatus#isTransportSecure()
+     */
+    @Override
+    public boolean isTransportSecure() {
+        return transportSecurity;
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.io.ITransportSecurityStatusSet#setTransportSecure(boolean)
+     */
+    @Override
+    public void setTransportSecure(boolean isSecure) {
+       this.transportSecurity = isSecure;
+    }
 }

--- a/gateway/engine/core/src/test/java/io/apiman/gateway/engine/impl/DefaultEngineFactoryTest.java
+++ b/gateway/engine/core/src/test/java/io/apiman/gateway/engine/impl/DefaultEngineFactoryTest.java
@@ -207,7 +207,8 @@ public class DefaultEngineFactoryTest {
         request.setDestination("/");
         request.setType("TEST");
                         
-        IServiceRequestExecutor prExecutor = engine.executor(request, new IAsyncResultHandler<IEngineResult>() {
+        IServiceRequestExecutor prExecutor = engine.executor(request, false, 
+                new IAsyncResultHandler<IEngineResult>() {
             
             @Override //At this point, we are either saying *fail* or *response connection is ready*
             public void handle(IAsyncResult<IEngineResult> result) {

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/GatewayServlet.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/GatewayServlet.java
@@ -155,7 +155,8 @@ public abstract class GatewayServlet extends HttpServlet {
         final CountDownLatch latch = new CountDownLatch(1);
         
         // Now execute the request via the apiman engine
-        IServiceRequestExecutor executor = getEngine().executor(srequest, new IAsyncResultHandler<IEngineResult>() {
+        IServiceRequestExecutor executor = getEngine().executor(srequest,
+                new IAsyncResultHandler<IEngineResult>() {
             @Override
             public void handle(IAsyncResult<IEngineResult> asyncResult) {
                 if (asyncResult.isSuccess()) {


### PR DESCRIPTION
I've spent a long while today working through a few different implementations of how to represent transport security in apiman. Although the implementations are simple, there are a wide range of security implications we need to consider.

Concept 1 advantages:
- You must explicitly set the transport security on the request, so you can't forget to set it.
- It is impossible for policies to accidentally turn off transport security as the interfaces don't expose the set method to policies (as opposed to concept 2 where someone can screw it up). They just access it through the context.

Disadvantages:
- Messier implementation, adds a few interfaces and code in a bunch of places.
- Logically, it's a bit unclear which bit of the system the "is secure" refers to (just request, response, the proxied request, response, etc)...