### PR TITLE
Completed org-new-member port with all features, plus an enhancement

### DIFF
--- a/manager/ui/apiman-plugin/plugins/apiman/html/org/apiman-user-entry.html
+++ b/manager/ui/apiman-plugin/plugins/apiman/html/org/apiman-user-entry.html
@@ -1,0 +1,5 @@
+<a href="#" class="item" ng-class="{selected: isSelectedUser == true}" ng-click="selectThisUser()">
+  <i class="fa fa-user fa-fw"></i>
+  <span class="">{{ user.fullName }}</span>
+  <span>(</span><span class="">{{ user.username }}</span><span>)</span>
+</a>

--- a/manager/ui/apiman-plugin/plugins/apiman/html/org/org-manage-members.html
+++ b/manager/ui/apiman-plugin/plugins/apiman/html/org/org-manage-members.html
@@ -21,7 +21,7 @@
             </div>
             <select title="Filter by role(s)..." ng-options="role.id as role.name for role in roles" ng-model="selectedRoles" class="selectpicker" apiman-select-picker="" multiple ng-change="filterMembers(filterValue)">
             </select>
-            <a href="{{ pluginName }}/new-member.html" class="btn btn-primary pull-right" data-i18n-key="add-member">Add Member</a>
+            <a href="{{ pluginName }}/org-new-member.html?org={{ organizationId }}" class="btn btn-primary pull-right" data-i18n-key="add-member">Add Member</a>
           </div>
         </div>
       </div>
@@ -30,7 +30,7 @@
         <div class="col-md-12 apiman-manage-members">
           <div class="container-fluid apiman-cards" data-field="cards">
             <div ng-repeat="member in filteredMembers">
-              <apiman-user-card member="member" roles="roles" org-id="{{organizationId}}"></apiman-user-card>
+              <apiman-user-card member="member" roles="roles" org-id="{{ organizationId }}"></apiman-user-card>
             </div>
           </div>
         </div>

--- a/manager/ui/apiman-plugin/plugins/apiman/html/org/org-new-member.html
+++ b/manager/ui/apiman-plugin/plugins/apiman/html/org/org-new-member.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
+    <script type="text/javascript" src="site.js"></script>
+  </head>
+
+  <body>
+    <div ng-include="'plugins/apiman/html/progress.include'"></div>
+    <div id="apiman-header" ng-include="'plugins/apiman/html/navbar.include'"></div>
+
+    <div id="form-page" class="container apiman-entity-new page" ng-controller="Apiman.OrgNewMemberController as onmCtrl">
+      <div class="row">
+        <h2 class="title" data-i18n-key="new-member">New Member</h2>
+      </div>
+      <!-- Helpful hint -->
+      <div class="row">
+        <p data-i18n-key="new-member-help-text" class="col-md-6 apiman-label-faded">Add a member to this organization by searching for a User below.  Once the User is located, simply select their roles and click 'Add Member'.</p>
+      </div>
+      <!-- HR -->
+      <div class="row hr-row">
+        <hr/>
+      </div>
+      <!-- User search bar -->
+      <div class="row">
+        <dl>
+          <dt data-i18n-key="find-user">Find a User</dt>
+          <dd>
+            <div class="" style="line-height: normal">
+              <apiman-search-box function="findUsers" placeholder="Search by username..."></apiman-search-box>
+            </div>
+          </dd>
+        </dl>
+      </div>
+      <!-- User search results -->
+      <div class="row">
+        <div class="panel panel-default input-search-results">
+          <div class="panel-body container-fluid">
+            <div ng-hide="searchBoxValue.length>0">(Search for users above)</div>
+            <apiman-user-entry user="user" selected-users="selectedUsers" ng-repeat="user in queriedUsers"></apiman-user-entry>
+          </div>
+        </div>
+      </div>
+      <!-- Role selections -->
+      <div class="row">
+        <dl>
+          <dt data-i18n-key="roles">Role(s)</dt>
+          <dd>
+            <div>
+              <select title="Select role(s)..." ng-options="role.id as role.name for role in roles"
+                ng-model="selectedRoles" class="selectpicker" apiman-select-picker=""
+                multiple>
+              </select>
+            </div>
+          </dd>
+        </dl>
+      </div>
+      <!-- HR -->
+      <div class="row hr-row">
+        <hr/>
+      </div>
+      <!-- Create Button -->
+      <div class="row">
+        <button class="btn btn-primary" data-i18n-key="add-member" data-icon="fa-cog" placeholder="Adding..."
+                ng-click="addMembers()" data-field="addMembersButton" apiman-action-btn
+                ng-disabled="selectedRoles.length === 0 || countObjectKeys(selectedUsers) === 0">
+          Add Member(s)
+        </button>
+        <a href="javascript:window.history.back()" class="btn btn-default btn-cancel" data-i18n-key="cancel">Cancel</a>
+      </div>
+    </div> <!-- /container -->
+  </body>
+</html>

--- a/manager/ui/apiman-plugin/plugins/apiman/ts/apimanPlugin.ts
+++ b/manager/ui/apiman-plugin/plugins/apiman/ts/apimanPlugin.ts
@@ -50,6 +50,7 @@ module Apiman {
         '/apiman/org-apps.html'         : { templateUrl: 'org/org-apps.html' },
         '/apiman/org-members.html'      : { templateUrl: 'org/org-members.html' },
         '/apiman/org-manage-members.html'   : { templateUrl: 'org/org-manage-members.html' },
+        '/apiman/org-new-member.html'  : { templateUrl: 'org/org-new-member.html' },
         '/apiman/org-activity.html'     : { templateUrl: 'org/org-activity.html' },
         '/apiman/plan-overview.html'    : { templateUrl: 'plan/plan-overview.html' },
         '/apiman/plan-policies.html'    : { templateUrl: 'plan/plan-policies.html' },

--- a/manager/ui/apiman-plugin/plugins/apiman/ts/org/org-new-member.ts
+++ b/manager/ui/apiman-plugin/plugins/apiman/ts/org/org-new-member.ts
@@ -1,0 +1,125 @@
+/// <reference path="../apimanPlugin.ts"/>
+/// <reference path="../services.ts"/>
+module Apiman {
+
+  export var OrgNewMemberController = _module.controller("Apiman.OrgNewMemberController",
+    ['$q', '$scope', '$location', 'OrgSvcs', 'PageLifecycle', '$rootScope', 'ApimanSvcs', 'Logger',
+  ($q, $scope, $location, OrgSvcs, PageLifecycle, $rootScope, ApimanSvcs, $log) => {
+    var params = $location.search();
+    $scope.organizationId = params.org;
+    $scope.selectedUsers = {};
+    $scope.selectedRoles = [];
+    $scope.queriedUsers = [];
+
+    $scope.addMembers = function() {
+      if ($scope.selectedRoles) {
+        $scope.addMembersButton.state = 'in-progress';
+        // Iterate over object like map (k:v)
+        jQuery.each($scope.selectedUsers, function(k, user) {
+          $log.debug('Adding user: ' + JSON.stringify(user));
+
+          var grantRolesBean = {
+            userId: user.username,
+            roleIds: $scope.selectedRoles
+          };
+
+          OrgSvcs.save({ organizationId: $scope.organizationId, entityType: 'roles' },
+            grantRolesBean, function() { // Success
+              $log.debug('Successfully Saved: ' + JSON.stringify(grantRolesBean));
+              $scope.addMembersButton.state = 'complete';
+              $location.url(pluginName + '/org-manage-members.html').search({ org: params.org });
+            }, function(error) { // Err TODO handle error better.
+              $scope.addMembersButton.state = 'error';
+              $log.debug('Error: ' + JSON.stringify(error));
+          });
+        });
+      }
+    }
+
+    $scope.findUsers = (searchBoxValue) => {
+      $scope.searchBoxValue = searchBoxValue;
+      if (searchBoxValue.length == 0) return $scope.queriedUsers = [];
+
+      var queryBean = {
+        filters: [{
+          name: 'fullName',
+          value: '*' + searchBoxValue + '*',
+          operator: 'like'
+        }],
+        orderBy: {
+          name: 'fullName',
+          ascending: true
+        },
+        paging: {
+          page: 1,
+          pageSize: 50
+        }
+      }
+
+      $log.debug('Query: ' + JSON.stringify(queryBean));
+
+      ApimanSvcs.save({ entityType: 'users', secondaryType: 'search' }, queryBean, function(reply) {
+        $log.debug('Reply: ' + JSON.stringify(reply));
+        $scope.queriedUsers = reply.beans;
+      });
+    }
+
+    $scope.countObjectKeys = (object) => {
+      return Object.keys(object).length;
+    }
+
+    var promise = $q.all({
+      org: $q(function(resolve, reject) {
+        OrgSvcs.get({ organizationId: params.org, entityType: '' }, function(org) {
+          $rootScope.mruOrg = org;
+          resolve(org);
+        }, function(error) {
+          reject(error);
+        });
+      }),
+      members: $q(function(resolve, reject) {
+        OrgSvcs.query({ organizationId: params.org, entityType: 'members' }, function(members) {
+          $scope.filteredMembers = members;
+          resolve(members);
+        }, function(error) {
+          reject(error);
+        });
+      }),
+      roles: $q(function(resolve, reject) {
+        ApimanSvcs.query({ entityType: 'roles' }, function(adminRoles) {
+          $scope.filteredRoles = adminRoles;
+          resolve(adminRoles);
+        }, function(error) {
+          reject(error);
+        });
+      })
+    });
+
+    PageLifecycle.loadPage('OrgNewMembers', promise, $scope);
+  }])
+
+  OrgMembersController.directive('apimanUserEntry', ['$log', function($log) {
+    return {
+      scope: {
+        user: '=',
+        selectedUsers: '='
+      },
+      templateUrl: 'plugins/apiman/html/org/apiman-user-entry.html',
+      link: function($scope) {
+        $scope.isSelectedUser = false;
+
+        $scope.selectThisUser = function() {
+          $scope.isSelectedUser = !$scope.isSelectedUser;
+          // If selected user then add to map; if deselected remove it.
+          if ($scope.isSelectedUser) {
+            $scope.selectedUsers[$scope.user.username] = $scope.user;
+          } else {
+            delete $scope.selectedUsers[$scope.user.username];
+          }
+          $log.debug("Selected " + $scope.user.username);
+          $log.debug("Global $scope.selectedUsers " + JSON.stringify($scope.selectedUsers));
+        }
+      }
+    };
+  }])
+}


### PR DESCRIPTION
it is now possible to add multiple members with the same roles in a single action. You click an entry to select and click again to deselect, as below: 

![image](https://cloud.githubusercontent.com/assets/423513/6885206/bdff1b6c-d60d-11e4-8690-0cef980ca478.png)

:see_no_evil:  Caveats:
 - Made workaround for very annoying CSS issue where the search box is marginally larger than the search icon. It works fine by having a tiny inline CSS snippet, but really needs a better solution - suggest @EricWittmann looks at is as I don't want to meddle with his CSS too much (example without work-around below).

![image](https://cloud.githubusercontent.com/assets/423513/6885241/7eca4984-d60e-11e4-9e5a-2f1a3e89f1e2.png)

- There's a bug present in the old version that allows you to (attempt to) add users to an org who have already been added. I will put the PR for that separately.