### PR TITLE
Remove ddl h2-update step as it's causing build issues

### DIFF
--- a/distro/ddl/pom.xml
+++ b/distro/ddl/pom.xml
@@ -90,7 +90,7 @@
           <execution>
             <!-- This step is used to create the current database, based on the current changelogs -->
             <id>h2-update</id>
-            <phase>process-resources</phase>
+            <!--<phase>process-resources</phase>-->
             <goals>
               <goal>update</goal>
             </goals>


### PR DESCRIPTION
Removed the h2-update build step within the ddl project as it implicitly requires a clean before it will build properly.  This step is part of a work in progress and may be removed in the future, keeping it around until we complete the next phase of the liquibase work.