### PR TITLE
Entity updates to support NOT NULL java.util.Date columns

### DIFF
--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apps/ApplicationBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apps/ApplicationBean.java
@@ -28,7 +28,10 @@ import javax.persistence.IdClass;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinColumns;
 import javax.persistence.ManyToOne;
+import javax.persistence.PrePersist;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 
@@ -60,8 +63,14 @@ public class ApplicationBean implements Serializable {
     private String description;
     @Column(name = "created_by", updatable=false, nullable=false)
     private String createdBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "created_on", updatable=false, nullable=false)
     private Date createdOn;
+
+    @PrePersist
+    protected void onCreate() {
+        createdOn = new Date();
+    }
 
     /**
      * @return the id

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apps/ApplicationVersionBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apps/ApplicationVersionBean.java
@@ -27,7 +27,11 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinColumns;
 import javax.persistence.ManyToOne;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
 
 import org.codehaus.jackson.map.annotate.JsonSerialize;
@@ -64,14 +68,18 @@ public class ApplicationVersionBean implements Serializable {
     private String version;
     @Column(name = "created_by", updatable=false, nullable=false)
     private String createdBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "created_on", updatable=false, nullable=false)
     private Date createdOn;
     @Column(name = "modified_by", updatable=true, nullable=false)
     private String modifiedBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "modified_on", updatable=true, nullable=false)
     private Date modifiedOn;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "published_on")
     private Date publishedOn;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "retired_on")
     private Date retiredOn;
 
@@ -79,6 +87,16 @@ public class ApplicationVersionBean implements Serializable {
      * Constructor.
      */
     public ApplicationVersionBean() {
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdOn = modifiedOn = new Date();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        modifiedOn = new Date();
     }
 
     /**

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/audit/AuditEntryBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/audit/AuditEntryBean.java
@@ -25,7 +25,10 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Lob;
+import javax.persistence.PrePersist;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 import org.hibernate.annotations.Type;
 
@@ -62,6 +65,7 @@ public class AuditEntryBean implements Serializable {
     private String entityId;
     @Column(name = "entity_version", updatable=false)
     private String entityVersion;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "created_on", updatable=false, nullable=false)
     private Date createdOn;
     @Column(updatable=false, nullable=false)
@@ -76,6 +80,11 @@ public class AuditEntryBean implements Serializable {
      * Constructor.
      */
     public AuditEntryBean() {
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdOn = new Date();
     }
 
     /**

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/contracts/ContractBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/contracts/ContractBean.java
@@ -29,7 +29,10 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinColumns;
 import javax.persistence.ManyToOne;
+import javax.persistence.PrePersist;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
 
 /**
@@ -67,6 +70,7 @@ public class ContractBean implements Serializable {
     private PlanVersionBean plan;
     @Column(name = "created_by", updatable=false, nullable=false)
     private String createdBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "created_on", updatable=false, nullable=false)
     private Date createdOn;
     @Column(updatable=false, nullable=false)
@@ -76,6 +80,11 @@ public class ContractBean implements Serializable {
      * Constructor.
      */
     public ContractBean() {
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdOn = new Date();
     }
 
     /**

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/gateways/GatewayBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/gateways/GatewayBean.java
@@ -32,6 +32,8 @@ import javax.persistence.PostUpdate;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.hibernate.annotations.Type;
@@ -58,10 +60,12 @@ public class GatewayBean implements Serializable {
     private String description;
     @Column(name = "created_by", updatable=false, nullable=false)
     private String createdBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "created_on", updatable=false, nullable=false)
     private Date createdOn;
     @Column(name = "modified_by", updatable=true, nullable=false)
     private String modifiedBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "modified_on", updatable=true, nullable=false)
     private Date modifiedOn;
 
@@ -79,8 +83,16 @@ public class GatewayBean implements Serializable {
     public GatewayBean() {
     }
 
-    @PrePersist @PreUpdate
-    protected void encryptData() {
+    @PrePersist
+    protected void onCreate() {
+        createdOn = modifiedOn = new Date();
+        // Encrypt the endpoint properties.
+        configuration = AesEncrypter.encrypt(configuration);
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        modifiedOn = new Date();
         // Encrypt the endpoint properties.
         configuration = AesEncrypter.encrypt(configuration);
     }

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/RoleBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/RoleBean.java
@@ -26,7 +26,10 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.PrePersist;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 /**
  * A role definition.  The definition of the role determines whether the
@@ -49,6 +52,7 @@ public class RoleBean implements Serializable {
     private String description;
     @Column(name = "created_by", updatable=false, nullable=false)
     private String createdBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "created_on", updatable=false, nullable=false)
     private Date createdOn;
     @Column(name = "auto_grant", updatable=true, nullable=true)
@@ -61,6 +65,11 @@ public class RoleBean implements Serializable {
      * Constructor.
      */
     public RoleBean() {
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdOn = new Date();
     }
 
     /**

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/RoleMembershipBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/RoleMembershipBean.java
@@ -22,7 +22,10 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.PrePersist;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
 
 /**
@@ -57,6 +60,7 @@ public class RoleMembershipBean implements Serializable {
     private String roleId;
     @Column(name="org_id")
     private String organizationId;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "created_on")
     private Date createdOn;
 
@@ -64,6 +68,11 @@ public class RoleMembershipBean implements Serializable {
      * Constructor.
      */
     public RoleMembershipBean() {
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdOn = new Date();
     }
 
     /**

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/UserBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/UserBean.java
@@ -23,6 +23,8 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import javax.persistence.Transient;
 
 /**
@@ -42,6 +44,7 @@ public class UserBean implements Serializable {
     @Column(name = "full_name")
     private String fullName;
     private String email;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "joined_on", updatable=false)
     private Date joinedOn;
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/orgs/OrganizationBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/orgs/OrganizationBean.java
@@ -21,7 +21,11 @@ import java.util.Date;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 
@@ -47,10 +51,12 @@ public class OrganizationBean implements Serializable {
     private String description;
     @Column(name = "created_by", updatable=false, nullable=false)
     private String createdBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "created_on", updatable=false, nullable=false)
     private Date createdOn;
     @Column(name = "modified_by", updatable=true, nullable=false)
     private String modifiedBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "modified_on", updatable=true, nullable=false)
     private Date modifiedOn;
 
@@ -58,6 +64,16 @@ public class OrganizationBean implements Serializable {
      * Constructor.
      */
     public OrganizationBean() {
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdOn = modifiedOn = new Date();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        modifiedOn = new Date();
     }
 
     /**

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/plans/PlanBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/plans/PlanBean.java
@@ -28,7 +28,10 @@ import javax.persistence.IdClass;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinColumns;
 import javax.persistence.ManyToOne;
+import javax.persistence.PrePersist;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 
@@ -60,8 +63,14 @@ public class PlanBean implements Serializable {
     private String description;
     @Column(name = "created_by", updatable=false, nullable=false)
     private String createdBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "created_on", updatable=false, nullable=false)
     private Date createdOn;
+
+    @PrePersist
+    protected void onCreate() {
+        createdOn = new Date();
+    }
 
     /**
      * @return the id

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/plans/PlanVersionBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/plans/PlanVersionBean.java
@@ -27,7 +27,11 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinColumns;
 import javax.persistence.ManyToOne;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
 
 /**
@@ -61,12 +65,15 @@ public class PlanVersionBean implements Serializable {
     private String version;
     @Column(name = "created_by", updatable=false, nullable=false)
     private String createdBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "created_on", updatable=false, nullable=false)
     private Date createdOn;
     @Column(name = "modified_by", updatable=true, nullable=false)
     private String modifiedBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "modified_on", updatable=true, nullable=false)
     private Date modifiedOn;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "locked_on")
     private Date lockedOn;
 
@@ -74,6 +81,16 @@ public class PlanVersionBean implements Serializable {
      * Constructor.
      */
     public PlanVersionBean() {
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdOn = modifiedOn = new Date();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        modifiedOn = new Date();
     }
 
     /**

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/plugins/PluginBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/plugins/PluginBean.java
@@ -22,7 +22,10 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.PrePersist;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
 
 import org.codehaus.jackson.map.annotate.JsonSerialize;
@@ -58,6 +61,7 @@ public class PluginBean implements Serializable {
     private String description;
     @Column(name = "created_by", updatable=false, nullable=false)
     private String createdBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "created_on", updatable=false, nullable=false)
     private Date createdOn;
 
@@ -65,6 +69,11 @@ public class PluginBean implements Serializable {
      * Constructor.
      */
     public PluginBean() {
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdOn = new Date();
     }
 
     /**

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/policies/PolicyBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/policies/PolicyBean.java
@@ -35,6 +35,8 @@ import javax.persistence.PostUpdate;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import javax.persistence.Transient;
 
 import org.codehaus.jackson.map.annotate.JsonSerialize;
@@ -76,10 +78,12 @@ public class PolicyBean implements Serializable {
     private String configuration;
     @Column(name = "created_by", updatable=false, nullable=false)
     private String createdBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "created_on", updatable=false, nullable=false)
     private Date createdOn;
     @Column(name = "modified_by", updatable=true, nullable=false)
     private String modifiedBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "modified_on", updatable=true, nullable=false)
     private Date modifiedOn;
     @ManyToOne(fetch=FetchType.EAGER, optional=false)
@@ -93,8 +97,16 @@ public class PolicyBean implements Serializable {
     public PolicyBean() {
     }
 
-    @PrePersist @PreUpdate
-    protected void encryptData() {
+    @PrePersist
+    protected void onCreate() {
+        createdOn = modifiedOn = new Date();
+        // Encrypt the endpoint properties.
+        configuration = AesEncrypter.encrypt(configuration);
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        modifiedOn = new Date();
         // Encrypt the endpoint properties.
         configuration = AesEncrypter.encrypt(configuration);
     }

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/services/ServiceBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/services/ServiceBean.java
@@ -28,7 +28,10 @@ import javax.persistence.IdClass;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinColumns;
 import javax.persistence.ManyToOne;
+import javax.persistence.PrePersist;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 
@@ -60,6 +63,7 @@ public class ServiceBean implements Serializable {
     private String description;
     @Column(name = "created_by", updatable=false, nullable=false)
     private String createdBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "created_on", updatable=false, nullable=false)
     private Date createdOn;
 
@@ -67,6 +71,11 @@ public class ServiceBean implements Serializable {
      * Constructor.
      */
     public ServiceBean() {
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdOn = new Date();
     }
 
     /**

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/services/ServiceVersionBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/services/ServiceVersionBean.java
@@ -34,7 +34,11 @@ import javax.persistence.JoinColumn;
 import javax.persistence.JoinColumns;
 import javax.persistence.ManyToOne;
 import javax.persistence.MapKeyColumn;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
 
 import org.codehaus.jackson.map.annotate.JsonSerialize;
@@ -88,14 +92,18 @@ public class ServiceVersionBean implements Serializable {
     private String version;
     @Column(name = "created_by", updatable=false, nullable=false)
     private String createdBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "created_on", updatable=false, nullable=false)
     private Date createdOn;
     @Column(name = "modified_by", updatable=true, nullable=false)
     private String modifiedBy;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "modified_on", updatable=true, nullable=false)
     private Date modifiedOn;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "published_on")
     private Date publishedOn;
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "retired_on")
     private Date retiredOn;
     @Column(name = "definition_type")
@@ -106,6 +114,16 @@ public class ServiceVersionBean implements Serializable {
      * Constructor.
      */
     public ServiceVersionBean() {
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdOn = modifiedOn = new Date();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        modifiedOn = new Date();
     }
 
     /**


### PR DESCRIPTION
Added @Temporal(TemporalType.TIMESTAMP) to all Date columns.  Also added @PrePersist and @PreUpdate to support NOT NULL Date columns within entities.  Hopfully this will address issues within Apiman relating to MySQL NOT NULL timestamps.