### PR TITLE
Connector factory is a special case for its apiman.properties config paths

### DIFF
--- a/distro/wildfly8/src/main/resources/overlay/standalone/configuration/apiman.properties
+++ b/distro/wildfly8/src/main/resources/overlay/standalone/configuration/apiman.properties
@@ -48,30 +48,30 @@ apiman.es.cluster-name=apiman
 
 # Enable devMode for HTTPS connections (gateway trusts any certificate).
 # This should *NOT* be used in production mode. *Use with great care.*
-apiman-gateway.components.IConnectorFactory.tls.devMode=true
+apiman-gateway.connector-factory.tls.devMode=true
 
 # Trust store contains certificate(s) trusted by gateway.
-#apiman-gateway.components.IConnectorFactory.tls.trustStore=<PATH_TO_TRUST_STORE>
-#apiman-gateway.components.IConnectorFactory.tls.trustStorePassword=<PASSWORD_IF_ANY>
+#apiman-gateway.connector-factory.tls.trustStore=<PATH_TO_TRUST_STORE>
+#apiman-gateway.connector-factory.tls.trustStorePassword=<PASSWORD_IF_ANY>
 
 # Key store contains gateway's keys (including private components: keep it safe).
-#apiman-gateway.components.IConnectorFactory.tls.keyStore=<PATH_TO_KEY_STORE>
-#apiman-gateway.components.IConnectorFactory.tls.keyStorePassword=<PASSWORD_IF_ANY> # Password on key store as a whole
-#apiman-gateway.components.IConnectorFactory.tls.keyPassword=<PASSWORD_IF_ANY> # Password on specific key(s)
+#apiman-gateway.connector-factory.tls.keyStore=<PATH_TO_KEY_STORE>
+#apiman-gateway.connector-factory.tls.keyStorePassword=<PASSWORD_IF_ANY> # Password on key store as a whole
+#apiman-gateway.connector-factory.tls.keyPassword=<PASSWORD_IF_ANY> # Password on specific key(s)
 # By default all keys can be used (will try all). If alias list provided, will only attempt to use listed keys.
-#apiman-gateway.components.IConnectorFactory.tls.keyAliases=<COMMA_SEPARATED_LIST>
+#apiman-gateway.connector-factory.tls.keyAliases=<COMMA_SEPARATED_LIST>
 
 # Allowed TLS/SSL protocols and ciphers suites as CSV. Availability will vary depending on your JVM impl.
 # Uses JVM defaults depending if not explicitly provided.
 # See: https://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html
-#apiman-gateway.components.IConnectorFactory.tls.allowedProtocols=TLSv1.2,TLSv1.1
-#apiman-gateway.components.IConnectorFactory.tls.allowedCiphers=TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+#apiman-gateway.connector-factory.tls.allowedProtocols=TLSv1.2,TLSv1.1
+#apiman-gateway.connector-factory.tls.allowedCiphers=TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
 
 # Whether certificate host checks should be bypassed. *Use with great care.*
-#apiman-gateway.components.IConnectorFactory.tls.allowAnyHost=false
+#apiman-gateway.connector-factory.tls.allowAnyHost=false
 
 # Whether self-signed certificates should be automatically trusted. *Use with great care.*
-#apiman-gateway.components.IConnectorFactory.tls.allowSelfSigned=false
+#apiman-gateway.connector-factory.tls.allowSelfSigned=false
 
 # ---------------------------------------------------------------------
 # Registry Settings


### PR DESCRIPTION
This fixes the issue of config not reaching the factory, but there's a strange problem that's only exhibiting in manual testing that I haven't been able to get to the bottom of yet (see https://issues.jboss.org/browse/APIMAN-443)