### PR TITLE
APIMAN-549 Remove sequence GenerationType.IDENTITY from PluginBean

### DIFF
--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/plugins/PluginBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/plugins/PluginBean.java
@@ -40,7 +40,7 @@ public class PluginBean implements Serializable {
 
     private static final long serialVersionUID = 2932636903455749308L;
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue
     private Long id;
     @Column(name = "group_id", updatable=false, nullable=false)
     private String groupId;


### PR DESCRIPTION
Inclusion of this sequence generation strategy is causing runtime problems within the application (when using PostgreSQL) and also during DDL generation for Oracle and perhaps other RDBMSs.  This is the only entity configured this way and all other entities are correctly getting generated ids from the configured hibernate_sequence.  Aligning PluginBean to match other entities within the project.