### PR TITLE
APIMAN-480 Add <finalName> tag to all poms using war packaging

### DIFF
--- a/gateway/platforms/war/wildfly8/api/pom.xml
+++ b/gateway/platforms/war/wildfly8/api/pom.xml
@@ -95,6 +95,7 @@
   </dependencies>
 
   <build>
+    <finalName>apiman-gateway-api</finalName>
     <plugins>
       <plugin>
         <artifactId>maven-war-plugin</artifactId>

--- a/gateway/platforms/war/wildfly8/gateway/pom.xml
+++ b/gateway/platforms/war/wildfly8/gateway/pom.xml
@@ -58,6 +58,7 @@
   </dependencies>
 
   <build>
+    <finalName>apiman-gateway</finalName>
     <plugins>
       <plugin>
         <artifactId>maven-war-plugin</artifactId>

--- a/manager/api/war/pom.xml
+++ b/manager/api/war/pom.xml
@@ -87,6 +87,7 @@
   </dependencies>
   
   <build>
+    <finalName>apiman</finalName>
     <plugins>
       <plugin>
         <artifactId>maven-war-plugin</artifactId>

--- a/manager/api/war/wildfly8/pom.xml
+++ b/manager/api/war/wildfly8/pom.xml
@@ -53,6 +53,7 @@
   </dependencies>
 
   <build>
+    <finalName>apiman</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/manager/ui/hawtio/pom.xml
+++ b/manager/ui/hawtio/pom.xml
@@ -11,6 +11,7 @@
   <name>apiman-manager-ui-hawtio</name>
 
   <build>
+    <finalName>apimanui</finalName>
     <plugins>
 
       <plugin>

--- a/manager/ui/hawtio/wildfly8/pom.xml
+++ b/manager/ui/hawtio/wildfly8/pom.xml
@@ -80,6 +80,7 @@
   </dependencies>
 
   <build>
+    <finalName>apimanui</finalName>
     <resources>
       <resource>
         <directory>src/main/resources</directory>

--- a/tools/services/pom.xml
+++ b/tools/services/pom.xml
@@ -21,4 +21,7 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+  <build>
+    <finalName>services</finalName>
+  </build>
 </project>


### PR DESCRIPTION
To aid in IDE/server integration, it is extremely helpful if projects that generate wars create war artifacts named to match the intended target context names.