### PR TITLE
APIMAN-619 - Build settings for Java 7 and earlier clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The general idea is to keep your 'master' branch in-sync with the 'upstream/mast
 
 ## Building apiman
 
-####Note: If you're using JDK 7 or earlier, please allocate additional memory within your user profile to allow Maven to do its work:
+####Note: If you're using JDK 1.7 or earlier, please allocate additional memory within your user profile to allow Maven to do its work:
   
 	Linux/OS X:
 		export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=256M"


### PR DESCRIPTION
Fixed a typo.  When referring to JDK, use correct JDK version numbering.