### PR TITLE
Disabled ES clustering over multicast in test server

### DIFF
--- a/manager/test/api/src/main/java/io/apiman/manager/test/server/ManagerApiTestServer.java
+++ b/manager/test/api/src/main/java/io/apiman/manager/test/server/ManagerApiTestServer.java
@@ -176,6 +176,7 @@ public class ManagerApiTestServer {
             settings.put("path.home", esHome.getAbsolutePath());
             settings.put("http.port", "6500-6600");
             settings.put("transport.tcp.port", "6600-6700");
+            settings.put("discovery.zen.ping.multicast.enabled", false);
 
             String clusterName = System.getProperty("apiman.test.es-cluster-name", ES_CLUSTER_NAME);
 


### PR DESCRIPTION
Turning off multicast discovery as it causes issues when building the project on multiple servers inside local network. If there is a need for it to be enabled, then feel free to reject. Clustering of nodes running on the same machine should still work.

