### PR TITLE
APIMAN-455 Apiman favicon is now displaying

### DIFF
--- a/manager/ui/hawtio/index.html
+++ b/manager/ui/hawtio/index.html
@@ -4,8 +4,8 @@
   <head>
     <meta charset="utf-8">
     <title>apiman</title>
-    <base href='/'></base>
-    <link rel="shortcut icon" href="/favicon.ico">
+    <base href='/'>
+    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
 
     <!-- bower:css -->
     <link rel="stylesheet" href="libs/bootstrap/dist/css/bootstrap.css" />


### PR DESCRIPTION
Base tag specifies base URL for relative URLs.  Previous favicon was using a absolute URL.