### PR TITLE
Add profile to exclude doclint under java8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1282,6 +1282,22 @@
         </pluginRepository>
       </pluginRepositories>
     </profile>
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
-
 </project>


### PR DESCRIPTION
Note that 1 test fails under Java 8, but that's unrelated to this doclint fix.

Thanks to this SO thread: http://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete