### PR TITLE
Idea for transport secure: Concept 2

### DIFF
--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/IServiceObjectBean.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/IServiceObjectBean.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.beans;
+
+import java.util.Map;
+
+/**
+ * Represents common elements of {@link ServiceRequest} and {@link ServiceResponse}.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public interface IServiceObjectBean {
+
+    /**
+     * @return the headers
+     */
+    Map<String, String> getHeaders();
+
+    /**
+     * @param headers the headers to set
+     */
+    void setHeaders(Map<String, String> headers);
+}

--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/ServiceRequest.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/ServiceRequest.java
@@ -24,7 +24,7 @@ import java.util.Map;
  *
  * @author eric.wittmann@redhat.com
  */
-public class ServiceRequest implements Serializable {
+public class ServiceRequest implements IServiceObjectBean, Serializable {
     
     private static final long serialVersionUID = 8024669261165845962L;
 
@@ -36,6 +36,7 @@ public class ServiceRequest implements Serializable {
     private Map<String, String> headers = new HeaderHashMap();
     private String remoteAddr;
     private Object rawRequest;
+    private boolean transportSecurity = false;
     
     /*
      * Optional fields - set these if you want the APIMan engine to
@@ -94,14 +95,14 @@ public class ServiceRequest implements Serializable {
     }
 
     /**
-     * @return the headers
+     * @see io.apiman.gateway.engine.beans.IServiceObjectBean#getHeaders()
      */
     public Map<String, String> getHeaders() {
         return headers;
     }
 
     /**
-     * @param headers the headers to set
+     * @see io.apiman.gateway.engine.beans.IServiceObjectBean#setHeaders(java.util.Map)
      */
     public void setHeaders(Map<String, String> headers) {
         this.headers = headers;
@@ -203,5 +204,23 @@ public class ServiceRequest implements Serializable {
      */
     public void setQueryParams(Map<String, String> queryParams) {
         this.queryParams = queryParams;
+    }
+
+    /**
+     * Indicates whether service request or response was made with transport security.
+     *
+     * @return true if transport is secure; else false.
+     */
+    public boolean isTransportSecure() {
+        return transportSecurity;
+    }
+
+    /**
+     * Set whether service request/response was made with transport security.
+     * 
+     * @param bool transport security status
+     */
+    public void setTransportSecure(boolean isSecure) {
+        this.transportSecurity = isSecure;
     }
 }

--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/ServiceResponse.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/ServiceResponse.java
@@ -25,14 +25,14 @@ import java.util.Map;
  *
  * @author eric.wittmann@redhat.com
  */
-public class ServiceResponse implements Serializable {
+public class ServiceResponse implements IServiceObjectBean, Serializable {
 
     private static final long serialVersionUID = -7245095046846226241L;
     
     private int code;
     private String message;
     private Map<String, String> headers = new HeaderHashMap();
-    private Map<String, Object> attributes = new HashMap<String, Object>();
+    private Map<String, Object> attributes = new HashMap<>();
 
     /**
      * Constructor.
@@ -41,15 +41,17 @@ public class ServiceResponse implements Serializable {
     }
 
     /**
-     * @return the headers
+     * @see io.apiman.gateway.engine.beans.IServiceObjectBean#getHeaders()
      */
+    @Override
     public Map<String, String> getHeaders() {
         return headers;
     }
 
     /**
-     * @param headers the headers to set
+     * @see io.apiman.gateway.engine.beans.IServiceObjectBean#setHeaders(java.util.Map)
      */
+    @Override
     public void setHeaders(Map<String, String> headers) {
         this.headers = headers;
     }
@@ -111,5 +113,4 @@ public class ServiceResponse implements Serializable {
     public Object getAttribute(String name) {
         return this.attributes.get(name);
     }
-
 }

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/GatewayServlet.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/GatewayServlet.java
@@ -267,6 +267,7 @@ public abstract class GatewayServlet extends HttpServlet {
         readHeaders(srequest, request);
         srequest.setRawRequest(request);
         srequest.setRemoteAddr(request.getRemoteAddr());
+        srequest.setTransportSecure(request.isSecure());
         return srequest;
     }
 

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/GatewayThreadContext.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/GatewayThreadContext.java
@@ -26,11 +26,11 @@ import io.apiman.gateway.engine.beans.ServiceResponse;
  * @author eric.wittmann@redhat.com
  */
 public class GatewayThreadContext {
-    
+
     private static final ThreadLocal<ServiceRequest> serviceRequest = new ThreadLocal<ServiceRequest>();
     private static final ThreadLocal<ServiceResponse> serviceResponse = new ThreadLocal<ServiceResponse>();
     private static final ThreadLocal<PolicyFailure> policyFailure = new ThreadLocal<PolicyFailure>();
-    
+
     /**
      * @return the thread-local service request
      */
@@ -66,7 +66,7 @@ public class GatewayThreadContext {
         }
         return request;
     }
-    
+
     /**
      * Resets all thread local objects.
      */
@@ -78,13 +78,14 @@ public class GatewayThreadContext {
         request.setRawRequest(null);
         request.setRemoteAddr(null);
         request.setType(null);
-        
+        request.setTransportSecure(false);
+
         ServiceResponse response = getServiceResponse();
         response.setCode(0);
         response.getHeaders().clear();
         response.setMessage(null);
         response.getAttributes().clear();
-        
+
         PolicyFailure failure = getPolicyFailure();
         failure.setFailureCode(0);
         failure.setMessage(null);

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/http/HttpGatewayStreamer.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/http/HttpGatewayStreamer.java
@@ -89,7 +89,7 @@ public class HttpGatewayStreamer implements Registrant, Handler<HttpServerReques
 
         handleResponse(request.response());
 
-        ServiceRequest serviceRequest = HttpServiceFactory.build(request, stripString);
+        ServiceRequest serviceRequest = HttpServiceFactory.build(request, stripString, false);
 
         // Received a request, handler called when #ready has been indicated.
         requestExecutor.execute(serviceRequest, new Handler<ISimpleWriteStream>() {

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/http/HttpServiceFactory.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/http/HttpServiceFactory.java
@@ -44,20 +44,14 @@ public class HttpServiceFactory {
         
         return apimanResponse;
     }
-    
-    public static ServiceResponse buildResponse(HttpServerResponse response) {
-        return buildResponse(response, new ServiceResponse());
-    }
-    
-    public static ServiceResponse buildResponse(HttpServerResponse response, ServiceResponse amanResponse) {
+
+    public static void buildResponse(HttpServerResponse response, ServiceResponse amanResponse) {
         response.headers().add(amanResponse.getHeaders());
         response.setStatusCode(amanResponse.getCode());
         response.setStatusMessage(amanResponse.getMessage());
-        
-        return amanResponse;
     }
     
-    public static ServiceRequest build(HttpServerRequest req, String stripFromStart) {
+    public static ServiceRequest build(HttpServerRequest req, String stripFromStart, boolean isTransportSecure) {
         ServiceRequest apimanRequest = new ServiceRequest();
         apimanRequest.setApiKey(parseApiKey(req));
         parseHeaders(apimanRequest.getHeaders(), req.headers(), Collections.<String>emptySet());
@@ -66,6 +60,7 @@ public class HttpServiceFactory {
         apimanRequest.setDestination(StringUtils.removeStart(req.path(), "/" + stripFromStart)); //$NON-NLS-1$
         apimanRequest.setRemoteAddr(req.remoteAddress().getAddress().getHostAddress());
         apimanRequest.setType(req.method());
+        apimanRequest.setTransportSecure(isTransportSecure);
 
         return apimanRequest;
     }


### PR DESCRIPTION
I've spent a long while today working through a few different implementations of how to represent transport security in apiman. Although the implementations are simple, there are a wide range of security implications we need to consider.

This is my preferred idea vs concept 1, and turns out to be simpler, I think, but has a few downsides which are worth considering. We will also need to extend this in some way to try and make sure that side-channels (like policies making requests) and connectors (i.e. backend connections) obey the same rules (or at least dire warnings that isn't really secure otherwise).

Essentially we simply encapsulate this logic into the request. 

Advantages:
 - Encapsulates this into the request, keeps the implementation very simple
 - This object is forwarded onto various areas of the system, and they can use it to determine that they should also utilise secure connections
 - In the future we could consider methods of enforcing this security on the basis of the TLS status (e.g. add a connectSecure method for connectors and call that if request had transport security).

Disadvantages:
 - Initially I had 'isTransportSecure' on the response, too. I deleted that because most stateful protocols don't include that information on the response (only on the request, obviously). The downside is that if we implement a stateless protocol that still has security but treats request and response separately then we'll probably need to add that back in.

- Something could accidentally unset the isTransportSecure status, which would break security for anything that relies upon it.