### PR TITLE
Trim down redundant matrix entries & noise reduction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,15 +28,11 @@ matrix:
   include:
     - env: ACTION='-Dapiman.gateway-test.config=vertx3-mem'
       jdk: oraclejdk8
-    - env: ACTION='-Dapiman.gateway-test.config=default'
-      jdk: oraclejdk8
-    - env: ACTION='-Dapiman.gateway-test.config=default'
-      jdk: oraclejdk7
     - env: ACTION='-Dapiman.gateway-test.config=servlet-es'
       jdk: oraclejdk8
     - env: ACTION='-Dapiman.gateway-test.config=servlet-es'
       jdk: oraclejdk7
 
-install: travis_retry mvn clean install -Dinvoker.skip -Dmaven.javadoc.skip=true
+install: travis_retry mvn clean install -Dinvoker.skip -Dmaven.javadoc.skip=true | egrep -v 'Download|\\[exec\\] [[:digit:]]+/[[:digit:]]+|^[[:space:]]*\\[exec\\][[:space:]]*$' ; [ ${PIPESTATUS[0]} == 0 ];
 
 script: if [[ -v COMMAND ]]; then $COMMAND; else travis_retry mvn test install -Dmaven.javadoc.skip=true $ACTION | egrep -v 'Download|\\[exec\\] [[:digit:]]+/[[:digit:]]+|^[[:space:]]*\\[exec\\][[:space:]]*$' ; [ ${PIPESTATUS[0]} == 0 ]; fi


### PR DESCRIPTION
- Trim down redundant matrix entries (they are run by in the base install builds anyway)
- Add more log noise filtering