### PR TITLE
APIMAN-556 Updates to correct liquibase DDL generation issues

### DIFF
--- a/distro/ddl/pom.xml
+++ b/distro/ddl/pom.xml
@@ -161,7 +161,7 @@
               <goal>updateSQL</goal>
             </goals>
             <configuration>
-              <migrationSqlOutputFile>${basedir}/target/apiman_mysql.ddl</migrationSqlOutputFile>
+              <migrationSqlOutputFile>${basedir}/target/apiman_mysql5.ddl</migrationSqlOutputFile>
               <driver>com.mysql.jdbc.Driver</driver>
               <url>offline:mysql?version=5.1&amp;caseSensitive=true&amp;changeLogFile=${basedir}/target/changelog/mysql/databasechangelog.csv</url>
               <username>apiman</username>

--- a/distro/ddl/pom.xml
+++ b/distro/ddl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.apiman</groupId>
     <artifactId>apiman-distro</artifactId>
-    <version>1.1.5.Final</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>apiman-distro-ddl</artifactId>
   <name>apiman-distro-ddl</name>
@@ -11,7 +11,7 @@
   <properties>
     <version.org.postgresql.jdbc.driver>9.4-1201-jdbc41</version.org.postgresql.jdbc.driver>
     <version.mysql.jdbc.driver>5.1.35</version.mysql.jdbc.driver>
-    <version.liquibase>3.3.5</version.liquibase>
+    <version.liquibase>3.4.1</version.liquibase>
   </properties>
 
   <dependencies>
@@ -121,7 +121,7 @@
           </execution>
           <execution>
             <id>h2-ddl</id>
-            <phase>process-resources</phase>
+            <phase>compile</phase>
             <goals>
               <goal>updateSQL</goal>
             </goals>
@@ -137,7 +137,7 @@
           </execution>
           <execution>
             <id>postgresql-ddl</id>
-            <phase>process-resources</phase>
+            <phase>compile</phase>
             <goals>
               <goal>updateSQL</goal>
             </goals>
@@ -147,20 +147,23 @@
               <url>offline:postgresql?version=9.3&amp;caseSensitive=true&amp;changeLogFile=${basedir}/target/changelog/postgresql/databasechangelog.csv</url>
               <username>apiman</username>
               <password>apiman</password>
+              <!-- Note: when upgrading from liquibase 3.3.5 -> 3.4.1, adding the defaultSchemaName below became a
+              requirement - otherwise this goal will fail.  This setting only appears to be required for Postgres. -->
+              <defaultSchemaName>public</defaultSchemaName>
               <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>
               <verbose>true</verbose>
             </configuration>
           </execution>
           <execution>
             <id>mysql-ddl</id>
-            <phase>process-resources</phase>
+            <phase>compile</phase>
             <goals>
               <goal>updateSQL</goal>
             </goals>
             <configuration>
-              <migrationSqlOutputFile>${basedir}/target/apiman_mysql5.ddl</migrationSqlOutputFile>
+              <migrationSqlOutputFile>${basedir}/target/apiman_mysql.ddl</migrationSqlOutputFile>
               <driver>com.mysql.jdbc.Driver</driver>
-              <url>offline:mysql?version=5.1&amp;caseSensitive=false&amp;changeLogFile=${basedir}/target/changelog/mysql/databasechangelog.csv</url>
+              <url>offline:mysql?version=5.1&amp;caseSensitive=true&amp;changeLogFile=${basedir}/target/changelog/mysql/databasechangelog.csv</url>
               <username>apiman</username>
               <password>apiman</password>
               <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>
@@ -184,7 +187,7 @@
                   <pluginExecutionFilter>
                     <groupId>org.liquibase</groupId>
                     <artifactId>liquibase-maven-plugin</artifactId>
-                    <versionRange>[3.3.5,)</versionRange>
+                    <versionRange>[3.4.1,)</versionRange>
                     <goals>
                       <goal>update</goal>
                       <goal>updateSQL</goal>

--- a/distro/ddl/src/main/liquibase/current/000-apiman-manager-api.db.sequences.changelog.xml
+++ b/distro/ddl/src/main/liquibase/current/000-apiman-manager-api.db.sequences.changelog.xml
@@ -2,8 +2,8 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
     <changeSet dbms="mysql" author="apiman" id="1434723514712-1">
         <sql dbms="mysql">
-            CREATE TABLE `hibernate_sequence` (`next_val` bigint(20) DEFAULT NULL) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-            INSERT INTO `hibernate_sequence` VALUES (999);
+            CREATE TABLE hibernate_sequence (next_val bigint(20) DEFAULT NULL) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+            INSERT INTO hibernate_sequence VALUES (999);
         </sql>
     </changeSet>
 

--- a/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml
+++ b/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml
@@ -5,46 +5,46 @@
             <column name="id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="created_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_on" type="DATETIME">
+            <column name="created_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="modified_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="modified_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="modified_on" type="DATETIME">
+            <column name="modified_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="published_on" type="DATETIME"/>
-            <column name="retired_on" type="DATETIME"/>
-            <column name="status" type="java.sql.Types.VARCHAR(255)">
+            <column name="published_on" type="TIMESTAMP"/>
+            <column name="retired_on" type="TIMESTAMP"/>
+            <column name="status" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="version" type="java.sql.Types.VARCHAR(255)">
+            <column name="version" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="app_id" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="app_org_id" type="java.sql.Types.VARCHAR(255)"/>
+            <column name="app_id" type="VARCHAR(255)"/>
+            <column name="app_org_id" type="VARCHAR(255)"/>
         </createTable>
     </changeSet>
     <changeSet author="apiman (generated)" id="1436469846462-2">
         <createTable tableName="applications">
-            <column name="id" type="java.sql.Types.VARCHAR(255)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="created_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_on" type="DATETIME">
+            <column name="created_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
             <column name="description" type="VARCHAR(512)"/>
-            <column name="name" type="java.sql.Types.VARCHAR(255)">
+            <column name="name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="organization_id" type="java.sql.Types.VARCHAR(255)">
+            <column name="organization_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
@@ -54,22 +54,22 @@
             <column name="id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_on" type="DATETIME">
+            <column name="created_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
             <column name="data" type="CLOB"/>
-            <column name="entity_id" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="entity_type" type="java.sql.Types.VARCHAR(255)">
+            <column name="entity_id" type="VARCHAR(255)"/>
+            <column name="entity_type" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="entity_version" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="organization_id" type="java.sql.Types.VARCHAR(255)">
+            <column name="entity_version" type="VARCHAR(255)"/>
+            <column name="organization_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="what" type="java.sql.Types.VARCHAR(255)">
+            <column name="what" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="who" type="java.sql.Types.VARCHAR(255)">
+            <column name="who" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
@@ -79,13 +79,13 @@
             <column name="id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="apikey" type="java.sql.Types.VARCHAR(255)">
+            <column name="apikey" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="created_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_on" type="DATETIME">
+            <column name="created_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
             <column name="appv_id" type="BIGINT"/>
@@ -98,37 +98,37 @@
             <column name="service_version_id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="value" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="name" type="java.sql.Types.VARCHAR(255)">
+            <column name="value" type="VARCHAR(255)"/>
+            <column name="name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
     </changeSet>
     <changeSet author="apiman (generated)" id="1436469846462-6">
         <createTable tableName="gateways">
-            <column name="id" type="java.sql.Types.VARCHAR(255)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="configuration" type="CLOB">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="created_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_on" type="DATETIME">
+            <column name="created_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
             <column name="description" type="VARCHAR(512)"/>
-            <column name="modified_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="modified_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="modified_on" type="DATETIME">
+            <column name="modified_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="name" type="java.sql.Types.VARCHAR(255)">
+            <column name="name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="type" type="java.sql.Types.VARCHAR(255)">
+            <column name="type" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
@@ -138,47 +138,47 @@
             <column name="id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_on" type="DATETIME"/>
-            <column name="org_id" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="role_id" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="user_id" type="java.sql.Types.VARCHAR(255)"/>
+            <column name="created_on" type="TIMESTAMP"/>
+            <column name="org_id" type="VARCHAR(255)"/>
+            <column name="role_id" type="VARCHAR(255)"/>
+            <column name="user_id" type="VARCHAR(255)"/>
         </createTable>
     </changeSet>
     <changeSet author="apiman (generated)" id="1436469846462-8">
         <createTable tableName="organizations">
-            <column name="id" type="java.sql.Types.VARCHAR(255)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="created_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_on" type="DATETIME">
+            <column name="created_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
             <column name="description" type="VARCHAR(512)"/>
-            <column name="modified_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="modified_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="modified_on" type="DATETIME">
+            <column name="modified_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="name" type="java.sql.Types.VARCHAR(255)">
+            <column name="name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
     </changeSet>
     <changeSet author="apiman (generated)" id="1436469846462-9">
         <createTable tableName="pd_templates">
-            <column name="policydef_id" type="java.sql.Types.VARCHAR(255)">
+            <column name="policydef_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="language" type="java.sql.Types.VARCHAR(255)"/>
+            <column name="language" type="VARCHAR(255)"/>
             <column name="template" type="VARCHAR(2048)"/>
         </createTable>
     </changeSet>
     <changeSet author="apiman (generated)" id="1436469846462-10">
         <createTable tableName="permissions">
-            <column name="role_id" type="java.sql.Types.VARCHAR(255)">
+            <column name="role_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="permissions" type="INT"/>
@@ -189,45 +189,45 @@
             <column name="id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="created_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_on" type="DATETIME">
+            <column name="created_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="locked_on" type="DATETIME"/>
-            <column name="modified_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="locked_on" type="TIMESTAMP"/>
+            <column name="modified_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="modified_on" type="DATETIME">
+            <column name="modified_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="status" type="java.sql.Types.VARCHAR(255)">
+            <column name="status" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="version" type="java.sql.Types.VARCHAR(255)">
+            <column name="version" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="plan_id" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="plan_org_id" type="java.sql.Types.VARCHAR(255)"/>
+            <column name="plan_id" type="VARCHAR(255)"/>
+            <column name="plan_org_id" type="VARCHAR(255)"/>
         </createTable>
     </changeSet>
     <changeSet author="apiman (generated)" id="1436469846462-12">
         <createTable tableName="plans">
-            <column name="id" type="java.sql.Types.VARCHAR(255)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="created_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_on" type="DATETIME">
+            <column name="created_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
             <column name="description" type="VARCHAR(512)"/>
-            <column name="name" type="java.sql.Types.VARCHAR(255)">
+            <column name="name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="organization_id" type="java.sql.Types.VARCHAR(255)">
+            <column name="organization_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
@@ -237,25 +237,25 @@
             <column name="id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="artifact_id" type="java.sql.Types.VARCHAR(255)">
+            <column name="artifact_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="classifier" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="created_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="classifier" type="VARCHAR(255)"/>
+            <column name="created_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_on" type="DATETIME">
+            <column name="created_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
             <column name="description" type="VARCHAR(512)"/>
-            <column name="group_id" type="java.sql.Types.VARCHAR(255)">
+            <column name="group_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="name" type="java.sql.Types.VARCHAR(255)">
+            <column name="name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="type" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="version" type="java.sql.Types.VARCHAR(255)">
+            <column name="type" type="VARCHAR(255)"/>
+            <column name="version" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
@@ -266,77 +266,77 @@
                 <constraints nullable="false"/>
             </column>
             <column name="configuration" type="CLOB"/>
-            <column name="created_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="created_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_on" type="DATETIME">
+            <column name="created_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="entity_id" type="java.sql.Types.VARCHAR(255)">
+            <column name="entity_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="entity_version" type="java.sql.Types.VARCHAR(255)">
+            <column name="entity_version" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="modified_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="modified_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="modified_on" type="DATETIME">
+            <column name="modified_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="name" type="java.sql.Types.VARCHAR(255)">
+            <column name="name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="order_index" type="INT">
                 <constraints nullable="false"/>
             </column>
-            <column name="organization_id" type="java.sql.Types.VARCHAR(255)">
+            <column name="organization_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="type" type="java.sql.Types.VARCHAR(255)">
+            <column name="type" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="definition_id" type="java.sql.Types.VARCHAR(255)">
+            <column name="definition_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
     </changeSet>
     <changeSet author="apiman (generated)" id="1436469846462-15">
         <createTable tableName="policydefs">
-            <column name="id" type="java.sql.Types.VARCHAR(255)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="description" type="VARCHAR(512)">
                 <constraints nullable="false"/>
             </column>
-            <column name="form" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="form_type" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="icon" type="java.sql.Types.VARCHAR(255)">
+            <column name="form" type="VARCHAR(255)"/>
+            <column name="form_type" type="VARCHAR(255)"/>
+            <column name="icon" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="name" type="java.sql.Types.VARCHAR(255)">
+            <column name="name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="plugin_id" type="BIGINT"/>
-            <column name="policy_impl" type="java.sql.Types.VARCHAR(255)">
+            <column name="policy_impl" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
     </changeSet>
     <changeSet author="apiman (generated)" id="1436469846462-16">
         <createTable tableName="roles">
-            <column name="id" type="java.sql.Types.VARCHAR(255)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="auto_grant" type="BOOLEAN"/>
-            <column name="created_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="created_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_on" type="DATETIME">
+            <column name="created_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
             <column name="description" type="VARCHAR(512)"/>
-            <column name="name" type="java.sql.Types.VARCHAR(255)"/>
+            <column name="name" type="VARCHAR(255)"/>
         </createTable>
     </changeSet>
     <changeSet author="apiman (generated)" id="1436469846462-17">
@@ -353,50 +353,50 @@
             <column name="id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="created_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_on" type="DATETIME">
+            <column name="created_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="definition_type" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="endpoint" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="endpoint_type" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="modified_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="definition_type" type="VARCHAR(255)"/>
+            <column name="endpoint" type="VARCHAR(255)"/>
+            <column name="endpoint_type" type="VARCHAR(255)"/>
+            <column name="modified_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="modified_on" type="DATETIME">
+            <column name="modified_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
             <column name="public_service" type="BOOLEAN">
                 <constraints nullable="false"/>
             </column>
-            <column name="published_on" type="DATETIME"/>
-            <column name="retired_on" type="DATETIME"/>
-            <column name="status" type="java.sql.Types.VARCHAR(255)">
+            <column name="published_on" type="TIMESTAMP"/>
+            <column name="retired_on" type="TIMESTAMP"/>
+            <column name="status" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="version" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="service_id" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="service_org_id" type="java.sql.Types.VARCHAR(255)"/>
+            <column name="version" type="VARCHAR(255)"/>
+            <column name="service_id" type="VARCHAR(255)"/>
+            <column name="service_org_id" type="VARCHAR(255)"/>
         </createTable>
     </changeSet>
     <changeSet author="apiman (generated)" id="1436469846462-19">
         <createTable tableName="services">
-            <column name="id" type="java.sql.Types.VARCHAR(255)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_by" type="java.sql.Types.VARCHAR(255)">
+            <column name="created_by" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created_on" type="DATETIME">
+            <column name="created_on" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
             <column name="description" type="VARCHAR(512)"/>
-            <column name="name" type="java.sql.Types.VARCHAR(255)">
+            <column name="name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="organization_id" type="java.sql.Types.VARCHAR(255)">
+            <column name="organization_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
@@ -406,7 +406,7 @@
             <column name="service_version_id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="gateway_id" type="java.sql.Types.VARCHAR(255)">
+            <column name="gateway_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
@@ -416,22 +416,22 @@
             <column name="service_version_id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="plan_id" type="java.sql.Types.VARCHAR(255)">
+            <column name="plan_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="version" type="java.sql.Types.VARCHAR(255)">
+            <column name="version" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
     </changeSet>
     <changeSet author="apiman (generated)" id="1436469846462-22">
         <createTable tableName="users">
-            <column name="username" type="java.sql.Types.VARCHAR(255)">
+            <column name="username" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="email" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="full_name" type="java.sql.Types.VARCHAR(255)"/>
-            <column name="joined_on" type="DATETIME"/>
+            <column name="email" type="VARCHAR(255)"/>
+            <column name="full_name" type="VARCHAR(255)"/>
+            <column name="joined_on" type="TIMESTAMP"/>
         </createTable>
     </changeSet>
 </databaseChangeLog>

--- a/distro/ddl/src/main/liquibase/master.xml
+++ b/distro/ddl/src/main/liquibase/master.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+  <property name="clob.type" value="longtext" dbms="mysql"/>
+
   <includeAll path="src/main/liquibase/current" />
 </databaseChangeLog>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -13,6 +13,7 @@
   <modules>
     <module>data</module>
     <module>db</module>
+    <module>ddl</module>
     <module>db-es</module>
     <module>eap64</module>
     <module>es</module>

--- a/pom.xml
+++ b/pom.xml
@@ -455,6 +455,11 @@
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>apiman-distro-ddl</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>apiman-distro-db-es</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
Added distro/ddl to the apiman build process
Updated ddl SNAPSHOT version to match project -> 1.2.0-SNAPSHOT
Upgraded liquibase to version 3.4.1
Changed ddl generation goals to execute during maven compile phase
Added global property to master.xml to treat MySQL clob type as longtext
Synchronized the changelogs with the entity generated changelogs prior to manual updates
Keeping manual LONGBLOB update in the changelogs - will need to document this for future JPA @Lob columns
Added defaultSchemaName to PostgreSQL updateSql goal - see comments in pom
Successfully loaded MySQL DDL
Successfully loaded PostgreSQL DDL