### PR TITLE
Fix issues with SSL construction

### DIFF
--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/ssl/SSLSessionStrategyFactory.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/ssl/SSLSessionStrategyFactory.java
@@ -18,9 +18,11 @@ package io.apiman.gateway.platforms.servlet.connectors.ssl;
 import io.apiman.common.config.options.TLSOptions;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.Socket;
 import java.security.KeyManagementException;
+import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -204,14 +206,15 @@ public class SSLSessionStrategyFactory {
 
         TrustStrategy trustStrategy = trustSelfSigned ?  SELF_SIGNED : null;
         HostnameVerifier hostnameVerifier = allowAnyHostname ? ALLOW_ANY :
-            SSLConnectionSocketFactory.getDefaultHostnameVerifier();
+            SSLConnectionSocketFactory.BROWSER_COMPATIBLE_HOSTNAME_VERIFIER;
         PrivateKeyStrategy privateKeyStrategy = keyAliases == null ? null : new SelectByAlias(keyAliases);
         boolean clientAuth = keyStore == null ? false : true;
 
         SSLContextBuilder builder = SSLContexts.custom();
 
         if (trustStore != null) {
-            builder.loadTrustMaterial(new File(trustStore),
+            loadTrustMaterial(builder,
+                    new File(trustStore),
                     trustStorePassword.toCharArray(),
                     trustStrategy);
         }
@@ -219,7 +222,7 @@ public class SSLSessionStrategyFactory {
         if (keyStore != null) {
             char[] ksp = keyStorePassword == null ? null : keyStorePassword.toCharArray();
             char[] kp = keyPassword == null ? null : keyPassword.toCharArray();
-            builder.loadKeyMaterial(new File(keyStore), ksp, kp, privateKeyStrategy);
+            loadKeyMaterial(builder, new File(keyStore), ksp, kp, privateKeyStrategy);
         }
 
         SSLContext sslContext = builder.build();
@@ -337,4 +340,39 @@ public class SSLSessionStrategyFactory {
             return null;
         }
     }
+
+    // This code is adapted from
+    // apache/httpcore/blob/4.4.x/httpcore/src/main/java/org/apache/http/ssl/SSLContextBuilder.java
+    // for compatibility purposes.
+    private static SSLContextBuilder loadTrustMaterial(SSLContextBuilder builder, final File file,
+            final char[] tsp, final TrustStrategy trustStrategy)
+                    throws NoSuchAlgorithmException, KeyStoreException, CertificateException, IOException {
+        Args.notNull(file, "Truststore file");
+        final KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        final FileInputStream instream = new FileInputStream(file);
+        try {
+            trustStore.load(instream, tsp);
+        } finally {
+            instream.close();
+        }
+        return builder.loadTrustMaterial(trustStore, trustStrategy);
+    }
+
+    // This code is adapted from
+    // apache/httpcore/blob/4.4.x/httpcore/src/main/java/org/apache/http/ssl/SSLContextBuilder.java
+    // for compatibility purposes.
+    private static SSLContextBuilder loadKeyMaterial(SSLContextBuilder builder, File file, char[] ksp,
+            char[] kp, PrivateKeyStrategy privateKeyStrategy) throws NoSuchAlgorithmException,
+                    KeyStoreException, UnrecoverableKeyException, CertificateException, IOException {
+        Args.notNull(file, "Keystore file");
+        final KeyStore identityStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        final FileInputStream instream = new FileInputStream(file);
+        try {
+            identityStore.load(instream, ksp);
+        } finally {
+            instream.close();
+        }
+        return builder.loadKeyMaterial(identityStore, kp, privateKeyStrategy);
+    }
+
 }

--- a/manager/api/gateway/src/main/java/io/apiman/manager/api/gateway/rest/RestGatewayLink.java
+++ b/manager/api/gateway/src/main/java/io/apiman/manager/api/gateway/rest/RestGatewayLink.java
@@ -33,9 +33,6 @@ import java.io.UnsupportedEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLSession;
-
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
@@ -58,15 +55,8 @@ import org.codehaus.jackson.map.ObjectMapper;
 public class RestGatewayLink implements IGatewayLink {
 
     private static final ObjectMapper mapper = new ObjectMapper();
-    private static HostnameVerifier allHostsValid;
     private static SSLConnectionSocketFactory sslConnectionFactory;
     static {
-        allHostsValid = new HostnameVerifier() {
-            @Override
-            public boolean verify(String hostname, SSLSession session) {
-                return true;
-            }
-        };
         try {
             SSLContextBuilder builder = new SSLContextBuilder();
             builder.loadTrustMaterial(null, new TrustStrategy() {
@@ -75,7 +65,7 @@ public class RestGatewayLink implements IGatewayLink {
                     return true;
                 }
             });
-            sslConnectionFactory = new SSLConnectionSocketFactory(builder.build(), allHostsValid);
+            sslConnectionFactory = new SSLConnectionSocketFactory(builder.build(), SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -98,7 +88,7 @@ public class RestGatewayLink implements IGatewayLink {
             setConfig((RestGatewayConfigBean) mapper.reader(RestGatewayConfigBean.class).readValue(cfg));
             getConfig().setPassword(AesEncrypter.decrypt(getConfig().getPassword()));
             httpClient = HttpClientBuilder.create()
-                    .setSSLHostnameVerifier(allHostsValid)
+                    .setHostnameVerifier(SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER)
                     .setSSLSocketFactory(sslConnectionFactory)
                     .addInterceptorFirst(new HttpRequestInterceptor() {
                         @Override


### PR DESCRIPTION
Weld is still unhappy after this SSL stuff has been fixed

```
11:45:51,188  WARN FAILED o.e.j.s.ServletContextHandler@e4bd0f2{/apiman,null,STARTING}: java.lang.AbstractMethodError: org.jboss.weld.environment.jetty.WeldDecorator.decorate(Ljava/lang/Object;)Ljava/lang/Object;
java.lang.AbstractMethodError: org.jboss.weld.environment.jetty.WeldDecorator.decorate(Ljava/lang/Object;)Ljava/lang/Object;
	at org.eclipse.jetty.servlet.ServletContextHandler$Context.createFilter(ServletContextHandler.java:1150)
	at org.eclipse.jetty.servlet.FilterHolder.initialize(FilterHolder.java:120)
	at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:852)
	at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:298)
	at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:741)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.doStart(ContextHandlerCollection.java:163)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132)
	at org.eclipse.jetty.server.Server.start(Server.java:387)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.Server.doStart(Server.java:354)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at io.apiman.manager.test.server.ManagerApiTestServer.start(ManagerApiTestServer.java:113)
	at io.apiman.distro.db.CreateH2Database.startServer(CreateH2Database.java:61)
	at io.apiman.distro.db.CreateH2Database.main(CreateH2Database.java:48)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:293)
	at java.lang.Thread.run(Thread.java:745)
11:45:51,190  WARN FAILED org.eclipse.jetty.server.handler.ContextHandlerCollection@6923b371[o.e.j.s.ServletContextHandler@e4bd0f2{/apiman,null,STARTING}, o.e.j.s.ServletContextHandler@8231a53{/mock-gateway,null,null}]: java.lang.AbstractMethodError: org.jboss.weld.environment.jetty.WeldDecorator.decorate(Ljava/lang/Object;)Ljava/lang/Object;
java.lang.AbstractMethodError: org.jboss.weld.environment.jetty.WeldDecorator.decorate(Ljava/lang/Object;)Ljava/lang/Object;
	at org.eclipse.jetty.servlet.ServletContextHandler$Context.createFilter(ServletContextHandler.java:1150)
	at org.eclipse.jetty.servlet.FilterHolder.initialize(FilterHolder.java:120)
	at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:852)
	at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:298)
	at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:741)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.doStart(ContextHandlerCollection.java:163)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132)
	at org.eclipse.jetty.server.Server.start(Server.java:387)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.Server.doStart(Server.java:354)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at io.apiman.manager.test.server.ManagerApiTestServer.start(ManagerApiTestServer.java:113)
	at io.apiman.distro.db.CreateH2Database.startServer(CreateH2Database.java:61)
	at io.apiman.distro.db.CreateH2Database.main(CreateH2Database.java:48)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:293)
	at java.lang.Thread.run(Thread.java:745)
11:45:51,209  INFO Started ServerConnector@5a49af37{HTTP/1.1}{0.0.0.0:7070}
11:45:51,209  WARN FAILED org.eclipse.jetty.server.Server@6d734cb8: java.lang.AbstractMethodError: org.jboss.weld.environment.jetty.WeldDecorator.decorate(Ljava/lang/Object;)Ljava/lang/Object;
java.lang.AbstractMethodError: org.jboss.weld.environment.jetty.WeldDecorator.decorate(Ljava/lang/Object;)Ljava/lang/Object;
	at org.eclipse.jetty.servlet.ServletContextHandler$Context.createFilter(ServletContextHandler.java:1150)
	at org.eclipse.jetty.servlet.FilterHolder.initialize(FilterHolder.java:120)
	at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:852)
	at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:298)
	at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:741)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.doStart(ContextHandlerCollection.java:163)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132)
	at org.eclipse.jetty.server.Server.start(Server.java:387)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.Server.doStart(Server.java:354)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at io.apiman.manager.test.server.ManagerApiTestServer.start(ManagerApiTestServer.java:113)
	at io.apiman.distro.db.CreateH2Database.startServer(CreateH2Database.java:61)
	at io.apiman.distro.db.CreateH2Database.main(CreateH2Database.java:48)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:293)
	at java.lang.Thread.run(Thread.java:745)
[WARNING]
java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:293)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.AbstractMethodError: org.jboss.weld.environment.jetty.WeldDecorator.decorate(Ljava/lang/Object;)Ljava/lang/Object;
	at org.eclipse.jetty.servlet.ServletContextHandler$Context.createFilter(ServletContextHandler.java:1150)
	at org.eclipse.jetty.servlet.FilterHolder.initialize(FilterHolder.java:120)
	at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:852)
	at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:298)
	at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:741)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.doStart(ContextHandlerCollection.java:163)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132)
	at org.eclipse.jetty.server.Server.start(Server.java:387)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.Server.doStart(Server.java:354)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at io.apiman.manager.test.server.ManagerApiTestServer.start(ManagerApiTestServer.java:113)
	at io.apiman.distro.db.CreateH2Database.startServer(CreateH2Database.java:61)
	at io.apiman.distro.db.CreateH2Database.main(CreateH2Database.java:48)
	... 6 more
```