### PR TITLE
Use a build matrix to switch between different gateway permutations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: java
 
+services:
+  - elasticsearch
+
 before_install:
   - export MAVEN_OPTS="-Xmx512m -XX:MaxPermSize=192m"
   - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
   - echo "Settings XML" && cat ~/.m2/settings.xml
+
+before_script:
+  - sleep 10 # Apparently needed to ensure ES has time to start up
 
 jdk:
   - oraclejdk8
@@ -15,3 +21,22 @@ notifications:
       - "chat.freenode.net#apiman"
     on_success: change
     on_failure: always
+    template:
+      - "%{repository} (%{branch}:%{commit} by %{author}): %{message} (%{build_url})"
+
+matrix:
+  include:
+    - env: ACTION='-Dapiman.gateway-test.config=vertx3-mem'
+      jdk: oraclejdk8
+    - env: ACTION='-Dapiman.gateway-test.config=default'
+      jdk: oraclejdk8
+    - env: ACTION='-Dapiman.gateway-test.config=default'
+      jdk: oraclejdk7
+    - env: ACTION='-Dapiman.gateway-test.config=servlet-es'
+      jdk: oraclejdk8
+    - env: ACTION='-Dapiman.gateway-test.config=servlet-es'
+      jdk: oraclejdk7
+
+install: travis_retry mvn clean install -Dinvoker.skip -Dmaven.javadoc.skip=true
+
+script: if [[ -v COMMAND ]]; then $COMMAND; else travis_retry mvn test install -Dmaven.javadoc.skip=true $ACTION | egrep -v 'Download|\\[exec\\] [[:digit:]]+/[[:digit:]]+|^[[:space:]]*\\[exec\\][[:space:]]*$' ; [ ${PIPESTATUS[0]} == 0 ]; fi


### PR DESCRIPTION
At present, this is in-memory, vert.x in-memory & elasticsearch.

Added some retry logic which helps get around annoying transient issues and/or unusual timing problems with eventually consistent bits.