### PR TITLE
Ensure reliable testing under Java8

### DIFF
--- a/gateway/platforms/vertx3/pom.xml
+++ b/gateway/platforms/vertx3/pom.xml
@@ -196,6 +196,19 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-jar-plugin</artifactId>
+	<version>2.6</version>
+	<executions>
+	  <execution>
+	    <goals>
+	      <goal>test-jar</goal>
+	    </goals>
+	  </execution>
+	</executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/gateway/platforms/vertx3/pom.xml
+++ b/gateway/platforms/vertx3/pom.xml
@@ -19,10 +19,10 @@
 
   <repositories>
     <repository>
-        <id>snapshots-repo</id>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
-</repositories>
+  </repositories>
 
   <dependencies>
     <!-- Vert.x provided dependencies -->
@@ -88,7 +88,7 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>apiman-gateway-engine-es</artifactId>
     </dependency>
-    
+
     <!-- Third Party Dependencies -->
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -103,10 +103,9 @@
   <build>
     <pluginManagement>
       <plugins>
-        <!--
-          This is a hack to prevent manually edited codegen stuff from being overwritten.
-          It should be reverted when upstream has been fixed.
-         -->
+        <!-- This is a hack to prevent manually edited codegen stuff from being overwritten.
+        It should be reverted when upstream has been fixed. -->
+
         <!-- Configure the execution of the compiler to execute the codegen processor -->
         <!-- <plugin> -->
         <!--   <artifactId>maven-compiler-plugin</artifactId> -->
@@ -128,11 +127,9 @@
       </plugins>
     </pluginManagement>
 
+    <!-- This ensures the codegen-ed sources make it into compilation phase
+    Should be removed when upstream is fixed. -->
     <plugins>
-      <!--
-        This ensures the codegen-ed sources make it into compilation phase
-        Should be removed when upstream is fixed.
-       -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
@@ -152,11 +149,9 @@
         </executions>
       </plugin>
 
-      <!--
-      You only need the part below if you want to build your application into a fat executable jar.
+      <!-- You only need the part below if you want to build your application into a fat executable jar.
       This is a jar that contains all the dependencies required to run it, so you can just run it with
-      java -jar
-      -->
+      java -jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
@@ -183,31 +178,30 @@
               </artifactSet>
               <outputFile>${project.build.directory}/${project.artifactId}-${project.version}-fat.jar</outputFile>
               <filters>
-                  <filter>
-                      <artifact>*:*</artifact>
-                      <excludes>
-                          <exclude>META-INF/*.SF</exclude>
-                          <exclude>META-INF/*.DSA</exclude>
-                          <exclude>META-INF/*.RSA</exclude>
-                      </excludes>
-                  </filter>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
               </filters>
             </configuration>
           </execution>
         </executions>
       </plugin>
-
+      <!-- Export test jar -->
       <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-jar-plugin</artifactId>
-	<version>2.6</version>
-	<executions>
-	  <execution>
-	    <goals>
-	      <goal>test-jar</goal>
-	    </goals>
-	  </execution>
-	</executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/gateway/test/pom.xml
+++ b/gateway/test/pom.xml
@@ -125,4 +125,33 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>java8</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>apiman-gateway-platforms-vertx3</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>apiman-gateway-platforms-vertx3</artifactId>
+          <version>${project.version}</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>apiman-gateway-engine-vertx-eb-inmemory</artifactId>
+          <version>${project.version}</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
I discovered some glitches, which I've managed to resolve (thanks StackOverflow!)

Essentially, I am now properly exporting the test classes from the vertx3 gateway, which ensure they're available on the classpath when you run `mvn clean test -Dapiman.gateway-test.config=vertx3-mem`. By default they're not available, so they may/may not be on the classpath.

Also ensure that a few other things are reliably on the classpath (in-memory). See: https://github.com/apiman/apiman/compare/apiman:master...msavy:8fixes?expand=1#diff-0bc78dba935aa46d68cf49b963ef5a65R135

I've double checked and tests on java8 for the vert.x 3 port are always passing now.