### PR TITLE
IBufferFactoryComponent Interface and implementations

### DIFF
--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/components/IBufferFactoryComponent.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/components/IBufferFactoryComponent.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.components;
+
+import io.apiman.gateway.engine.io.IApimanBuffer;
+import io.apiman.gateway.engine.policy.IPolicy;
+
+/**
+ * Allows platform-specific buffer objects to be generated. There may be occasions where a {@link IPolicy} may
+ * legitimately wish to construct a new buffer (e.g. caching), and therefore needs a mechanism to efficiently
+ * get a new {@link IApimanBuffer} buffer with a native implementation.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public interface IBufferFactoryComponent {
+
+    /**
+     * Instantiate an {@link IApimanBuffer}.
+     * 
+     * @return A new empty buffer
+     */
+    IApimanBuffer createBuffer();
+
+    /**
+     * Instantiate an {@link IApimanBuffer} with {@link String}.
+     * 
+     * @param stringData string to instantiate buffer
+     * @return A buffer instantiated with stringData
+     */
+    IApimanBuffer createBuffer(String stringData);
+
+    /**
+     * Instantiate an {@link IApimanBuffer} with {@link String}.
+     * 
+     * @param stringData string to instantiate buffer
+     * @param enc encoding of string
+     * @return A buffer instantiated with stringData
+     */
+    IApimanBuffer createBuffer(String stringData, String enc);
+
+    /**
+     * Instantiate an {@link IApimanBuffer} with {@link Byte} array.
+     * 
+     * @param byteData byte array data to instantiate buffer
+     * @return Buffer instantiated with byteData
+     */
+    IApimanBuffer createBuffer(byte[] byteData);
+}

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/components/BufferFactoryComponentImpl.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/components/BufferFactoryComponentImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.platforms.servlet.components;
+
+import java.io.UnsupportedEncodingException;
+
+import io.apiman.gateway.engine.components.IBufferFactoryComponent;
+import io.apiman.gateway.engine.io.IApimanBuffer;
+import io.apiman.gateway.platforms.servlet.io.ByteBuffer;
+
+/**
+ * Implementation of {@link IBufferFactoryComponent} for servlets.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class BufferFactoryComponentImpl implements IBufferFactoryComponent {
+
+    /**
+     * @see io.apiman.gateway.engine.components.IBufferFactoryComponent#createBuffer()
+     */
+    @Override
+    public IApimanBuffer createBuffer() {
+        return new ByteBuffer(30);
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.components.IBufferFactoryComponent#createBuffer(java.lang.String)
+     */
+    @Override
+    public IApimanBuffer createBuffer(String stringData) {
+        return new ByteBuffer(stringData);
+    }
+
+    /**
+     * @throws UnsupportedEncodingException
+     * @see io.apiman.gateway.engine.components.IBufferFactoryComponent#createBuffer(java.lang.String,
+     *      java.lang.String)
+     */
+    @Override
+    public IApimanBuffer createBuffer(String stringData, String enc) {
+        return new ByteBuffer(stringData, enc);
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.components.IBufferFactoryComponent#createBuffer(byte[])
+     */
+    @Override
+    public IApimanBuffer createBuffer(byte[] byteData) {
+        return new ByteBuffer(byteData);
+    }
+}

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/io/ByteBuffer.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/io/ByteBuffer.java
@@ -20,6 +20,7 @@ import io.apiman.gateway.engine.io.IApimanBuffer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 
 /**
  * A simple {@link IApimanBuffer} from a byte array.
@@ -34,11 +35,44 @@ public class ByteBuffer implements IApimanBuffer {
     
     /**
      * Constructor.
+     * 
+     * @param size initial size
      */
     public ByteBuffer(int size) {
         buffer = new byte[size];
     }
     
+    /**
+     * Constructor.
+     * 
+     * @param stringData String data
+     */
+    public ByteBuffer(String stringData) {
+        buffer = stringData.getBytes();
+        bytesInBuffer = buffer.length;
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param stringData String data
+     * @param enc String data encoding
+     */
+    public ByteBuffer(String stringData, String enc) {
+        try {
+            buffer = stringData.getBytes(enc);
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * @param byteData
+     */
+    public ByteBuffer(byte[] byteData) {
+        buffer = Arrays.copyOf(byteData, byteData.length);
+    }
+
     /**
      * @see io.apiman.gateway.engine.io.IApimanBuffer#getNativeBuffer()
      */

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/components/BufferFactoryComponentImpl.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/components/BufferFactoryComponentImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.vertx.components;
+
+import io.apiman.gateway.engine.components.IBufferFactoryComponent;
+import io.apiman.gateway.engine.io.IApimanBuffer;
+import io.apiman.gateway.vertx.io.VertxApimanBuffer;
+
+/**
+ * Implementation of {@link IBufferFactoryComponent} for Vert.x
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class BufferFactoryComponentImpl implements IBufferFactoryComponent {
+
+    /**
+     * @see io.apiman.gateway.engine.components.IBufferFactoryComponent#createBuffer()
+     */
+    @Override
+    public IApimanBuffer createBuffer() {
+        return new VertxApimanBuffer();
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.components.IBufferFactoryComponent#createBuffer(java.lang.String)
+     */
+    @Override
+    public IApimanBuffer createBuffer(String stringData) {
+        return new VertxApimanBuffer(stringData);
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.components.IBufferFactoryComponent#createBuffer(java.lang.String,
+     *      java.lang.String)
+     */
+    @Override
+    public IApimanBuffer createBuffer(String stringData, String enc) {
+        return new VertxApimanBuffer(stringData, enc);
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.components.IBufferFactoryComponent#createBuffer(byte[])
+     */
+    @Override
+    public IApimanBuffer createBuffer(byte[] byteData) {
+        return new VertxApimanBuffer(byteData);
+    }
+}

--- a/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/io/VertxApimanBuffer.java
+++ b/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/io/VertxApimanBuffer.java
@@ -30,8 +30,24 @@ public class VertxApimanBuffer implements IApimanBuffer {
 
     private Buffer nativeBuffer;
     
+    public VertxApimanBuffer() {
+        this.nativeBuffer = new Buffer();
+    }
+    
     public VertxApimanBuffer(Buffer nativeBuffer) {
         this.nativeBuffer = nativeBuffer;
+    }
+
+    public VertxApimanBuffer(String stringData) {
+        this.nativeBuffer = new Buffer(stringData);
+    }
+
+    public VertxApimanBuffer(String stringData, String enc) {
+        this.nativeBuffer = new Buffer(stringData, enc);
+    }
+
+    public VertxApimanBuffer(byte[] byteData) {
+        this.nativeBuffer = new Buffer(byteData);
     }
 
     @Override


### PR DESCRIPTION
Thoughts:
 - Should we have a create method that accepts byte[] *without* any copying the array (or perhaps this should be the default behaviour).
 - Should we have a `relinquishBuffer`? Perhaps we can look at how Netty does its pooling/reuse. This is probably a strong candidate for reuse optimisations.



