### PR TITLE
Add timeout option for jest client, and double default T/O in many places - useful in CI scenarios

### DIFF
--- a/gateway/test/src/main/java/io/apiman/gateway/test/server/GatewayServer.java
+++ b/gateway/test/src/main/java/io/apiman/gateway/test/server/GatewayServer.java
@@ -55,6 +55,7 @@ public class GatewayServer {
 
     public static GatewayServer gatewayServer;
     private static final String ES_CLUSTER_NAME = "_apimantest";
+    private static final int JEST_TIMEOUT = 6000;
     public static JestClient ES_CLIENT = null;
 
     private Server server;
@@ -150,7 +151,7 @@ public class GatewayServer {
             String connectionUrl = "http://localhost:6500";
             JestClientFactory factory = new JestClientFactory();
             factory.setHttpClientConfig(new HttpClientConfig.Builder(connectionUrl).multiThreaded(true)
-                    .build());
+                    .connTimeout(JEST_TIMEOUT).readTimeout(JEST_TIMEOUT).build());
             client = factory.getObject();
             ES_CLIENT = client;
         }

--- a/manager/api/war/src/main/java/io/apiman/manager/api/war/WarApiManagerConfig.java
+++ b/manager/api/war/src/main/java/io/apiman/manager/api/war/WarApiManagerConfig.java
@@ -55,5 +55,4 @@ public class WarApiManagerConfig extends ApiManagerConfig implements IJpaPropert
         }
         return rval;
     }
-
 }

--- a/manager/api/war/src/main/java/io/apiman/manager/api/war/WarCdiFactory.java
+++ b/manager/api/war/src/main/java/io/apiman/manager/api/war/WarCdiFactory.java
@@ -67,6 +67,7 @@ public class WarCdiFactory {
 
     private static JestClient sStorageESClient;
     private static JestClient sMetricsESClient;
+    private static final int JEST_TIMEOUT = 6000;
     private static EsStorage sESStorage;
 
     @Produces @ApimanLogger
@@ -227,7 +228,8 @@ public class WarCdiFactory {
         builder.append(config.getStorageESPort());
         String connectionUrl = builder.toString();
         JestClientFactory factory = new JestClientFactory();
-        Builder httpConfig = new HttpClientConfig.Builder(connectionUrl).multiThreaded(true);
+        Builder httpConfig = new HttpClientConfig.Builder(connectionUrl).connTimeout(JEST_TIMEOUT).readTimeout(JEST_TIMEOUT)
+                .multiThreaded(true);
         String username = config.getStorageESUsername();
         String password = config.getStorageESPassword();
         if (username != null) {
@@ -250,7 +252,8 @@ public class WarCdiFactory {
         builder.append(config.getMetricsESPort());
         String connectionUrl = builder.toString();
         JestClientFactory factory = new JestClientFactory();
-        Builder httpConfig = new HttpClientConfig.Builder(connectionUrl).multiThreaded(true);
+        Builder httpConfig = new HttpClientConfig.Builder(connectionUrl).connTimeout(JEST_TIMEOUT).readTimeout(JEST_TIMEOUT)
+                .multiThreaded(true);
         String username = config.getMetricsESUsername();
         String password = config.getMetricsESPassword();
         if (username != null) {

--- a/manager/test/api/src/main/java/io/apiman/manager/test/server/ManagerApiTestServer.java
+++ b/manager/test/api/src/main/java/io/apiman/manager/test/server/ManagerApiTestServer.java
@@ -88,6 +88,7 @@ public class ManagerApiTestServer {
     private Node node = null;
     //private Client client = null;
     private JestClient client = null;
+    private static final int JEST_TIMEOUT = 6000;
 
     /**
      * Constructor.
@@ -201,7 +202,7 @@ public class ManagerApiTestServer {
             String connectionUrl = "http://localhost:6500";
             JestClientFactory factory = new JestClientFactory();
             factory.setHttpClientConfig(new HttpClientConfig.Builder(connectionUrl).multiThreaded(true)
-                    .build());
+                    .connTimeout(JEST_TIMEOUT ).readTimeout(JEST_TIMEOUT).build());
             client = factory.getObject();
             ES_CLIENT = client;
         }

--- a/manager/test/api/src/main/java/io/apiman/manager/test/server/TestCdiFactory.java
+++ b/manager/test/api/src/main/java/io/apiman/manager/test/server/TestCdiFactory.java
@@ -15,18 +15,6 @@
  */
 package io.apiman.manager.test.server;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.New;
-import javax.enterprise.inject.Produces;
-import javax.enterprise.inject.spi.InjectionPoint;
-import javax.inject.Named;
-
 import io.apiman.common.config.SystemPropertiesConfiguration;
 import io.apiman.manager.api.beans.services.EndpointType;
 import io.apiman.manager.api.beans.summary.AvailableServiceBean;
@@ -54,6 +42,18 @@ import io.searchbox.client.JestClient;
 import io.searchbox.client.JestClientFactory;
 import io.searchbox.client.config.HttpClientConfig;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.New;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Named;
+
 /**
  * Attempt to create producer methods for CDI beans.
  *
@@ -63,6 +63,8 @@ import io.searchbox.client.config.HttpClientConfig;
 @SuppressWarnings("nls")
 @Named("ApimanLogFactory")
 public class TestCdiFactory {
+
+    private static final int JEST_TIMEOUT = 6000;
 
     @Produces @ApplicationScoped
     public static ISecurityContext provideSecurityContext(@New DefaultSecurityContext defaultSC) {
@@ -188,8 +190,8 @@ public class TestCdiFactory {
 
             String connectionUrl = "http://" + host + ":" + port + "";
             JestClientFactory factory = new JestClientFactory();
-            factory.setHttpClientConfig(new HttpClientConfig.Builder(connectionUrl).multiThreaded(true)
-                    .build());
+            factory.setHttpClientConfig(new HttpClientConfig.Builder(connectionUrl).multiThreaded(true).
+                    connTimeout(JEST_TIMEOUT).readTimeout(JEST_TIMEOUT).build());
             return factory.getObject();
         } else {
             return null;

--- a/manager/test/api/src/test/java/io/apiman/manager/test/es/ESMetricsAccessorTest.java
+++ b/manager/test/api/src/test/java/io/apiman/manager/test/es/ESMetricsAccessorTest.java
@@ -94,7 +94,7 @@ public class ESMetricsAccessorTest {
     }
 
     private static JestClient createJestClient() {
-        return ESClientFactory.createJestClient("http", "localhost", 6500, "apiman_metrics", null, null, true);
+        return ESClientFactory.createJestClient("http", "localhost", 6500, "apiman_metrics", null, null, true, 6000);
     }
 
     private static void loadTestData() throws Exception {


### PR DESCRIPTION
Not sure whether this was worth adding as an extra config option in various places, so I just hard-coded a larger default in those areas.

Where it was easy I added an extra option to make it configurable (EsClientFactory).

Before merging it might be worth putting this one through CI a few times to see whether it trips anymore.