### PR TITLE
re #714 #485 Disable Fields if Service is Published

### DIFF
--- a/manager/ui/hawtio/plugins/api-manager/html/forms/edit-policy.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/forms/edit-policy.html
@@ -2,19 +2,31 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0"></meta>
   </head>
 
   <body>
     
     <div ng-include="headerInclude"></div>
-    <div ng-controller="Apiman.EditPolicyController" id="form-page" class="container apiman-edit-policy apiman-entity-new page" data-field="page" ng-cloak="" ng-show="pageState == 'loaded'">
+    <div ng-controller="Apiman.EditPolicyController"
+         id="form-page"
+         class="container apiman-edit-policy apiman-entity-new page"
+         data-field="page"
+         ng-cloak=""
+         ng-show="pageState == 'loaded'">
       <div class="row">
-        <h2 class="title" data-field="heading" apiman-i18n-key="edit-policy">Edit Policy</h2>
+        <h2 class="title"
+            data-field="heading"
+            apiman-i18n-key="edit-policy">Edit Policy</h2>
       </div>
       <!-- Helpful hint -->
       <div class="row">
-        <p class="col-md-6 apiman-label-faded" apiman-i18n-key="edit-policy-help-text" class="apiman-label-faded">Update this policy's configuration settings using the form below.</p>
+        <p class="col-md-6 apiman-label-faded"
+           apiman-i18n-key="edit-policy-help-text"
+           class="apiman-label-faded">
+          Update this policy's configuration settings using the form below.
+        </p>
       </div>
       <!-- HR -->
       <div class="row hr-row">
@@ -22,7 +34,8 @@
       </div>
 
       <!-- Policy Type-specific config -->
-      <div class="row" ng-show="include">
+      <div class="row"
+           ng-show="include">
         <h3 data-field="policyHeading">{{ policy.definition.name }} Configuration</h3>
         <div class="apiman-box col-md-9 container">
           <div ng-include="include"></div>
@@ -35,8 +48,23 @@
       </div>
       <!-- Update Button -->
       <div class="row">
-        <button id="update-policy" apiman-status="Created,Ready" ng-show="hasPermission" apiman-action-btn="" ng-click="updatePolicy()" ng-disabled="!isValid" class="btn btn-primary" data-field="updateButton" apiman-i18n-key="update-policy" placeholder="Updating..." data-icon="fa-cog">Update Policy</button>
-        <a id="cancel" data-field="cancelButton" href="javascript:window.history.back()" class="btn btn-default btn-cancel" data-field="cancelButton" apiman-i18n-key="cancel">Cancel</a>
+        <button id="update-policy"
+                apiman-status="Created,Ready"
+                ng-show="hasPermission"
+                apiman-action-btn=""
+                ng-click="updatePolicy()"
+                ng-disabled="!isValid"
+                class="btn btn-primary"
+                data-field="updateButton"
+                apiman-i18n-key="update-policy"
+                placeholder="Updating..."
+                data-icon="fa-cog">Update Policy</button>
+        <a id="cancel"
+           data-field="cancelButton"
+           href="javascript:window.history.back()"
+           class="btn btn-default btn-cancel"
+           data-field="cancelButton"
+           apiman-i18n-key="cancel">Cancel</a>
       </div>
     </div> <!-- /container -->
   </body>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/Default.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/Default.include
@@ -1,4 +1,4 @@
 <div class="form policy-config default" ng-controller="Apiman.DefaultPolicyConfigFormController">
   <span apiman-i18n-key="default-policy-config-msg">Please manually configure your policy's JSON configuration below.</span>
-  <textarea id="raw-config" ng-model="rawConfig" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></textarea>
+  <textarea id="raw-config" ng-model="rawConfig" ng-disabled="isEntityDisabled()"></textarea>
 </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/Default.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/Default.include
@@ -1,4 +1,4 @@
 <div class="form policy-config default" ng-controller="Apiman.DefaultPolicyConfigFormController">
   <span apiman-i18n-key="default-policy-config-msg">Please manually configure your policy's JSON configuration below.</span>
-  <textarea id="raw-config" ng-model="rawConfig" ng-disabled="getEntityStatus() !== 'Ready'"></textarea>
+  <textarea id="raw-config" ng-model="rawConfig" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></textarea>
 </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/Default.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/Default.include
@@ -1,4 +1,4 @@
 <div class="form policy-config default" ng-controller="Apiman.DefaultPolicyConfigFormController">
   <span apiman-i18n-key="default-policy-config-msg">Please manually configure your policy's JSON configuration below.</span>
-  <textarea id="raw-config" ng-model="rawConfig"></textarea>
+  <textarea id="raw-config" ng-model="rawConfig" ng-disabled="getEntityStatus() !== 'Ready'"></textarea>
 </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/authorization.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/authorization.include
@@ -36,14 +36,14 @@
     </div>
     <div class="panel-body">
       <span apiman-i18n-key="authorization.to-access">To access resource</span>
-      <input id="path" ng-model="path" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="authorization.enter-path" placeholder="(/path/to/.*)" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+      <input id="path" ng-model="path" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="authorization.enter-path" placeholder="(/path/to/.*)" ng-disabled="isEntityDisabled()"></input>
       <span apiman-i18n-key="authorization.using-verb">using verb/action</span>
-      <input id="verb" ng-model="verb" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="authorization.enter-verb" placeholder="(verb)" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+      <input id="verb" ng-model="verb" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="authorization.enter-verb" placeholder="(verb)" ng-disabled="isEntityDisabled()"></input>
       <span apiman-i18n-key="authorization.must-have-role">the user must have role</span>
-      <input id="role" ng-model="role" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="authorization.enter-role" placeholder="(required role)" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+      <input id="role" ng-model="role" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="authorization.enter-role" placeholder="(required role)" ng-disabled="isEntityDisabled()"></input>
       <span apiman-i18n-key="authorization.period">.</span>
       <div>
-        <button id="add-rule" ng-disabled="currentItemInvalid()" ng-click="add(path, verb, role)" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px" ng-disabled="getEntityStatus() !== 'Ready'">Add</button>
+        <button id="add-rule" ng-disabled="currentItemInvalid()" ng-click="add(path, verb, role)" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px" ng-disabled="isEntityDisabled()">Add</button>
       </div>
     </div>
   </div>
@@ -69,7 +69,7 @@
         <td>{{ item.verb }}</td>
         <td>{{ item.role }}</td>
         <td>
-          <button ng-click="remove(item)" class="btn btn-default" ng-disabled="getEntityStatus() !== 'Ready'"><i class="fa fa-times fa-fw"></i></button>
+          <button ng-click="remove(item)" class="btn btn-default" ng-disabled="isEntityDisabled()"><i class="fa fa-times fa-fw"></i></button>
         </td>
       </tr>
       <tr>
@@ -87,7 +87,7 @@
       <dt apiman-i18n-key="multiple-match-action">Multiple Match Action</dt>
       <dd>
         <span apiman-i18n-key="auth.multi-match-pre">I want the request to pass when</span>
-        <select id="multiple-match-action" ng-model="config.multiMatch" apiman-select-picker="" class="inline-form-select selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+        <select id="multiple-match-action" ng-model="config.multiMatch" apiman-select-picker="" class="inline-form-select selectpicker" data-live-search="false" ng-disabled="isEntityDisabled()">
           <option value="any" apiman-i18n-key="auth.any">at least one</option>
           <option value="all" apiman-i18n-key="auth.all">all</option>
         </select>
@@ -98,7 +98,7 @@
       <dt apiman-i18n-key="unmatched-request-action">Unmatched Request Action</dt>
       <dd>
         <span apiman-i18n-key="auth.if-request-unmatched-pre">I want the request to</span>
-        <select id="unmatched-request-action" ng-model="config.requestUnmatched" apiman-select-picker="" class="inline-form-select selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+        <select id="unmatched-request-action" ng-model="config.requestUnmatched" apiman-select-picker="" class="inline-form-select selectpicker" data-live-search="false" ng-disabled="isEntityDisabled()">
           <option value="fail" apiman-i18n-key="auth.fail">fail</option>
           <option value="pass" apiman-i18n-key="auth.pass">pass</option>
         </select>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/authorization.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/authorization.include
@@ -87,7 +87,7 @@
       <dt apiman-i18n-key="multiple-match-action">Multiple Match Action</dt>
       <dd>
         <span apiman-i18n-key="auth.multi-match-pre">I want the request to pass when</span>
-        <select id="multiple-match-action" ng-model="config.multiMatch" apiman-select-picker="" class="inline-form-select selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== 'Ready'">
+        <select id="multiple-match-action" ng-model="config.multiMatch" apiman-select-picker="" class="inline-form-select selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
           <option value="any" apiman-i18n-key="auth.any">at least one</option>
           <option value="all" apiman-i18n-key="auth.all">all</option>
         </select>
@@ -98,7 +98,7 @@
       <dt apiman-i18n-key="unmatched-request-action">Unmatched Request Action</dt>
       <dd>
         <span apiman-i18n-key="auth.if-request-unmatched-pre">I want the request to</span>
-        <select id="unmatched-request-action" ng-model="config.requestUnmatched" apiman-select-picker="" class="inline-form-select selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== 'Ready'">
+        <select id="unmatched-request-action" ng-model="config.requestUnmatched" apiman-select-picker="" class="inline-form-select selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
           <option value="fail" apiman-i18n-key="auth.fail">fail</option>
           <option value="pass" apiman-i18n-key="auth.pass">pass</option>
         </select>
@@ -106,5 +106,4 @@
       </dd>
     </dl>
   </div>
-
 </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/authorization.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/authorization.include
@@ -36,14 +36,14 @@
     </div>
     <div class="panel-body">
       <span apiman-i18n-key="authorization.to-access">To access resource</span>
-      <input id="path" ng-model="path" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="authorization.enter-path" placeholder="(/path/to/.*)"></input>
+      <input id="path" ng-model="path" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="authorization.enter-path" placeholder="(/path/to/.*)" ng-disabled="getEntityStatus() !== 'Ready'"></input>
       <span apiman-i18n-key="authorization.using-verb">using verb/action</span>
-      <input id="verb" ng-model="verb" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="authorization.enter-verb" placeholder="(verb)"></input>
+      <input id="verb" ng-model="verb" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="authorization.enter-verb" placeholder="(verb)" ng-disabled="getEntityStatus() !== 'Ready'"></input>
       <span apiman-i18n-key="authorization.must-have-role">the user must have role</span>
-      <input id="role" ng-model="role" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="authorization.enter-role" placeholder="(required role)"></input>
+      <input id="role" ng-model="role" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="authorization.enter-role" placeholder="(required role)" ng-disabled="getEntityStatus() !== 'Ready'"></input>
       <span apiman-i18n-key="authorization.period">.</span>
       <div>
-        <button id="add-rule" ng-disabled="currentItemInvalid()" ng-click="add(path, verb, role)" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
+        <button id="add-rule" ng-disabled="currentItemInvalid()" ng-click="add(path, verb, role)" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px" ng-disabled="getEntityStatus() !== 'Ready'">Add</button>
       </div>
     </div>
   </div>
@@ -69,7 +69,7 @@
         <td>{{ item.verb }}</td>
         <td>{{ item.role }}</td>
         <td>
-          <button ng-click="remove(item)" class="btn btn-default"><i class="fa fa-times fa-fw"></i></button>
+          <button ng-click="remove(item)" class="btn btn-default" ng-disabled="getEntityStatus() !== 'Ready'"><i class="fa fa-times fa-fw"></i></button>
         </td>
       </tr>
       <tr>
@@ -87,7 +87,7 @@
       <dt apiman-i18n-key="multiple-match-action">Multiple Match Action</dt>
       <dd>
         <span apiman-i18n-key="auth.multi-match-pre">I want the request to pass when</span>
-        <select id="multiple-match-action" ng-model="config.multiMatch" apiman-select-picker="" class="inline-form-select selectpicker" data-live-search="false">
+        <select id="multiple-match-action" ng-model="config.multiMatch" apiman-select-picker="" class="inline-form-select selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== 'Ready'">
           <option value="any" apiman-i18n-key="auth.any">at least one</option>
           <option value="all" apiman-i18n-key="auth.all">all</option>
         </select>
@@ -98,7 +98,7 @@
       <dt apiman-i18n-key="unmatched-request-action">Unmatched Request Action</dt>
       <dd>
         <span apiman-i18n-key="auth.if-request-unmatched-pre">I want the request to</span>
-        <select id="unmatched-request-action" ng-model="config.requestUnmatched" apiman-select-picker="" class="inline-form-select selectpicker" data-live-search="false">
+        <select id="unmatched-request-action" ng-model="config.requestUnmatched" apiman-select-picker="" class="inline-form-select selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== 'Ready'">
           <option value="fail" apiman-i18n-key="auth.fail">fail</option>
           <option value="pass" apiman-i18n-key="auth.pass">pass</option>
         </select>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/basic-auth.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/basic-auth.include
@@ -3,16 +3,16 @@
     <dl>
       <dt apiman-i18n-key="auth-realm">Authentication Realm</dt>
       <dd>
-        <input id="realm" ng-model="config.realm" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="basic-auth.enter-realm" placeholder="Realm..."></input>
+        <input id="realm" ng-model="config.realm" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="basic-auth.enter-realm" placeholder="Realm..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
       </dd>
       <dt apiman-i18n-key="require-transport-security">Require Transport Security</dt>
       <dd>
-        <input id="requireTS" type="checkbox" ng-model="config.requireTransportSecurity"></input>
+        <input id="requireTS" type="checkbox" ng-model="config.requireTransportSecurity" ng-disabled="getEntityStatus() !== 'Ready'"></input>
         <label for="requireTS" apiman-i18n-key="basic-auth.transport-security-required" title="When enabled, requests must be received on a secure channel (e.g. SSL) otherwise they will fail.">Transport security required</label>
       </dd>
       <dt apiman-i18n-key="forward-authenticated-user">Forward Authenticated Username as HTTP Header</dt>
       <dd>
-        <input id="forward-identity" ng-model="config.forwardIdentityHttpHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="base-auth.enter-auth-user-header" placeholder="HTTP header or leave blank to disable..."></input>
+        <input id="forward-identity" ng-model="config.forwardIdentityHttpHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="base-auth.enter-auth-user-header" placeholder="HTTP header or leave blank to disable..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
       </dd>
       <dt apiman-i18n-key="require-basic-auth">Require Basic Authentication</dt>
       <dd>
@@ -20,13 +20,13 @@
           If this option is enabled, then BASIC authentication is required for the request to succeed.  You
           might disable this option if you want to support both BASIC auth and OAuth policies (for example).
         </p>
-        <input id="requireBasic" type="checkbox" ng-model="config.requireBasicAuth"></input>
+        <input id="requireBasic" type="checkbox" ng-model="config.requireBasicAuth" ng-disabled="getEntityStatus() !== 'Ready'"></input>
         <label for="requireBasic" apiman-i18n-key="basic-auth.basic-auth-required" title="When enabled, requests *must* provide BASIC auth credentials, otherwise the request will fail.">Basic Auth required</label>
       </dd>
       <hr />
       <dt apiman-i18n-key="identity-source">Identity Source</dt>
       <dd>
-        <select id="identity-source" ng-model="identitySourceType" apiman-select-picker="" class="selectpicker" data-live-search="false">
+        <select id="identity-source" ng-model="identitySourceType" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== 'Ready'">
           <option value="" selected="selected" data-content="<span class='apiman-label-faded'>Choose an Identity Source...</span>" apiman-i18n-key="basic-auth.choose-identity-source">Choose an Identity Source...</option>
           <option value="static" apiman-i18n-key="basic-auth.static" data-content="<span>Static</span>">Static</option>
           <option value="jdbc" apiman-i18n-key="basic-auth.jdbc" data-content="<span>JDBC</span>">JDBC</option>
@@ -45,19 +45,19 @@
       <dt apiman-i18n-key="static-identities">Static Identities</dt>
     </div>
     <div style="width: 100%; float: left; margin-bottom: 5px;">
-      <select id="static-identities" ng-model="selectedIdentity" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="(item.username) for item in config.staticIdentity.identities | orderBy: 'username'">
+      <select id="static-identities" ng-model="selectedIdentity" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="(item.username) for item in config.staticIdentity.identities | orderBy: 'username'" ng-disabled="getEntityStatus() !== 'Ready'">
       </select>
       <div style="margin-left: 5px; float: left">
-        <button id="static-clear" ng-click="clear()" ng-disabled="!config.staticIdentity.identities" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
+        <button id="static-clear" ng-click="clear()" ng-disabled="!config.staticIdentity.identities" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px" ng-disabled="getEntityStatus() !== 'Ready'">Clear</button>
         <div class="clear:both"></div>
-        <button id="static-remove" ng-click="remove(selectedIdentity)" ng-disabled="!selectedIdentity" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;">Remove</button>
+        <button id="static-remove" ng-click="remove(selectedIdentity)" ng-disabled="!selectedIdentity" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;" ng-disabled="getEntityStatus() !== 'Ready'">Remove</button>
       </div>
     </div>
     <div style="width: 100%; float: left; margin-bottom: 10px; margin-top: 5px">
-      <input id="static-username" ng-model="username" class="apiman-form-control form-control" style="width: 85px; float: left; margin-right: 5px" type="text" apiman-i18n-key="basic-auth.enter-username" placeholder="Username..."></input>
+      <input id="static-username" ng-model="username" class="apiman-form-control form-control" style="width: 85px; float: left; margin-right: 5px" type="text" apiman-i18n-key="basic-auth.enter-username" placeholder="Username..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
       <div style="width: 8px; float: left; line-height: 28px" apiman-i18n-skip>:</div>
-      <input id="static-password" ng-model="password" class="apiman-form-control form-control" style="width: 102px; float: left; margin-right: 5px" type="password" apiman-i18n-key="basic-auth.enter-password" placeholder="Password..."></input>
-      <button id="static-add" ng-disabled="!username || !password" ng-click="add(username, password)" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
+      <input id="static-password" ng-model="password" class="apiman-form-control form-control" style="width: 102px; float: left; margin-right: 5px" type="password" apiman-i18n-key="basic-auth.enter-password" placeholder="Password..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
+      <button id="static-add" ng-disabled="!username || !password" ng-click="add(username, password)" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px" ng-disabled="getEntityStatus() !== 'Ready'">Add</button>
     </div>
   </div>
 
@@ -67,15 +67,15 @@
       <dl>
         <dt apiman-i18n-key="jdbc-datasource">JDBC Datasource (JNDI Location)</dt>
         <dd>
-          <input id="jdbc-datasource" ng-model="config.jdbcIdentity.datasourcePath" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-jndi-loc" placeholder="JNDI Datasource location (example: jdbc/ExampleDS)"></input>
+          <input id="jdbc-datasource" ng-model="config.jdbcIdentity.datasourcePath" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-jndi-loc" placeholder="JNDI Datasource location (example: jdbc/ExampleDS)" ng-disabled="getEntityStatus() !== 'Ready'"></input>
         </dd>
         <dt apiman-i18n-key="jdbc-query">SQL Query</dt>
         <dd>
-          <textarea id="jdbc-query" ng-model="config.jdbcIdentity.query" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-sql-query" placeholder="SQL Query (example: SELECT * FROM users WHERE u=? AND p=?)"></textarea>
+          <textarea id="jdbc-query" ng-model="config.jdbcIdentity.query" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-sql-query" placeholder="SQL Query (example: SELECT * FROM users WHERE u=? AND p=?)" ng-disabled="getEntityStatus() !== 'Ready'"></textarea>
         </dd>
         <dt apiman-i18n-key="jdbc-hash-algorithm">Password Hash Algorithm</dt>
         <dd>
-          <select id="jdbc-pwd-hash" ng-model="config.jdbcIdentity.hashAlgorithm" apiman-select-picker="" class="selectpicker" data-live-search="false">
+          <select id="jdbc-pwd-hash" ng-model="config.jdbcIdentity.hashAlgorithm" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== 'Ready'">
             <option value="None" apiman-i18n-key="basic-auth.none">None</option>
             <option value="SHA1" apiman-i18n-key="basic-auth.sha1">SHA1</option>
             <option value="MD5" apiman-i18n-key="basic-auth.md5">MD5</option>
@@ -85,12 +85,12 @@
           </select>
         </dd>
         <dd>
-          <input id="jdbc-extract-roles" type="checkbox" ng-model="config.jdbcIdentity.extractRoles" style="margin-top: 15px"></input>
+          <input id="jdbc-extract-roles" type="checkbox" ng-model="config.jdbcIdentity.extractRoles" style="margin-top: 15px" ng-disabled="getEntityStatus() !== 'Ready'"></input>
           <label for="jdbc-extract-roles" apiman-i18n-key="basic-auth.extract-jdbc-roles" title="When enabled, roles can also be extracted from the database for use in the Authorization Policy (sold separately).">Also extract user roles from the DB</label>
         </dd>
         <dt ng-show="config.jdbcIdentity.extractRoles == true" apiman-i18n-key="roles-sql-query">Roles SQL Query</dt>
         <dd ng-show="config.jdbcIdentity.extractRoles == true">
-          <textarea id="jdbc-role-query" ng-model="config.jdbcIdentity.roleQuery" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-role-sql-query" placeholder="Role SQL Query (example: SELECT r.rolename FROM roles r WHERE r.user=?)"></textarea>
+          <textarea id="jdbc-role-query" ng-model="config.jdbcIdentity.roleQuery" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-role-sql-query" placeholder="Role SQL Query (example: SELECT r.rolename FROM roles r WHERE r.user=?)" ng-disabled="getEntityStatus() !== 'Ready'"></textarea>
         </dd>
       </dl>
     </div>
@@ -102,15 +102,15 @@
       <dl>
         <dt apiman-i18n-key="ldap-server-url">LDAP Server URL</dt>
         <dd>
-          <input id="ldap-url" ng-model="config.ldapIdentity.url" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-url" placeholder="LDAP Url (example: ldap://example.org)"></input>
+          <input id="ldap-url" ng-model="config.ldapIdentity.url" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-url" placeholder="LDAP Url (example: ldap://example.org)" ng-disabled="getEntityStatus() !== 'Ready'"></input>
         </dd>
         <dt apiman-i18n-key="ldap-bind-dn">LDAP Bind DN</dt>
         <dd>
-          <input id="ldap-bind-dn" ng-model="config.ldapIdentity.dnPattern" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-binddn" placeholder="LDAP Bind DN (example: cn=${username},dc=overlord,dc=org)"></input>
+          <input id="ldap-bind-dn" ng-model="config.ldapIdentity.dnPattern" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-binddn" placeholder="LDAP Bind DN (example: cn=${username},dc=overlord,dc=org)" ng-disabled="getEntityStatus() !== 'Ready'"></input>
         </dd>
         <dt apiman-i18n-key="bind-as">Bind to LDAP As...</dt>
         <dd>
-          <select id="ldap-bind-as" ng-model="config.ldapIdentity.bindAs" apiman-select-picker="" class="selectpicker" data-live-search="false">
+          <select id="ldap-bind-as" ng-model="config.ldapIdentity.bindAs" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== 'Ready'">
             <option selected="selected" value="UserAccount" apiman-i18n-key="ldap-auth.inbound-user">The inbound user</option>
             <option value="ServiceAccount" apiman-i18n-key="ldap-auth.service-account">A service account</option>
           </select>
@@ -118,33 +118,33 @@
         <div ng-show="config.ldapIdentity.bindAs == 'ServiceAccount'" style="margin-top: 15px">
 	        <dt apiman-i18n-key="service-account-username">Service Account Username</dt>
 	        <dd>
-	          <input id="ldap-sa-username" ng-model="config.ldapIdentity.credentials.username" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.credentials.username" placeholder="Enter a username..."></input>
+	          <input id="ldap-sa-username" ng-model="config.ldapIdentity.credentials.username" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.credentials.username" placeholder="Enter a username..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
 	        </dd>
 	        <dt apiman-i18n-key="service-account-password">Service Account Password</dt>
 	        <dd>
-	          <input id="ldap-sa-pass" ng-model="config.ldapIdentity.credentials.password" class="apiman-form-control form-control" type="password" apiman-i18n-key="basic-auth.ldap.credentials.password" placeholder="Enter a password..."></input>
-              <input id="ldap-sa-pass-confirm" style="margin-top: 3px" ng-model="repeatPassword" class="apiman-form-control form-control" type="password" apiman-i18n-key="basic-auth.ldap.credentials.repeat-password" placeholder="Repeat password"></input>
+	          <input id="ldap-sa-pass" ng-model="config.ldapIdentity.credentials.password" class="apiman-form-control form-control" type="password" apiman-i18n-key="basic-auth.ldap.credentials.password" placeholder="Enter a password..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
+              <input id="ldap-sa-pass-confirm" style="margin-top: 3px" ng-model="repeatPassword" class="apiman-form-control form-control" type="password" apiman-i18n-key="basic-auth.ldap.credentials.repeat-password" placeholder="Repeat password" ng-disabled="getEntityStatus() !== 'Ready'"></input>
 	        </dd>
             <dt apiman-i18n-key="user-search-base-dn">User Search Base DN</dt>
             <dd>
-              <input id="ldap-us-base-dn" ng-model="config.ldapIdentity.userSearch.baseDn" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.userSearch.baseDn" placeholder="Enter a Base DN..."></input>
+              <input id="ldap-us-base-dn" ng-model="config.ldapIdentity.userSearch.baseDn" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.userSearch.baseDn" placeholder="Enter a Base DN..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
             </dd>
             <dt apiman-i18n-key="user-search-expression">User Search Expression</dt>
             <dd>
-              <input id="ldap-us-expr" ng-model="config.ldapIdentity.userSearch.expression" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.userSearch.expression" placeholder="Enter an expression..."></input>
+              <input id="ldap-us-expr" ng-model="config.ldapIdentity.userSearch.expression" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.userSearch.expression" placeholder="Enter an expression..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
             </dd>
         </div>
         <dd>
-          <input id="ldap-extract-roles" type="checkbox" ng-model="config.ldapIdentity.extractRoles" style="margin-top: 15px"></input>
+          <input id="ldap-extract-roles" type="checkbox" ng-model="config.ldapIdentity.extractRoles" style="margin-top: 15px" ng-disabled="getEntityStatus() !== 'Ready'"></input>
           <label for="ldap-extract-roles" apiman-i18n-key="basic-auth.extract-ldap-roles" title="When enabled, roles can also be extracted from the directory for use in the Authorization Policy (sold separately).">Also extract user roles from the directory</label>
         </dd>
         <dt ng-show="config.ldapIdentity.extractRoles == true" apiman-i18n-key="ldap-membership-attr">Group Membership Attribute</dt>
         <dd ng-show="config.ldapIdentity.extractRoles == true">
-          <input id="ldap-group-attr" ng-model="config.ldapIdentity.membershipAttribute" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-membership-attr" placeholder="memberOf"></input>
+          <input id="ldap-group-attr" ng-model="config.ldapIdentity.membershipAttribute" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-membership-attr" placeholder="memberOf" ng-disabled="getEntityStatus() !== 'Ready'"></input>
         </dd>
         <dt ng-show="config.ldapIdentity.extractRoles == true" apiman-i18n-key="ldap-rolename-attr">Role Name Attribute</dt>
         <dd ng-show="config.ldapIdentity.extractRoles == true">
-          <input id="ldap-role-name-attr" ng-model="config.ldapIdentity.rolenameAttribute" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-rolename-attr" placeholder="objectGUID"></input>
+          <input id="ldap-role-name-attr" ng-model="config.ldapIdentity.rolenameAttribute" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-rolename-attr" placeholder="objectGUID" ng-disabled="getEntityStatus() !== 'Ready'"></input>
         </dd>
       </dl>
     </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/basic-auth.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/basic-auth.include
@@ -3,16 +3,16 @@
     <dl>
       <dt apiman-i18n-key="auth-realm">Authentication Realm</dt>
       <dd>
-        <input id="realm" ng-model="config.realm" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="basic-auth.enter-realm" placeholder="Realm..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <input id="realm" ng-model="config.realm" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="basic-auth.enter-realm" placeholder="Realm..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
       </dd>
       <dt apiman-i18n-key="require-transport-security">Require Transport Security</dt>
       <dd>
-        <input id="requireTS" type="checkbox" ng-model="config.requireTransportSecurity" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <input id="requireTS" type="checkbox" ng-model="config.requireTransportSecurity" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
         <label for="requireTS" apiman-i18n-key="basic-auth.transport-security-required" title="When enabled, requests must be received on a secure channel (e.g. SSL) otherwise they will fail.">Transport security required</label>
       </dd>
       <dt apiman-i18n-key="forward-authenticated-user">Forward Authenticated Username as HTTP Header</dt>
       <dd>
-        <input id="forward-identity" ng-model="config.forwardIdentityHttpHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="base-auth.enter-auth-user-header" placeholder="HTTP header or leave blank to disable..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <input id="forward-identity" ng-model="config.forwardIdentityHttpHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="base-auth.enter-auth-user-header" placeholder="HTTP header or leave blank to disable..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
       </dd>
       <dt apiman-i18n-key="require-basic-auth">Require Basic Authentication</dt>
       <dd>
@@ -20,13 +20,13 @@
           If this option is enabled, then BASIC authentication is required for the request to succeed.  You
           might disable this option if you want to support both BASIC auth and OAuth policies (for example).
         </p>
-        <input id="requireBasic" type="checkbox" ng-model="config.requireBasicAuth" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <input id="requireBasic" type="checkbox" ng-model="config.requireBasicAuth" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
         <label for="requireBasic" apiman-i18n-key="basic-auth.basic-auth-required" title="When enabled, requests *must* provide BASIC auth credentials, otherwise the request will fail.">Basic Auth required</label>
       </dd>
       <hr />
       <dt apiman-i18n-key="identity-source">Identity Source</dt>
       <dd>
-        <select id="identity-source" ng-model="identitySourceType" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== 'Ready'">
+        <select id="identity-source" ng-model="identitySourceType" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
           <option value="" selected="selected" data-content="<span class='apiman-label-faded'>Choose an Identity Source...</span>" apiman-i18n-key="basic-auth.choose-identity-source">Choose an Identity Source...</option>
           <option value="static" apiman-i18n-key="basic-auth.static" data-content="<span>Static</span>">Static</option>
           <option value="jdbc" apiman-i18n-key="basic-auth.jdbc" data-content="<span>JDBC</span>">JDBC</option>
@@ -45,19 +45,19 @@
       <dt apiman-i18n-key="static-identities">Static Identities</dt>
     </div>
     <div style="width: 100%; float: left; margin-bottom: 5px;">
-      <select id="static-identities" ng-model="selectedIdentity" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="(item.username) for item in config.staticIdentity.identities | orderBy: 'username'" ng-disabled="getEntityStatus() !== 'Ready'">
+      <select id="static-identities" ng-model="selectedIdentity" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="(item.username) for item in config.staticIdentity.identities | orderBy: 'username'" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
       </select>
       <div style="margin-left: 5px; float: left">
-        <button id="static-clear" ng-click="clear()" ng-disabled="!config.staticIdentity.identities" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px" ng-disabled="getEntityStatus() !== 'Ready'">Clear</button>
+        <button id="static-clear" ng-click="clear()" ng-disabled="!config.staticIdentity.identities || getEntityStatus() !== ('Ready' || 'Created)" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
         <div class="clear:both"></div>
-        <button id="static-remove" ng-click="remove(selectedIdentity)" ng-disabled="!selectedIdentity" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;" ng-disabled="getEntityStatus() !== 'Ready'">Remove</button>
+        <button id="static-remove" ng-click="remove(selectedIdentity)" ng-disabled="!selectedIdentity  || getEntityStatus() !== ('Ready' || 'Created)" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;">Remove</button>
       </div>
     </div>
     <div style="width: 100%; float: left; margin-bottom: 10px; margin-top: 5px">
-      <input id="static-username" ng-model="username" class="apiman-form-control form-control" style="width: 85px; float: left; margin-right: 5px" type="text" apiman-i18n-key="basic-auth.enter-username" placeholder="Username..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
+      <input id="static-username" ng-model="username" class="apiman-form-control form-control" style="width: 85px; float: left; margin-right: 5px" type="text" apiman-i18n-key="basic-auth.enter-username" placeholder="Username..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
       <div style="width: 8px; float: left; line-height: 28px" apiman-i18n-skip>:</div>
-      <input id="static-password" ng-model="password" class="apiman-form-control form-control" style="width: 102px; float: left; margin-right: 5px" type="password" apiman-i18n-key="basic-auth.enter-password" placeholder="Password..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
-      <button id="static-add" ng-disabled="!username || !password" ng-click="add(username, password)" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px" ng-disabled="getEntityStatus() !== 'Ready'">Add</button>
+      <input id="static-password" ng-model="password" class="apiman-form-control form-control" style="width: 102px; float: left; margin-right: 5px" type="password" apiman-i18n-key="basic-auth.enter-password" placeholder="Password..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+      <button id="static-add" ng-disabled="!username || !password || getEntityStatus() !== ('Ready' || 'Created')" ng-click="add(username, password)" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
     </div>
   </div>
 
@@ -67,15 +67,15 @@
       <dl>
         <dt apiman-i18n-key="jdbc-datasource">JDBC Datasource (JNDI Location)</dt>
         <dd>
-          <input id="jdbc-datasource" ng-model="config.jdbcIdentity.datasourcePath" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-jndi-loc" placeholder="JNDI Datasource location (example: jdbc/ExampleDS)" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+          <input id="jdbc-datasource" ng-model="config.jdbcIdentity.datasourcePath" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-jndi-loc" placeholder="JNDI Datasource location (example: jdbc/ExampleDS)" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
         </dd>
         <dt apiman-i18n-key="jdbc-query">SQL Query</dt>
         <dd>
-          <textarea id="jdbc-query" ng-model="config.jdbcIdentity.query" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-sql-query" placeholder="SQL Query (example: SELECT * FROM users WHERE u=? AND p=?)" ng-disabled="getEntityStatus() !== 'Ready'"></textarea>
+          <textarea id="jdbc-query" ng-model="config.jdbcIdentity.query" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-sql-query" placeholder="SQL Query (example: SELECT * FROM users WHERE u=? AND p=?)" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></textarea>
         </dd>
         <dt apiman-i18n-key="jdbc-hash-algorithm">Password Hash Algorithm</dt>
         <dd>
-          <select id="jdbc-pwd-hash" ng-model="config.jdbcIdentity.hashAlgorithm" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== 'Ready'">
+          <select id="jdbc-pwd-hash" ng-model="config.jdbcIdentity.hashAlgorithm" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
             <option value="None" apiman-i18n-key="basic-auth.none">None</option>
             <option value="SHA1" apiman-i18n-key="basic-auth.sha1">SHA1</option>
             <option value="MD5" apiman-i18n-key="basic-auth.md5">MD5</option>
@@ -85,12 +85,12 @@
           </select>
         </dd>
         <dd>
-          <input id="jdbc-extract-roles" type="checkbox" ng-model="config.jdbcIdentity.extractRoles" style="margin-top: 15px" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+          <input id="jdbc-extract-roles" type="checkbox" ng-model="config.jdbcIdentity.extractRoles" style="margin-top: 15px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
           <label for="jdbc-extract-roles" apiman-i18n-key="basic-auth.extract-jdbc-roles" title="When enabled, roles can also be extracted from the database for use in the Authorization Policy (sold separately).">Also extract user roles from the DB</label>
         </dd>
         <dt ng-show="config.jdbcIdentity.extractRoles == true" apiman-i18n-key="roles-sql-query">Roles SQL Query</dt>
         <dd ng-show="config.jdbcIdentity.extractRoles == true">
-          <textarea id="jdbc-role-query" ng-model="config.jdbcIdentity.roleQuery" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-role-sql-query" placeholder="Role SQL Query (example: SELECT r.rolename FROM roles r WHERE r.user=?)" ng-disabled="getEntityStatus() !== 'Ready'"></textarea>
+          <textarea id="jdbc-role-query" ng-model="config.jdbcIdentity.roleQuery" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-role-sql-query" placeholder="Role SQL Query (example: SELECT r.rolename FROM roles r WHERE r.user=?)" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></textarea>
         </dd>
       </dl>
     </div>
@@ -102,15 +102,15 @@
       <dl>
         <dt apiman-i18n-key="ldap-server-url">LDAP Server URL</dt>
         <dd>
-          <input id="ldap-url" ng-model="config.ldapIdentity.url" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-url" placeholder="LDAP Url (example: ldap://example.org)" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+          <input id="ldap-url" ng-model="config.ldapIdentity.url" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-url" placeholder="LDAP Url (example: ldap://example.org)" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
         </dd>
         <dt apiman-i18n-key="ldap-bind-dn">LDAP Bind DN</dt>
         <dd>
-          <input id="ldap-bind-dn" ng-model="config.ldapIdentity.dnPattern" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-binddn" placeholder="LDAP Bind DN (example: cn=${username},dc=overlord,dc=org)" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+          <input id="ldap-bind-dn" ng-model="config.ldapIdentity.dnPattern" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-binddn" placeholder="LDAP Bind DN (example: cn=${username},dc=overlord,dc=org)" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
         </dd>
         <dt apiman-i18n-key="bind-as">Bind to LDAP As...</dt>
         <dd>
-          <select id="ldap-bind-as" ng-model="config.ldapIdentity.bindAs" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== 'Ready'">
+          <select id="ldap-bind-as" ng-model="config.ldapIdentity.bindAs" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
             <option selected="selected" value="UserAccount" apiman-i18n-key="ldap-auth.inbound-user">The inbound user</option>
             <option value="ServiceAccount" apiman-i18n-key="ldap-auth.service-account">A service account</option>
           </select>
@@ -118,33 +118,33 @@
         <div ng-show="config.ldapIdentity.bindAs == 'ServiceAccount'" style="margin-top: 15px">
 	        <dt apiman-i18n-key="service-account-username">Service Account Username</dt>
 	        <dd>
-	          <input id="ldap-sa-username" ng-model="config.ldapIdentity.credentials.username" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.credentials.username" placeholder="Enter a username..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
+	          <input id="ldap-sa-username" ng-model="config.ldapIdentity.credentials.username" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.credentials.username" placeholder="Enter a username..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
 	        </dd>
 	        <dt apiman-i18n-key="service-account-password">Service Account Password</dt>
 	        <dd>
-	          <input id="ldap-sa-pass" ng-model="config.ldapIdentity.credentials.password" class="apiman-form-control form-control" type="password" apiman-i18n-key="basic-auth.ldap.credentials.password" placeholder="Enter a password..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
-              <input id="ldap-sa-pass-confirm" style="margin-top: 3px" ng-model="repeatPassword" class="apiman-form-control form-control" type="password" apiman-i18n-key="basic-auth.ldap.credentials.repeat-password" placeholder="Repeat password" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+	          <input id="ldap-sa-pass" ng-model="config.ldapIdentity.credentials.password" class="apiman-form-control form-control" type="password" apiman-i18n-key="basic-auth.ldap.credentials.password" placeholder="Enter a password..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+              <input id="ldap-sa-pass-confirm" style="margin-top: 3px" ng-model="repeatPassword" class="apiman-form-control form-control" type="password" apiman-i18n-key="basic-auth.ldap.credentials.repeat-password" placeholder="Repeat password" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
 	        </dd>
             <dt apiman-i18n-key="user-search-base-dn">User Search Base DN</dt>
             <dd>
-              <input id="ldap-us-base-dn" ng-model="config.ldapIdentity.userSearch.baseDn" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.userSearch.baseDn" placeholder="Enter a Base DN..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
+              <input id="ldap-us-base-dn" ng-model="config.ldapIdentity.userSearch.baseDn" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.userSearch.baseDn" placeholder="Enter a Base DN..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
             </dd>
             <dt apiman-i18n-key="user-search-expression">User Search Expression</dt>
             <dd>
-              <input id="ldap-us-expr" ng-model="config.ldapIdentity.userSearch.expression" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.userSearch.expression" placeholder="Enter an expression..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
+              <input id="ldap-us-expr" ng-model="config.ldapIdentity.userSearch.expression" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.userSearch.expression" placeholder="Enter an expression..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
             </dd>
         </div>
         <dd>
-          <input id="ldap-extract-roles" type="checkbox" ng-model="config.ldapIdentity.extractRoles" style="margin-top: 15px" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+          <input id="ldap-extract-roles" type="checkbox" ng-model="config.ldapIdentity.extractRoles" style="margin-top: 15px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
           <label for="ldap-extract-roles" apiman-i18n-key="basic-auth.extract-ldap-roles" title="When enabled, roles can also be extracted from the directory for use in the Authorization Policy (sold separately).">Also extract user roles from the directory</label>
         </dd>
         <dt ng-show="config.ldapIdentity.extractRoles == true" apiman-i18n-key="ldap-membership-attr">Group Membership Attribute</dt>
         <dd ng-show="config.ldapIdentity.extractRoles == true">
-          <input id="ldap-group-attr" ng-model="config.ldapIdentity.membershipAttribute" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-membership-attr" placeholder="memberOf" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+          <input id="ldap-group-attr" ng-model="config.ldapIdentity.membershipAttribute" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-membership-attr" placeholder="memberOf" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
         </dd>
         <dt ng-show="config.ldapIdentity.extractRoles == true" apiman-i18n-key="ldap-rolename-attr">Role Name Attribute</dt>
         <dd ng-show="config.ldapIdentity.extractRoles == true">
-          <input id="ldap-role-name-attr" ng-model="config.ldapIdentity.rolenameAttribute" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-rolename-attr" placeholder="objectGUID" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+          <input id="ldap-role-name-attr" ng-model="config.ldapIdentity.rolenameAttribute" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-rolename-attr" placeholder="objectGUID" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
         </dd>
       </dl>
     </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/basic-auth.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/basic-auth.include
@@ -3,16 +3,16 @@
     <dl>
       <dt apiman-i18n-key="auth-realm">Authentication Realm</dt>
       <dd>
-        <input id="realm" ng-model="config.realm" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="basic-auth.enter-realm" placeholder="Realm..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <input id="realm" ng-model="config.realm" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="basic-auth.enter-realm" placeholder="Realm..." ng-disabled="isEntityDisabled()"></input>
       </dd>
       <dt apiman-i18n-key="require-transport-security">Require Transport Security</dt>
       <dd>
-        <input id="requireTS" type="checkbox" ng-model="config.requireTransportSecurity" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <input id="requireTS" type="checkbox" ng-model="config.requireTransportSecurity" ng-disabled="isEntityDisabled()"></input>
         <label for="requireTS" apiman-i18n-key="basic-auth.transport-security-required" title="When enabled, requests must be received on a secure channel (e.g. SSL) otherwise they will fail.">Transport security required</label>
       </dd>
       <dt apiman-i18n-key="forward-authenticated-user">Forward Authenticated Username as HTTP Header</dt>
       <dd>
-        <input id="forward-identity" ng-model="config.forwardIdentityHttpHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="base-auth.enter-auth-user-header" placeholder="HTTP header or leave blank to disable..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <input id="forward-identity" ng-model="config.forwardIdentityHttpHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="base-auth.enter-auth-user-header" placeholder="HTTP header or leave blank to disable..." ng-disabled="isEntityDisabled()"></input>
       </dd>
       <dt apiman-i18n-key="require-basic-auth">Require Basic Authentication</dt>
       <dd>
@@ -20,13 +20,13 @@
           If this option is enabled, then BASIC authentication is required for the request to succeed.  You
           might disable this option if you want to support both BASIC auth and OAuth policies (for example).
         </p>
-        <input id="requireBasic" type="checkbox" ng-model="config.requireBasicAuth" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <input id="requireBasic" type="checkbox" ng-model="config.requireBasicAuth" ng-disabled="isEntityDisabled()"></input>
         <label for="requireBasic" apiman-i18n-key="basic-auth.basic-auth-required" title="When enabled, requests *must* provide BASIC auth credentials, otherwise the request will fail.">Basic Auth required</label>
       </dd>
       <hr />
       <dt apiman-i18n-key="identity-source">Identity Source</dt>
       <dd>
-        <select id="identity-source" ng-model="identitySourceType" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+        <select id="identity-source" ng-model="identitySourceType" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="isEntityDisabled()">
           <option value="" selected="selected" data-content="<span class='apiman-label-faded'>Choose an Identity Source...</span>" apiman-i18n-key="basic-auth.choose-identity-source">Choose an Identity Source...</option>
           <option value="static" apiman-i18n-key="basic-auth.static" data-content="<span>Static</span>">Static</option>
           <option value="jdbc" apiman-i18n-key="basic-auth.jdbc" data-content="<span>JDBC</span>">JDBC</option>
@@ -45,19 +45,19 @@
       <dt apiman-i18n-key="static-identities">Static Identities</dt>
     </div>
     <div style="width: 100%; float: left; margin-bottom: 5px;">
-      <select id="static-identities" ng-model="selectedIdentity" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="(item.username) for item in config.staticIdentity.identities | orderBy: 'username'" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+      <select id="static-identities" ng-model="selectedIdentity" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="(item.username) for item in config.staticIdentity.identities | orderBy: 'username'" ng-disabled="isEntityDisabled()">
       </select>
       <div style="margin-left: 5px; float: left">
-        <button id="static-clear" ng-click="clear()" ng-disabled="!config.staticIdentity.identities || getEntityStatus() !== ('Ready' || 'Created)" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
+        <button id="static-clear" ng-click="clear()" ng-disabled="!config.staticIdentity.identities || isEntityDisabled()" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
         <div class="clear:both"></div>
-        <button id="static-remove" ng-click="remove(selectedIdentity)" ng-disabled="!selectedIdentity  || getEntityStatus() !== ('Ready' || 'Created)" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;">Remove</button>
+        <button id="static-remove" ng-click="remove(selectedIdentity)" ng-disabled="!selectedIdentity  || isEntityDisabled()" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;">Remove</button>
       </div>
     </div>
     <div style="width: 100%; float: left; margin-bottom: 10px; margin-top: 5px">
-      <input id="static-username" ng-model="username" class="apiman-form-control form-control" style="width: 85px; float: left; margin-right: 5px" type="text" apiman-i18n-key="basic-auth.enter-username" placeholder="Username..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+      <input id="static-username" ng-model="username" class="apiman-form-control form-control" style="width: 85px; float: left; margin-right: 5px" type="text" apiman-i18n-key="basic-auth.enter-username" placeholder="Username..." ng-disabled="isEntityDisabled()"></input>
       <div style="width: 8px; float: left; line-height: 28px" apiman-i18n-skip>:</div>
-      <input id="static-password" ng-model="password" class="apiman-form-control form-control" style="width: 102px; float: left; margin-right: 5px" type="password" apiman-i18n-key="basic-auth.enter-password" placeholder="Password..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
-      <button id="static-add" ng-disabled="!username || !password || getEntityStatus() !== ('Ready' || 'Created')" ng-click="add(username, password)" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
+      <input id="static-password" ng-model="password" class="apiman-form-control form-control" style="width: 102px; float: left; margin-right: 5px" type="password" apiman-i18n-key="basic-auth.enter-password" placeholder="Password..." ng-disabled="isEntityDisabled()"></input>
+      <button id="static-add" ng-disabled="!username || !password || isEntityDisabled()" ng-click="add(username, password)" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
     </div>
   </div>
 
@@ -67,15 +67,15 @@
       <dl>
         <dt apiman-i18n-key="jdbc-datasource">JDBC Datasource (JNDI Location)</dt>
         <dd>
-          <input id="jdbc-datasource" ng-model="config.jdbcIdentity.datasourcePath" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-jndi-loc" placeholder="JNDI Datasource location (example: jdbc/ExampleDS)" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+          <input id="jdbc-datasource" ng-model="config.jdbcIdentity.datasourcePath" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-jndi-loc" placeholder="JNDI Datasource location (example: jdbc/ExampleDS)" ng-disabled="isEntityDisabled()"></input>
         </dd>
         <dt apiman-i18n-key="jdbc-query">SQL Query</dt>
         <dd>
-          <textarea id="jdbc-query" ng-model="config.jdbcIdentity.query" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-sql-query" placeholder="SQL Query (example: SELECT * FROM users WHERE u=? AND p=?)" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></textarea>
+          <textarea id="jdbc-query" ng-model="config.jdbcIdentity.query" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-sql-query" placeholder="SQL Query (example: SELECT * FROM users WHERE u=? AND p=?)" ng-disabled="isEntityDisabled()"></textarea>
         </dd>
         <dt apiman-i18n-key="jdbc-hash-algorithm">Password Hash Algorithm</dt>
         <dd>
-          <select id="jdbc-pwd-hash" ng-model="config.jdbcIdentity.hashAlgorithm" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+          <select id="jdbc-pwd-hash" ng-model="config.jdbcIdentity.hashAlgorithm" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="isEntityDisabled()">
             <option value="None" apiman-i18n-key="basic-auth.none">None</option>
             <option value="SHA1" apiman-i18n-key="basic-auth.sha1">SHA1</option>
             <option value="MD5" apiman-i18n-key="basic-auth.md5">MD5</option>
@@ -85,12 +85,12 @@
           </select>
         </dd>
         <dd>
-          <input id="jdbc-extract-roles" type="checkbox" ng-model="config.jdbcIdentity.extractRoles" style="margin-top: 15px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+          <input id="jdbc-extract-roles" type="checkbox" ng-model="config.jdbcIdentity.extractRoles" style="margin-top: 15px" ng-disabled="isEntityDisabled()"></input>
           <label for="jdbc-extract-roles" apiman-i18n-key="basic-auth.extract-jdbc-roles" title="When enabled, roles can also be extracted from the database for use in the Authorization Policy (sold separately).">Also extract user roles from the DB</label>
         </dd>
         <dt ng-show="config.jdbcIdentity.extractRoles == true" apiman-i18n-key="roles-sql-query">Roles SQL Query</dt>
         <dd ng-show="config.jdbcIdentity.extractRoles == true">
-          <textarea id="jdbc-role-query" ng-model="config.jdbcIdentity.roleQuery" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-role-sql-query" placeholder="Role SQL Query (example: SELECT r.rolename FROM roles r WHERE r.user=?)" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></textarea>
+          <textarea id="jdbc-role-query" ng-model="config.jdbcIdentity.roleQuery" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ds.enter-role-sql-query" placeholder="Role SQL Query (example: SELECT r.rolename FROM roles r WHERE r.user=?)" ng-disabled="isEntityDisabled()"></textarea>
         </dd>
       </dl>
     </div>
@@ -102,15 +102,15 @@
       <dl>
         <dt apiman-i18n-key="ldap-server-url">LDAP Server URL</dt>
         <dd>
-          <input id="ldap-url" ng-model="config.ldapIdentity.url" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-url" placeholder="LDAP Url (example: ldap://example.org)" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+          <input id="ldap-url" ng-model="config.ldapIdentity.url" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-url" placeholder="LDAP Url (example: ldap://example.org)" ng-disabled="isEntityDisabled()"></input>
         </dd>
         <dt apiman-i18n-key="ldap-bind-dn">LDAP Bind DN</dt>
         <dd>
-          <input id="ldap-bind-dn" ng-model="config.ldapIdentity.dnPattern" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-binddn" placeholder="LDAP Bind DN (example: cn=${username},dc=overlord,dc=org)" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+          <input id="ldap-bind-dn" ng-model="config.ldapIdentity.dnPattern" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-binddn" placeholder="LDAP Bind DN (example: cn=${username},dc=overlord,dc=org)" ng-disabled="isEntityDisabled()"></input>
         </dd>
         <dt apiman-i18n-key="bind-as">Bind to LDAP As...</dt>
         <dd>
-          <select id="ldap-bind-as" ng-model="config.ldapIdentity.bindAs" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+          <select id="ldap-bind-as" ng-model="config.ldapIdentity.bindAs" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="isEntityDisabled()">
             <option selected="selected" value="UserAccount" apiman-i18n-key="ldap-auth.inbound-user">The inbound user</option>
             <option value="ServiceAccount" apiman-i18n-key="ldap-auth.service-account">A service account</option>
           </select>
@@ -118,33 +118,33 @@
         <div ng-show="config.ldapIdentity.bindAs == 'ServiceAccount'" style="margin-top: 15px">
 	        <dt apiman-i18n-key="service-account-username">Service Account Username</dt>
 	        <dd>
-	          <input id="ldap-sa-username" ng-model="config.ldapIdentity.credentials.username" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.credentials.username" placeholder="Enter a username..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+	          <input id="ldap-sa-username" ng-model="config.ldapIdentity.credentials.username" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.credentials.username" placeholder="Enter a username..." ng-disabled="isEntityDisabled()"></input>
 	        </dd>
 	        <dt apiman-i18n-key="service-account-password">Service Account Password</dt>
 	        <dd>
-	          <input id="ldap-sa-pass" ng-model="config.ldapIdentity.credentials.password" class="apiman-form-control form-control" type="password" apiman-i18n-key="basic-auth.ldap.credentials.password" placeholder="Enter a password..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
-              <input id="ldap-sa-pass-confirm" style="margin-top: 3px" ng-model="repeatPassword" class="apiman-form-control form-control" type="password" apiman-i18n-key="basic-auth.ldap.credentials.repeat-password" placeholder="Repeat password" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+	          <input id="ldap-sa-pass" ng-model="config.ldapIdentity.credentials.password" class="apiman-form-control form-control" type="password" apiman-i18n-key="basic-auth.ldap.credentials.password" placeholder="Enter a password..." ng-disabled="isEntityDisabled()"></input>
+              <input id="ldap-sa-pass-confirm" style="margin-top: 3px" ng-model="repeatPassword" class="apiman-form-control form-control" type="password" apiman-i18n-key="basic-auth.ldap.credentials.repeat-password" placeholder="Repeat password" ng-disabled="isEntityDisabled()"></input>
 	        </dd>
             <dt apiman-i18n-key="user-search-base-dn">User Search Base DN</dt>
             <dd>
-              <input id="ldap-us-base-dn" ng-model="config.ldapIdentity.userSearch.baseDn" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.userSearch.baseDn" placeholder="Enter a Base DN..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+              <input id="ldap-us-base-dn" ng-model="config.ldapIdentity.userSearch.baseDn" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.userSearch.baseDn" placeholder="Enter a Base DN..." ng-disabled="isEntityDisabled()"></input>
             </dd>
             <dt apiman-i18n-key="user-search-expression">User Search Expression</dt>
             <dd>
-              <input id="ldap-us-expr" ng-model="config.ldapIdentity.userSearch.expression" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.userSearch.expression" placeholder="Enter an expression..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+              <input id="ldap-us-expr" ng-model="config.ldapIdentity.userSearch.expression" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.userSearch.expression" placeholder="Enter an expression..." ng-disabled="isEntityDisabled()"></input>
             </dd>
         </div>
         <dd>
-          <input id="ldap-extract-roles" type="checkbox" ng-model="config.ldapIdentity.extractRoles" style="margin-top: 15px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+          <input id="ldap-extract-roles" type="checkbox" ng-model="config.ldapIdentity.extractRoles" style="margin-top: 15px" ng-disabled="isEntityDisabled()"></input>
           <label for="ldap-extract-roles" apiman-i18n-key="basic-auth.extract-ldap-roles" title="When enabled, roles can also be extracted from the directory for use in the Authorization Policy (sold separately).">Also extract user roles from the directory</label>
         </dd>
         <dt ng-show="config.ldapIdentity.extractRoles == true" apiman-i18n-key="ldap-membership-attr">Group Membership Attribute</dt>
         <dd ng-show="config.ldapIdentity.extractRoles == true">
-          <input id="ldap-group-attr" ng-model="config.ldapIdentity.membershipAttribute" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-membership-attr" placeholder="memberOf" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+          <input id="ldap-group-attr" ng-model="config.ldapIdentity.membershipAttribute" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-membership-attr" placeholder="memberOf" ng-disabled="isEntityDisabled()"></input>
         </dd>
         <dt ng-show="config.ldapIdentity.extractRoles == true" apiman-i18n-key="ldap-rolename-attr">Role Name Attribute</dt>
         <dd ng-show="config.ldapIdentity.extractRoles == true">
-          <input id="ldap-role-name-attr" ng-model="config.ldapIdentity.rolenameAttribute" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-rolename-attr" placeholder="objectGUID" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+          <input id="ldap-role-name-attr" ng-model="config.ldapIdentity.rolenameAttribute" class="apiman-form-control form-control" type="text" apiman-i18n-key="basic-auth.ldap.enter-rolename-attr" placeholder="objectGUID" ng-disabled="isEntityDisabled()"></input>
         </dd>
       </dl>
     </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/caching.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/caching.include
@@ -1,7 +1,7 @@
 <div class="form policy-config caching" data-field="form" ng-controller="Apiman.CachingFormController" style="margin-top: 10px">
   <div>
     <span apiman-i18n-key="caching.config-sentence-preamble">Cache API responses for</span>
-    <input id="ttl" ng-model="config.ttl" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 150px" type="text" apiman-i18n-key="caching.enter-num-seconds" placeholder="Enter time-to-live" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+    <input id="ttl" ng-model="config.ttl" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 150px" type="text" apiman-i18n-key="caching.enter-num-seconds" placeholder="Enter time-to-live" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
     <span apiman-i18n-key="caching.seconds">seconds.</span>
   </div>
 </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/caching.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/caching.include
@@ -1,7 +1,7 @@
 <div class="form policy-config caching" data-field="form" ng-controller="Apiman.CachingFormController" style="margin-top: 10px">
   <div>
     <span apiman-i18n-key="caching.config-sentence-preamble">Cache API responses for</span>
-    <input id="ttl" ng-model="config.ttl" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 150px" type="text" apiman-i18n-key="caching.enter-num-seconds" placeholder="Enter time-to-live"></input>
+    <input id="ttl" ng-model="config.ttl" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 150px" type="text" apiman-i18n-key="caching.enter-num-seconds" placeholder="Enter time-to-live" ng-disabled="getEntityStatus() !== 'Ready'"></input>
     <span apiman-i18n-key="caching.seconds">seconds.</span>
   </div>
 </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/caching.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/caching.include
@@ -1,7 +1,7 @@
 <div class="form policy-config caching" data-field="form" ng-controller="Apiman.CachingFormController" style="margin-top: 10px">
   <div>
     <span apiman-i18n-key="caching.config-sentence-preamble">Cache API responses for</span>
-    <input id="ttl" ng-model="config.ttl" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 150px" type="text" apiman-i18n-key="caching.enter-num-seconds" placeholder="Enter time-to-live" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+    <input id="ttl" ng-model="config.ttl" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 150px" type="text" apiman-i18n-key="caching.enter-num-seconds" placeholder="Enter time-to-live" ng-disabled="isEntityDisabled()"></input>
     <span apiman-i18n-key="caching.seconds">seconds.</span>
   </div>
 </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/ignored-resources.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/ignored-resources.include
@@ -1,14 +1,14 @@
 <div class="form policy-config ip-list" data-field="form" ng-controller="Apiman.IgnoredResourcesFormController">
   <div apiman-i18n-key="ignored-resources-message">Manage the list of regular expressions to be ignored in the box below.</div>
   <div style="width: 100%; float: left; margin-bottom: 5px; margin-top: 5px">
-    <select id="paths" ng-model="selectedPath" data-field="pathsToIgnore" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="item for item in config.pathsToIgnore | orderBy: 'toString()'" ng-disabled="getEntityStatus() !== 'Ready'">
+    <select id="paths" ng-model="selectedPath" data-field="pathsToIgnore" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="item for item in config.pathsToIgnore | orderBy: 'toString()'" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
     </select>
     <div style="margin-left: 5px; float: left">
-      <button id="clear" ng-click="clear()" ng-disabled="!config.pathsToIgnore || getEntityStatus() !== 'Ready'" data-field="clear" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
+      <button id="clear" ng-click="clear()" ng-disabled="!config.pathsToIgnore || getEntityStatus() !== ('Ready' || 'Created')" data-field="clear" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
       <div class="clear:both"></div>
-      <button id="remove" ng-click="remove(selectedPath)" ng-disabled="!selectedPath" data-field="remove" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;" ng-disabled="getEntityStatus() !== 'Ready'">Remove</button>
+      <button id="remove" ng-click="remove(selectedPath)" ng-disabled="!selectedPath || getEntityStatus() !== ('Ready' || 'Created')" data-field="remove" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;">Remove</button>
     </div>
   </div>
-  <input id="path" ng-model="path" data-field="pathToIgnore" class="apiman-form-control form-control" style="width: 200px; float: left; margin-right: 5px" type="text" apiman-i18n-key="ignored-resources.enter-path" placeholder="Enter a Path to ignore..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
-  <button id="add" ng-disabled="!path" ng-click="add(path)" data-field="add" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
+  <input id="path" ng-model="path" data-field="pathToIgnore" class="apiman-form-control form-control" style="width: 200px; float: left; margin-right: 5px" type="text" apiman-i18n-key="ignored-resources.enter-path" placeholder="Enter a Path to ignore..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+  <button id="add" ng-disabled="!path || getEntityStatus() !== ('Ready' || 'Created')" ng-click="add(path)" data-field="add" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
 </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/ignored-resources.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/ignored-resources.include
@@ -1,14 +1,14 @@
 <div class="form policy-config ip-list" data-field="form" ng-controller="Apiman.IgnoredResourcesFormController">
   <div apiman-i18n-key="ignored-resources-message">Manage the list of regular expressions to be ignored in the box below.</div>
   <div style="width: 100%; float: left; margin-bottom: 5px; margin-top: 5px">
-    <select id="paths" ng-model="selectedPath" data-field="pathsToIgnore" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="item for item in config.pathsToIgnore | orderBy: 'toString()'">
+    <select id="paths" ng-model="selectedPath" data-field="pathsToIgnore" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="item for item in config.pathsToIgnore | orderBy: 'toString()'" ng-disabled="getEntityStatus() !== 'Ready'">
     </select>
     <div style="margin-left: 5px; float: left">
-      <button id="clear" ng-click="clear()" ng-disabled="!config.pathsToIgnore" data-field="clear" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
+      <button id="clear" ng-click="clear()" ng-disabled="!config.pathsToIgnore || getEntityStatus() !== 'Ready'" data-field="clear" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
       <div class="clear:both"></div>
-      <button id="remove" ng-click="remove(selectedPath)" ng-disabled="!selectedPath" data-field="remove" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;">Remove</button>
+      <button id="remove" ng-click="remove(selectedPath)" ng-disabled="!selectedPath" data-field="remove" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;" ng-disabled="getEntityStatus() !== 'Ready'">Remove</button>
     </div>
   </div>
-  <input id="path" ng-model="path" data-field="pathToIgnore" class="apiman-form-control form-control" style="width: 200px; float: left; margin-right: 5px" type="text" apiman-i18n-key="ignored-resources.enter-path" placeholder="Enter a Path to ignore..."></input>
+  <input id="path" ng-model="path" data-field="pathToIgnore" class="apiman-form-control form-control" style="width: 200px; float: left; margin-right: 5px" type="text" apiman-i18n-key="ignored-resources.enter-path" placeholder="Enter a Path to ignore..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
   <button id="add" ng-disabled="!path" ng-click="add(path)" data-field="add" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
 </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/ignored-resources.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/ignored-resources.include
@@ -1,14 +1,14 @@
 <div class="form policy-config ip-list" data-field="form" ng-controller="Apiman.IgnoredResourcesFormController">
   <div apiman-i18n-key="ignored-resources-message">Manage the list of regular expressions to be ignored in the box below.</div>
   <div style="width: 100%; float: left; margin-bottom: 5px; margin-top: 5px">
-    <select id="paths" ng-model="selectedPath" data-field="pathsToIgnore" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="item for item in config.pathsToIgnore | orderBy: 'toString()'" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+    <select id="paths" ng-model="selectedPath" data-field="pathsToIgnore" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="item for item in config.pathsToIgnore | orderBy: 'toString()'" ng-disabled="isEntityDisabled()">
     </select>
     <div style="margin-left: 5px; float: left">
-      <button id="clear" ng-click="clear()" ng-disabled="!config.pathsToIgnore || getEntityStatus() !== ('Ready' || 'Created')" data-field="clear" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
+      <button id="clear" ng-click="clear()" ng-disabled="!config.pathsToIgnore || isEntityDisabled()" data-field="clear" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
       <div class="clear:both"></div>
-      <button id="remove" ng-click="remove(selectedPath)" ng-disabled="!selectedPath || getEntityStatus() !== ('Ready' || 'Created')" data-field="remove" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;">Remove</button>
+      <button id="remove" ng-click="remove(selectedPath)" ng-disabled="!selectedPath || isEntityDisabled()" data-field="remove" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;">Remove</button>
     </div>
   </div>
-  <input id="path" ng-model="path" data-field="pathToIgnore" class="apiman-form-control form-control" style="width: 200px; float: left; margin-right: 5px" type="text" apiman-i18n-key="ignored-resources.enter-path" placeholder="Enter a Path to ignore..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
-  <button id="add" ng-disabled="!path || getEntityStatus() !== ('Ready' || 'Created')" ng-click="add(path)" data-field="add" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
+  <input id="path" ng-model="path" data-field="pathToIgnore" class="apiman-form-control form-control" style="width: 200px; float: left; margin-right: 5px" type="text" apiman-i18n-key="ignored-resources.enter-path" placeholder="Enter a Path to ignore..." ng-disabled="isEntityDisabled()"></input>
+  <button id="add" ng-disabled="!path || isEntityDisabled()" ng-click="add(path)" data-field="add" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
 </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/ip-list.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/ip-list.include
@@ -3,12 +3,12 @@
     <dl style="margin-bottom: 0px">
       <dt apiman-i18n-key="ip-http-header">IP Address HTTP Header</dt>
       <dd>
-        <input id="http-header" ng-model="config.httpHeader" data-field="httpHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="iplist.enter-http-header" placeholder="HTTP header (optional)..."></input>
+        <input id="http-header" ng-model="config.httpHeader" data-field="httpHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="iplist.enter-http-header" placeholder="HTTP header (optional)..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
       </dd>
       <dt apiman-i18n-key="failure-code">Failure Response</dt>
       <dd>
         <p apiman-i18n-key="ip-list.response-code-explanation">Choose how apiman should respond to a client if the request fails due to a violation of this policy.</p>
-        <select id="failure-code" ng-model="config.responseCode" apiman-select-picker="" class="selectpicker" data-live-search="false">
+        <select id="failure-code" ng-model="config.responseCode" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== 'Ready'">
           <option value="403" apiman-i18n-key="ip-list.auth-failure-403">Authentication Failure (403)</option>
           <option value="404" apiman-i18n-key="ip-list.not-found-404">Not Found (404)</option>
           <option value="500" apiman-i18n-key="ip-list.server-error-500">Server Error (500)</option>
@@ -19,14 +19,14 @@
   </div>
   <div style="width: 300px" apiman-i18n-key="ip-list-message">Manage the list of IP addresses in the box below.  Wildcards can be used by specifying "*" as one of the components of the IP address, such as "10.0.*.*".</div>
   <div style="width: 100%; float: left; margin-bottom: 5px; margin-top: 5px">
-    <select id="ip-addresses" ng-model="selectedIP" data-field="ipAddresses" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="item for item in config.ipList | orderBy: 'toString()'">
+    <select id="ip-addresses" ng-model="selectedIP" data-field="ipAddresses" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="item for item in config.ipList | orderBy: 'toString()'" ng-disabled="getEntityStatus() !== 'Ready'">
     </select>
     <div style="margin-left: 5px; float: left">
-      <button id="clear" ng-click="clear()" ng-disabled="!config.ipList" data-field="clear" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
+      <button id="clear" ng-click="clear()" ng-disabled="!config.ipList || getEntityStatus() !== 'Ready'" data-field="clear" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
       <div class="clear:both"></div>
-      <button id="remove" ng-click="remove(selectedIP)" ng-disabled="!selectedIP" data-field="remove" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;">Remove</button>
+      <button id="remove" ng-click="remove(selectedIP)" ng-disabled="!selectedIP || getEntityStatus() !== 'Ready'" data-field="remove" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;">Remove</button>
     </div>
   </div>
-  <input id="ip-address" ng-model="ipAddress" ng-pattern="/((^\s*(((?:\*|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\.){3}(?:\*|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])))\s*$))/" data-field="ipAddress" class="apiman-form-control form-control" style="width: 200px; float: left; margin-right: 5px" type="text" apiman-i18n-key="iplist.enter-ip-address" placeholder="Enter an IP address..."></input>
-  <button id="add" ng-disabled="!ipAddress" ng-click="add(ipAddress)" data-field="add" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
+  <input id="ip-address" ng-model="ipAddress" ng-pattern="/((^\s*(((?:\*|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\.){3}(?:\*|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])))\s*$))/" data-field="ipAddress" class="apiman-form-control form-control" style="width: 200px; float: left; margin-right: 5px" type="text" apiman-i18n-key="iplist.enter-ip-address" placeholder="Enter an IP address..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
+  <button id="add" ng-disabled="!ipAddress || getEntityStatus() !== 'Ready'" ng-click="add(ipAddress)" data-field="add" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
 </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/ip-list.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/ip-list.include
@@ -3,12 +3,12 @@
     <dl style="margin-bottom: 0px">
       <dt apiman-i18n-key="ip-http-header">IP Address HTTP Header</dt>
       <dd>
-        <input id="http-header" ng-model="config.httpHeader" data-field="httpHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="iplist.enter-http-header" placeholder="HTTP header (optional)..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <input id="http-header" ng-model="config.httpHeader" data-field="httpHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="iplist.enter-http-header" placeholder="HTTP header (optional)..." ng-disabled="isEntityDisabled()"></input>
       </dd>
       <dt apiman-i18n-key="failure-code">Failure Response</dt>
       <dd>
         <p apiman-i18n-key="ip-list.response-code-explanation">Choose how apiman should respond to a client if the request fails due to a violation of this policy.</p>
-        <select id="failure-code" ng-model="config.responseCode" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+        <select id="failure-code" ng-model="config.responseCode" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="isEntityDisabled()">
           <option value="403" apiman-i18n-key="ip-list.auth-failure-403">Authentication Failure (403)</option>
           <option value="404" apiman-i18n-key="ip-list.not-found-404">Not Found (404)</option>
           <option value="500" apiman-i18n-key="ip-list.server-error-500">Server Error (500)</option>
@@ -19,14 +19,14 @@
   </div>
   <div style="width: 300px" apiman-i18n-key="ip-list-message">Manage the list of IP addresses in the box below.  Wildcards can be used by specifying "*" as one of the components of the IP address, such as "10.0.*.*".</div>
   <div style="width: 100%; float: left; margin-bottom: 5px; margin-top: 5px">
-    <select id="ip-addresses" ng-model="selectedIP" data-field="ipAddresses" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="item for item in config.ipList | orderBy: 'toString()'" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+    <select id="ip-addresses" ng-model="selectedIP" data-field="ipAddresses" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="item for item in config.ipList | orderBy: 'toString()'" ng-disabled="isEntityDisabled()">
     </select>
     <div style="margin-left: 5px; float: left">
-      <button id="clear" ng-click="clear()" ng-disabled="!config.ipList || getEntityStatus() !== ('Ready' || 'Created')" data-field="clear" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
+      <button id="clear" ng-click="clear()" ng-disabled="!config.ipList || isEntityDisabled()" data-field="clear" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
       <div class="clear:both"></div>
-      <button id="remove" ng-click="remove(selectedIP)" ng-disabled="!selectedIP || getEntityStatus() !== ('Ready' || 'Created')" data-field="remove" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;">Remove</button>
+      <button id="remove" ng-click="remove(selectedIP)" ng-disabled="!selectedIP || isEntityDisabled()" data-field="remove" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;">Remove</button>
     </div>
   </div>
-  <input id="ip-address" ng-model="ipAddress" ng-pattern="/((^\s*(((?:\*|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\.){3}(?:\*|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])))\s*$))/" data-field="ipAddress" class="apiman-form-control form-control" style="width: 200px; float: left; margin-right: 5px" type="text" apiman-i18n-key="iplist.enter-ip-address" placeholder="Enter an IP address..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
-  <button id="add" ng-disabled="!ipAddress || getEntityStatus() !== ('Ready' || 'Created')" ng-click="add(ipAddress)" data-field="add" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
+  <input id="ip-address" ng-model="ipAddress" ng-pattern="/((^\s*(((?:\*|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\.){3}(?:\*|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])))\s*$))/" data-field="ipAddress" class="apiman-form-control form-control" style="width: 200px; float: left; margin-right: 5px" type="text" apiman-i18n-key="iplist.enter-ip-address" placeholder="Enter an IP address..." ng-disabled="isEntityDisabled()"></input>
+  <button id="add" ng-disabled="!ipAddress || isEntityDisabled()" ng-click="add(ipAddress)" data-field="add" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
 </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/ip-list.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/ip-list.include
@@ -3,12 +3,12 @@
     <dl style="margin-bottom: 0px">
       <dt apiman-i18n-key="ip-http-header">IP Address HTTP Header</dt>
       <dd>
-        <input id="http-header" ng-model="config.httpHeader" data-field="httpHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="iplist.enter-http-header" placeholder="HTTP header (optional)..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <input id="http-header" ng-model="config.httpHeader" data-field="httpHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="iplist.enter-http-header" placeholder="HTTP header (optional)..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
       </dd>
       <dt apiman-i18n-key="failure-code">Failure Response</dt>
       <dd>
         <p apiman-i18n-key="ip-list.response-code-explanation">Choose how apiman should respond to a client if the request fails due to a violation of this policy.</p>
-        <select id="failure-code" ng-model="config.responseCode" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== 'Ready'">
+        <select id="failure-code" ng-model="config.responseCode" apiman-select-picker="" class="selectpicker" data-live-search="false" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
           <option value="403" apiman-i18n-key="ip-list.auth-failure-403">Authentication Failure (403)</option>
           <option value="404" apiman-i18n-key="ip-list.not-found-404">Not Found (404)</option>
           <option value="500" apiman-i18n-key="ip-list.server-error-500">Server Error (500)</option>
@@ -19,14 +19,14 @@
   </div>
   <div style="width: 300px" apiman-i18n-key="ip-list-message">Manage the list of IP addresses in the box below.  Wildcards can be used by specifying "*" as one of the components of the IP address, such as "10.0.*.*".</div>
   <div style="width: 100%; float: left; margin-bottom: 5px; margin-top: 5px">
-    <select id="ip-addresses" ng-model="selectedIP" data-field="ipAddresses" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="item for item in config.ipList | orderBy: 'toString()'" ng-disabled="getEntityStatus() !== 'Ready'">
+    <select id="ip-addresses" ng-model="selectedIP" data-field="ipAddresses" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="item for item in config.ipList | orderBy: 'toString()'" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
     </select>
     <div style="margin-left: 5px; float: left">
-      <button id="clear" ng-click="clear()" ng-disabled="!config.ipList || getEntityStatus() !== 'Ready'" data-field="clear" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
+      <button id="clear" ng-click="clear()" ng-disabled="!config.ipList || getEntityStatus() !== ('Ready' || 'Created')" data-field="clear" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
       <div class="clear:both"></div>
-      <button id="remove" ng-click="remove(selectedIP)" ng-disabled="!selectedIP || getEntityStatus() !== 'Ready'" data-field="remove" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;">Remove</button>
+      <button id="remove" ng-click="remove(selectedIP)" ng-disabled="!selectedIP || getEntityStatus() !== ('Ready' || 'Created')" data-field="remove" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;">Remove</button>
     </div>
   </div>
-  <input id="ip-address" ng-model="ipAddress" ng-pattern="/((^\s*(((?:\*|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\.){3}(?:\*|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])))\s*$))/" data-field="ipAddress" class="apiman-form-control form-control" style="width: 200px; float: left; margin-right: 5px" type="text" apiman-i18n-key="iplist.enter-ip-address" placeholder="Enter an IP address..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
-  <button id="add" ng-disabled="!ipAddress || getEntityStatus() !== 'Ready'" ng-click="add(ipAddress)" data-field="add" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
+  <input id="ip-address" ng-model="ipAddress" ng-pattern="/((^\s*(((?:\*|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\.){3}(?:\*|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])))\s*$))/" data-field="ipAddress" class="apiman-form-control form-control" style="width: 200px; float: left; margin-right: 5px" type="text" apiman-i18n-key="iplist.enter-ip-address" placeholder="Enter an IP address..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+  <button id="add" ng-disabled="!ipAddress || getEntityStatus() !== ('Ready' || 'Created')" ng-click="add(ipAddress)" data-field="add" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
 </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/quota.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/quota.include
@@ -1,15 +1,15 @@
 <div class="form policy-config quota" data-field="form" ng-controller="Apiman.QuotaFormController" style="margin-top: 10px">
   <div>
     <span apiman-i18n-key="quota.config-sentence-preamble">I want to set a quota of </span>
-    <input id="num-requests" ng-model="config.limit" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 100px" type="text" apiman-i18n-key="quota.enter-num-requests" placeholder="# of requests"></input>
+    <input id="num-requests" ng-model="config.limit" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 100px" type="text" apiman-i18n-key="quota.enter-num-requests" placeholder="# of requests" ng-disabled="getEntityStatus() !== 'Ready'"></input>
     <span apiman-i18n-key="quota.requests-per">requests per</span>
-    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" data-field="granularity" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px">
+    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" data-field="granularity" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== 'Ready'">
       <option value="" data-content="<span class='apiman-label-faded'>Granularity</span>" apiman-i18n-key="granularity">Granularity</option>
       <option value="Application" apiman-i18n-key="quota.application">Application</option>
       <option value="User" apiman-i18n-key="quota.user">User</option>
     </select>
     <span apiman-i18n-key="per">per</span>
-    <select id="period" ng-model="config.period" apiman-select-picker="" data-field="period" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px">
+    <select id="period" ng-model="config.period" apiman-select-picker="" data-field="period" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== 'Ready'">
       <option value="" data-content="<span class='apiman-label-faded'>Period</span>" apiman-i18n-key="quota.period">Period</option>
       <option value="Day" apiman-i18n-key="quota.day">Day</option>
       <option value="Month" apiman-i18n-key="quota.month">Month</option>
@@ -18,7 +18,7 @@
   </div>
   <div style="margin-top: 8px;" id="userRow" ng-show="config.granularity == 'User'">
     <span apiman-i18n-key="reate-limiting.get-user-id-from">Get the user's id from:</span>
-    <input id="user-header" ng-model="config.userHeader" data-field="userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="quota.enter-user-header" placeholder="Enter header (e.g. X-Identity)..."></input>
+    <input id="user-header" ng-model="config.userHeader" data-field="userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="quota.enter-user-header" placeholder="Enter header (e.g. X-Identity)..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
   </div>
   <hr/>
   <div>
@@ -33,15 +33,15 @@
     <dl>
       <dt apiman-i18n-key="quota.limit-header">Limit Response Header</dt>
       <dd>
-        <input id="limit-header" ng-model="config.headerLimit" data-field="limitHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-limit-header" placeholder="X-Quota-Limit"></input>
+        <input id="limit-header" ng-model="config.headerLimit" data-field="limitHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-limit-header" placeholder="X-Quota-Limit" ng-disabled="getEntityStatus() !== 'Ready'"></input>
       </dd>
       <dt apiman-i18n-key="quota.remaining-header">Remaining Response Header</dt>
       <dd>
-        <input id="remaining-header" ng-model="config.headerRemaining" data-field="remainingHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-remaining-header" placeholder="X-Quota-Remaining"></input>
+        <input id="remaining-header" ng-model="config.headerRemaining" data-field="remainingHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-remaining-header" placeholder="X-Quota-Remaining" ng-disabled="getEntityStatus() !== 'Ready'"></input>
       </dd>
       <dt apiman-i18n-key="quota.reset-header">Reset Response Header</dt>
       <dd>
-        <input id="reset-header" ng-model="config.headerReset" data-field="resetHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-reset-header" placeholder="X-Quota-Reset"></input>
+        <input id="reset-header" ng-model="config.headerReset" data-field="resetHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-reset-header" placeholder="X-Quota-Reset" ng-disabled="getEntityStatus() !== 'Ready'"></input>
       </dd>
     </dl>
   </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/quota.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/quota.include
@@ -3,13 +3,13 @@
     <span apiman-i18n-key="quota.config-sentence-preamble">I want to set a quota of </span>
     <input id="num-requests" ng-model="config.limit" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 100px" type="text" apiman-i18n-key="quota.enter-num-requests" placeholder="# of requests" ng-disabled="getEntityStatus() !== 'Ready'"></input>
     <span apiman-i18n-key="quota.requests-per">requests per</span>
-    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" data-field="granularity" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== 'Ready'">
+    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" data-field="granularity" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
       <option value="" data-content="<span class='apiman-label-faded'>Granularity</span>" apiman-i18n-key="granularity">Granularity</option>
       <option value="Application" apiman-i18n-key="quota.application">Application</option>
       <option value="User" apiman-i18n-key="quota.user">User</option>
     </select>
     <span apiman-i18n-key="per">per</span>
-    <select id="period" ng-model="config.period" apiman-select-picker="" data-field="period" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== 'Ready'">
+    <select id="period" ng-model="config.period" apiman-select-picker="" data-field="period" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
       <option value="" data-content="<span class='apiman-label-faded'>Period</span>" apiman-i18n-key="quota.period">Period</option>
       <option value="Day" apiman-i18n-key="quota.day">Day</option>
       <option value="Month" apiman-i18n-key="quota.month">Month</option>
@@ -18,7 +18,7 @@
   </div>
   <div style="margin-top: 8px;" id="userRow" ng-show="config.granularity == 'User'">
     <span apiman-i18n-key="reate-limiting.get-user-id-from">Get the user's id from:</span>
-    <input id="user-header" ng-model="config.userHeader" data-field="userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="quota.enter-user-header" placeholder="Enter header (e.g. X-Identity)..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
+    <input id="user-header" ng-model="config.userHeader" data-field="userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="quota.enter-user-header" placeholder="Enter header (e.g. X-Identity)..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
   </div>
   <hr/>
   <div>
@@ -33,15 +33,15 @@
     <dl>
       <dt apiman-i18n-key="quota.limit-header">Limit Response Header</dt>
       <dd>
-        <input id="limit-header" ng-model="config.headerLimit" data-field="limitHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-limit-header" placeholder="X-Quota-Limit" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <input id="limit-header" ng-model="config.headerLimit" data-field="limitHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-limit-header" placeholder="X-Quota-Limit" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
       </dd>
       <dt apiman-i18n-key="quota.remaining-header">Remaining Response Header</dt>
       <dd>
-        <input id="remaining-header" ng-model="config.headerRemaining" data-field="remainingHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-remaining-header" placeholder="X-Quota-Remaining" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <input id="remaining-header" ng-model="config.headerRemaining" data-field="remainingHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-remaining-header" placeholder="X-Quota-Remaining" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
       </dd>
       <dt apiman-i18n-key="quota.reset-header">Reset Response Header</dt>
       <dd>
-        <input id="reset-header" ng-model="config.headerReset" data-field="resetHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-reset-header" placeholder="X-Quota-Reset" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <input id="reset-header" ng-model="config.headerReset" data-field="resetHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-reset-header" placeholder="X-Quota-Reset" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
       </dd>
     </dl>
   </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/quota.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/quota.include
@@ -1,15 +1,15 @@
 <div class="form policy-config quota" data-field="form" ng-controller="Apiman.QuotaFormController" style="margin-top: 10px">
   <div>
     <span apiman-i18n-key="quota.config-sentence-preamble">I want to set a quota of </span>
-    <input id="num-requests" ng-model="config.limit" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 100px" type="text" apiman-i18n-key="quota.enter-num-requests" placeholder="# of requests" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+    <input id="num-requests" ng-model="config.limit" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 100px" type="text" apiman-i18n-key="quota.enter-num-requests" placeholder="# of requests" ng-disabled="isEntityDisabled()"></input>
     <span apiman-i18n-key="quota.requests-per">requests per</span>
-    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" data-field="granularity" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" data-field="granularity" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="isEntityDisabled()">
       <option value="" data-content="<span class='apiman-label-faded'>Granularity</span>" apiman-i18n-key="granularity">Granularity</option>
       <option value="Application" apiman-i18n-key="quota.application">Application</option>
       <option value="User" apiman-i18n-key="quota.user">User</option>
     </select>
     <span apiman-i18n-key="per">per</span>
-    <select id="period" ng-model="config.period" apiman-select-picker="" data-field="period" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+    <select id="period" ng-model="config.period" apiman-select-picker="" data-field="period" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="isEntityDisabled()">
       <option value="" data-content="<span class='apiman-label-faded'>Period</span>" apiman-i18n-key="quota.period">Period</option>
       <option value="Day" apiman-i18n-key="quota.day">Day</option>
       <option value="Month" apiman-i18n-key="quota.month">Month</option>
@@ -18,7 +18,7 @@
   </div>
   <div style="margin-top: 8px;" id="userRow" ng-show="config.granularity == 'User'">
     <span apiman-i18n-key="reate-limiting.get-user-id-from">Get the user's id from:</span>
-    <input id="user-header" ng-model="config.userHeader" data-field="userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="quota.enter-user-header" placeholder="Enter header (e.g. X-Identity)..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+    <input id="user-header" ng-model="config.userHeader" data-field="userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="quota.enter-user-header" placeholder="Enter header (e.g. X-Identity)..." ng-disabled="isEntityDisabled()"></input>
   </div>
   <hr/>
   <div>
@@ -33,15 +33,15 @@
     <dl>
       <dt apiman-i18n-key="quota.limit-header">Limit Response Header</dt>
       <dd>
-        <input id="limit-header" ng-model="config.headerLimit" data-field="limitHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-limit-header" placeholder="X-Quota-Limit" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <input id="limit-header" ng-model="config.headerLimit" data-field="limitHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-limit-header" placeholder="X-Quota-Limit" ng-disabled="isEntityDisabled()"></input>
       </dd>
       <dt apiman-i18n-key="quota.remaining-header">Remaining Response Header</dt>
       <dd>
-        <input id="remaining-header" ng-model="config.headerRemaining" data-field="remainingHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-remaining-header" placeholder="X-Quota-Remaining" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <input id="remaining-header" ng-model="config.headerRemaining" data-field="remainingHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-remaining-header" placeholder="X-Quota-Remaining" ng-disabled="isEntityDisabled()"></input>
       </dd>
       <dt apiman-i18n-key="quota.reset-header">Reset Response Header</dt>
       <dd>
-        <input id="reset-header" ng-model="config.headerReset" data-field="resetHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-reset-header" placeholder="X-Quota-Reset" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <input id="reset-header" ng-model="config.headerReset" data-field="resetHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="quota.enter-reset-header" placeholder="X-Quota-Reset" ng-disabled="isEntityDisabled()"></input>
       </dd>
     </dl>
   </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/rate-limiting.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/rate-limiting.include
@@ -1,16 +1,16 @@
 <div class="form policy-config rates" data-field="form" ng-controller="Apiman.RateLimitingFormController" style="margin-top: 10px">
   <div>
     <span apiman-i18n-key="config-sentence-preamble">I want to limit request rates to</span>
-    <input id="num-requests" ng-model="config.limit" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 100px" type="text" apiman-i18n-key="rate-limiting.enter-num-requests" placeholder="# of requests"></input>
+    <input id="num-requests" ng-model="config.limit" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 100px" type="text" apiman-i18n-key="rate-limiting.enter-num-requests" placeholder="# of requests" ng-disabled="getEntityStatus() !== 'Ready'"></input>
     <span apiman-i18n-key="requests-per">requests per</span>
-    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" data-field="granularity" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px">
+    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" data-field="granularity" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== 'Ready'">
       <option value="" data-content="<span class='apiman-label-faded'>Granularity</span>" apiman-i18n-key="granularity">Granularity</option>
       <option value="Application" apiman-i18n-key="rate-limiting.application">Application</option>
       <option value="User" apiman-i18n-key="rate-limiting.user">User</option>
       <option value="Service" apiman-i18n-key="rate-limiting.service">Service</option>
     </select>
     <span apiman-i18n-key="per">per</span>
-    <select id="period" ng-model="config.period" apiman-select-picker="" data-field="period" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px">
+    <select id="period" ng-model="config.period" apiman-select-picker="" data-field="period" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== 'Ready'">
       <option value="" data-content="<span class='apiman-label-faded'>Period</span>" apiman-i18n-key="rate-limiting.period">Period</option>
       <option value="Second" apiman-i18n-key="rate-limiting.second">Second</option>
       <option value="Minute" apiman-i18n-key="rate-limiting.minute">Minute</option>
@@ -22,7 +22,7 @@
   </div>
   <div style="margin-top: 8px;" id="userRow" ng-show="config.granularity == 'User'">
     <span apiman-i18n-key="reate-limiting.get-user-id-from">Get the user's id from:</span>
-    <input id="user-header" ng-model="config.userHeader" data-field="userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="rate-limiting.enter-user-header" placeholder="Enter header (e.g. X-Identity)..."></input>
+    <input id="user-header" ng-model="config.userHeader" data-field="userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="rate-limiting.enter-user-header" placeholder="Enter header (e.g. X-Identity)..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
   </div>
   <hr/>
   <div>
@@ -37,15 +37,15 @@
     <dl>
       <dt apiman-i18n-key="rate-limiting.limit-header">Limit Response Header</dt>
       <dd>
-        <input id="limit-header" ng-model="config.headerLimit" data-field="limitHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-limit-header" placeholder="X-RateLimit-Limit"></input>
+        <input id="limit-header" ng-model="config.headerLimit" data-field="limitHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-limit-header" placeholder="X-RateLimit-Limit" ng-disabled="getEntityStatus() !== 'Ready'"></input>
       </dd>
       <dt apiman-i18n-key="rate-limiting.remaining-header">Remaining Response Header</dt>
       <dd>
-        <input id="remaining-header" ng-model="config.headerRemaining" data-field="remainingHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-remaining-header" placeholder="X-RateLimit-Remaining"></input>
+        <input id="remaining-header" ng-model="config.headerRemaining" data-field="remainingHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-remaining-header" placeholder="X-RateLimit-Remaining" ng-disabled="getEntityStatus() !== 'Ready'"></input>
       </dd>
       <dt apiman-i18n-key="rate-limiting.reset-header">Reset Response Header</dt>
       <dd>
-        <input id="reset-header" ng-model="config.headerReset" data-field="resetHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-reset-header" placeholder="X-RateLimit-Reset"></input>
+        <input id="reset-header" ng-model="config.headerReset" data-field="resetHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-reset-header" placeholder="X-RateLimit-Reset" ng-disabled="getEntityStatus() !== 'Ready'"></input>
       </dd>
     </dl>
   </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/rate-limiting.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/rate-limiting.include
@@ -1,16 +1,16 @@
 <div class="form policy-config rates" data-field="form" ng-controller="Apiman.RateLimitingFormController" style="margin-top: 10px">
   <div>
     <span apiman-i18n-key="config-sentence-preamble">I want to limit request rates to</span>
-    <input id="num-requests" ng-model="config.limit" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 100px" type="text" apiman-i18n-key="rate-limiting.enter-num-requests" placeholder="# of requests" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+    <input id="num-requests" ng-model="config.limit" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 100px" type="text" apiman-i18n-key="rate-limiting.enter-num-requests" placeholder="# of requests" ng-disabled="isEntityDisabled()"></input>
     <span apiman-i18n-key="requests-per">requests per</span>
-    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" data-field="granularity" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" data-field="granularity" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="isEntityDisabled()">
       <option value="" data-content="<span class='apiman-label-faded'>Granularity</span>" apiman-i18n-key="granularity">Granularity</option>
       <option value="Application" apiman-i18n-key="rate-limiting.application">Application</option>
       <option value="User" apiman-i18n-key="rate-limiting.user">User</option>
       <option value="Service" apiman-i18n-key="rate-limiting.service">Service</option>
     </select>
     <span apiman-i18n-key="per">per</span>
-    <select id="period" ng-model="config.period" apiman-select-picker="" data-field="period" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+    <select id="period" ng-model="config.period" apiman-select-picker="" data-field="period" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="isEntityDisabled()">
       <option value="" data-content="<span class='apiman-label-faded'>Period</span>" apiman-i18n-key="rate-limiting.period">Period</option>
       <option value="Second" apiman-i18n-key="rate-limiting.second">Second</option>
       <option value="Minute" apiman-i18n-key="rate-limiting.minute">Minute</option>
@@ -22,7 +22,7 @@
   </div>
   <div style="margin-top: 8px;" id="userRow" ng-show="config.granularity == 'User'">
     <span apiman-i18n-key="reate-limiting.get-user-id-from">Get the user's id from:</span>
-    <input id="user-header" ng-model="config.userHeader" data-field="userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="rate-limiting.enter-user-header" placeholder="Enter header (e.g. X-Identity)..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+    <input id="user-header" ng-model="config.userHeader" data-field="userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="rate-limiting.enter-user-header" placeholder="Enter header (e.g. X-Identity)..." ng-disabled="isEntityDisabled()"></input>
   </div>
   <hr/>
   <div>
@@ -37,15 +37,15 @@
     <dl>
       <dt apiman-i18n-key="rate-limiting.limit-header">Limit Response Header</dt>
       <dd>
-        <input id="limit-header" ng-model="config.headerLimit" data-field="limitHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-limit-header" placeholder="X-RateLimit-Limit" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <input id="limit-header" ng-model="config.headerLimit" data-field="limitHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-limit-header" placeholder="X-RateLimit-Limit" ng-disabled="isEntityDisabled()"></input>
       </dd>
       <dt apiman-i18n-key="rate-limiting.remaining-header">Remaining Response Header</dt>
       <dd>
-        <input id="remaining-header" ng-model="config.headerRemaining" data-field="remainingHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-remaining-header" placeholder="X-RateLimit-Remaining" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <input id="remaining-header" ng-model="config.headerRemaining" data-field="remainingHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-remaining-header" placeholder="X-RateLimit-Remaining" ng-disabled="isEntityDisabled()"></input>
       </dd>
       <dt apiman-i18n-key="rate-limiting.reset-header">Reset Response Header</dt>
       <dd>
-        <input id="reset-header" ng-model="config.headerReset" data-field="resetHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-reset-header" placeholder="X-RateLimit-Reset" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <input id="reset-header" ng-model="config.headerReset" data-field="resetHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-reset-header" placeholder="X-RateLimit-Reset" ng-disabled="isEntityDisabled()"></input>
       </dd>
     </dl>
   </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/rate-limiting.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/rate-limiting.include
@@ -1,16 +1,16 @@
 <div class="form policy-config rates" data-field="form" ng-controller="Apiman.RateLimitingFormController" style="margin-top: 10px">
   <div>
     <span apiman-i18n-key="config-sentence-preamble">I want to limit request rates to</span>
-    <input id="num-requests" ng-model="config.limit" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 100px" type="text" apiman-i18n-key="rate-limiting.enter-num-requests" placeholder="# of requests" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+    <input id="num-requests" ng-model="config.limit" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 100px" type="text" apiman-i18n-key="rate-limiting.enter-num-requests" placeholder="# of requests" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
     <span apiman-i18n-key="requests-per">requests per</span>
-    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" data-field="granularity" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== 'Ready'">
+    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" data-field="granularity" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
       <option value="" data-content="<span class='apiman-label-faded'>Granularity</span>" apiman-i18n-key="granularity">Granularity</option>
       <option value="Application" apiman-i18n-key="rate-limiting.application">Application</option>
       <option value="User" apiman-i18n-key="rate-limiting.user">User</option>
       <option value="Service" apiman-i18n-key="rate-limiting.service">Service</option>
     </select>
     <span apiman-i18n-key="per">per</span>
-    <select id="period" ng-model="config.period" apiman-select-picker="" data-field="period" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== 'Ready'">
+    <select id="period" ng-model="config.period" apiman-select-picker="" data-field="period" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
       <option value="" data-content="<span class='apiman-label-faded'>Period</span>" apiman-i18n-key="rate-limiting.period">Period</option>
       <option value="Second" apiman-i18n-key="rate-limiting.second">Second</option>
       <option value="Minute" apiman-i18n-key="rate-limiting.minute">Minute</option>
@@ -22,7 +22,7 @@
   </div>
   <div style="margin-top: 8px;" id="userRow" ng-show="config.granularity == 'User'">
     <span apiman-i18n-key="reate-limiting.get-user-id-from">Get the user's id from:</span>
-    <input id="user-header" ng-model="config.userHeader" data-field="userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="rate-limiting.enter-user-header" placeholder="Enter header (e.g. X-Identity)..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
+    <input id="user-header" ng-model="config.userHeader" data-field="userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="rate-limiting.enter-user-header" placeholder="Enter header (e.g. X-Identity)..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
   </div>
   <hr/>
   <div>
@@ -37,15 +37,15 @@
     <dl>
       <dt apiman-i18n-key="rate-limiting.limit-header">Limit Response Header</dt>
       <dd>
-        <input id="limit-header" ng-model="config.headerLimit" data-field="limitHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-limit-header" placeholder="X-RateLimit-Limit" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <input id="limit-header" ng-model="config.headerLimit" data-field="limitHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-limit-header" placeholder="X-RateLimit-Limit" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
       </dd>
       <dt apiman-i18n-key="rate-limiting.remaining-header">Remaining Response Header</dt>
       <dd>
-        <input id="remaining-header" ng-model="config.headerRemaining" data-field="remainingHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-remaining-header" placeholder="X-RateLimit-Remaining" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <input id="remaining-header" ng-model="config.headerRemaining" data-field="remainingHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-remaining-header" placeholder="X-RateLimit-Remaining" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
       </dd>
       <dt apiman-i18n-key="rate-limiting.reset-header">Reset Response Header</dt>
       <dd>
-        <input id="reset-header" ng-model="config.headerReset" data-field="resetHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-reset-header" placeholder="X-RateLimit-Reset" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <input id="reset-header" ng-model="config.headerReset" data-field="resetHeader" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="rate-limiting.enter-reset-header" placeholder="X-RateLimit-Reset" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
       </dd>
     </dl>
   </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/transfer-quota.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/transfer-quota.include
@@ -11,8 +11,8 @@
   <div>
     <form class="form-inline">
 	    <span apiman-i18n-key="transfer-quota.config-sentence-preamble">I want to set a transfer (data) quota of </span>
-        <input id="num-bytes" ng-model="limitAmount" type="text" class="form-control" style="width: 85px; height: 28px; margin-top: -2px; margin-left: 5px; margin-right: -8px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
-        <select id="denomination" ng-model="limitDenomination" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: auto; margin-left: 0px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+        <input id="num-bytes" ng-model="limitAmount" type="text" class="form-control" style="width: 85px; height: 28px; margin-top: -2px; margin-left: 5px; margin-right: -8px" ng-disabled="isEntityDisabled()"></input>
+        <select id="denomination" ng-model="limitDenomination" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: auto; margin-left: 0px" ng-disabled="isEntityDisabled()">
           <option apiman-i18n-key="transfer-quota.bytes" value="B">B</option>
           <option apiman-i18n-key="transfer-quota.kilobytes" value="KB">KB</option>
           <option apiman-i18n-key="transfer-quota.megabytes" value="MB">MB</option>
@@ -20,7 +20,7 @@
         </select>
 
 	    <span apiman-i18n-key="transfer-quota.of">of</span>
-	    <select id="direction" ng-model="config.direction" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: auto;" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+	    <select id="direction" ng-model="config.direction" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: auto;" ng-disabled="isEntityDisabled()">
 	      <option value="" data-content="<span class='apiman-label-faded'>transfer direction</span>" apiman-i18n-key="transfer-direction">transfer direction</option>
 	      <option apiman-i18n-key="upload" value="upload">upload</option>
 	      <option apiman-i18n-key="download" value="download">download</option>
@@ -28,7 +28,7 @@
 	    </select>
 	    
 	    <span apiman-i18n-key="transfer-quota.per">data per</span>
-	    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+	    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="isEntityDisabled()">
 	      <option value="" data-content="<span class='apiman-label-faded'>Granularity</span>" apiman-i18n-key="granularity">Granularity</option>
 	      <option value="Application" apiman-i18n-key="rate-limiting.application">Application</option>
 	      <option value="User" apiman-i18n-key="rate-limiting.user">User</option>
@@ -36,7 +36,7 @@
 	    </select>
 	    
 	    <span apiman-i18n-key="per">per</span>
-	    <select id="period" ng-model="config.period" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+	    <select id="period" ng-model="config.period" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="isEntityDisabled()">
 	      <option value="" data-content="<span class='apiman-label-faded'>Period</span>" apiman-i18n-key="rate-limiting.period">Period</option>
 	      <option value="Second" apiman-i18n-key="rate-limiting.second">Second</option>
 	      <option value="Minute" apiman-i18n-key="rate-limiting.minute">Minute</option>
@@ -49,7 +49,7 @@
   </div>
   <div style="margin-top: 8px;" id="userRow" ng-show="config.granularity == 'User'">
     <span apiman-i18n-key="reate-limiting.get-user-id-from">Get the user's id from:</span>
-    <input id="user-header" ng-model="config.userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="transfer-quota.enter-user-header" placeholder="Enter header (e.g. X-Identity)..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+    <input id="user-header" ng-model="config.userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="transfer-quota.enter-user-header" placeholder="Enter header (e.g. X-Identity)..." ng-disabled="isEntityDisabled()"></input>
   </div>
   <hr/>
   <div>
@@ -64,15 +64,15 @@
     <dl>
       <dt apiman-i18n-key="transfer-quota.limit-header">Limit Response Header</dt>
       <dd>
-        <input id="limit-header" ng-model="config.headerLimit" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-limit-header" placeholder="X-TransferQuota-Limit" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <input id="limit-header" ng-model="config.headerLimit" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-limit-header" placeholder="X-TransferQuota-Limit" ng-disabled="isEntityDisabled()"></input>
       </dd>
       <dt apiman-i18n-key="transfer-quota.remaining-header">Remaining Response Header</dt>
       <dd>
-        <input id="remaining-header" ng-model="config.headerRemaining" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-remaining-header" placeholder="X-TransferQuota-Remaining" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <input id="remaining-header" ng-model="config.headerRemaining" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-remaining-header" placeholder="X-TransferQuota-Remaining" ng-disabled="isEntityDisabled()"></input>
       </dd>
       <dt apiman-i18n-key="transfer-quota.reset-header">Reset Response Header</dt>
       <dd>
-        <input id="reset-header" ng-model="config.headerReset" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-reset-header" placeholder="X-TransferQuota-Reset" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <input id="reset-header" ng-model="config.headerReset" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-reset-header" placeholder="X-TransferQuota-Reset" ng-disabled="isEntityDisabled()"></input>
       </dd>
     </dl>
   </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/transfer-quota.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/transfer-quota.include
@@ -11,8 +11,8 @@
   <div>
     <form class="form-inline">
 	    <span apiman-i18n-key="transfer-quota.config-sentence-preamble">I want to set a transfer (data) quota of </span>
-        <input id="num-bytes" ng-model="limitAmount" type="text" class="form-control" style="width: 85px; height: 28px; margin-top: -2px; margin-left: 5px; margin-right: -8px"></input>
-        <select id="denomination" ng-model="limitDenomination" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: auto; margin-left: 0px">
+        <input id="num-bytes" ng-model="limitAmount" type="text" class="form-control" style="width: 85px; height: 28px; margin-top: -2px; margin-left: 5px; margin-right: -8px" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <select id="denomination" ng-model="limitDenomination" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: auto; margin-left: 0px" ng-disabled="getEntityStatus() !== 'Ready'">
           <option apiman-i18n-key="transfer-quota.bytes" value="B">B</option>
           <option apiman-i18n-key="transfer-quota.kilobytes" value="KB">KB</option>
           <option apiman-i18n-key="transfer-quota.megabytes" value="MB">MB</option>
@@ -20,7 +20,7 @@
         </select>
 
 	    <span apiman-i18n-key="transfer-quota.of">of</span>
-	    <select id="direction" ng-model="config.direction" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: auto;">
+	    <select id="direction" ng-model="config.direction" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: auto;" ng-disabled="getEntityStatus() !== 'Ready'">
 	      <option value="" data-content="<span class='apiman-label-faded'>transfer direction</span>" apiman-i18n-key="transfer-direction">transfer direction</option>
 	      <option apiman-i18n-key="upload" value="upload">upload</option>
 	      <option apiman-i18n-key="download" value="download">download</option>
@@ -28,7 +28,7 @@
 	    </select>
 	    
 	    <span apiman-i18n-key="transfer-quota.per">data per</span>
-	    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px">
+	    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== 'Ready'">
 	      <option value="" data-content="<span class='apiman-label-faded'>Granularity</span>" apiman-i18n-key="granularity">Granularity</option>
 	      <option value="Application" apiman-i18n-key="rate-limiting.application">Application</option>
 	      <option value="User" apiman-i18n-key="rate-limiting.user">User</option>
@@ -36,7 +36,7 @@
 	    </select>
 	    
 	    <span apiman-i18n-key="per">per</span>
-	    <select id="period" ng-model="config.period" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px">
+	    <select id="period" ng-model="config.period" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== 'Ready'">
 	      <option value="" data-content="<span class='apiman-label-faded'>Period</span>" apiman-i18n-key="rate-limiting.period">Period</option>
 	      <option value="Second" apiman-i18n-key="rate-limiting.second">Second</option>
 	      <option value="Minute" apiman-i18n-key="rate-limiting.minute">Minute</option>
@@ -49,7 +49,7 @@
   </div>
   <div style="margin-top: 8px;" id="userRow" ng-show="config.granularity == 'User'">
     <span apiman-i18n-key="reate-limiting.get-user-id-from">Get the user's id from:</span>
-    <input id="user-header" ng-model="config.userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="transfer-quota.enter-user-header" placeholder="Enter header (e.g. X-Identity)..."></input>
+    <input id="user-header" ng-model="config.userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="transfer-quota.enter-user-header" placeholder="Enter header (e.g. X-Identity)..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
   </div>
   <hr/>
   <div>
@@ -64,15 +64,15 @@
     <dl>
       <dt apiman-i18n-key="transfer-quota.limit-header">Limit Response Header</dt>
       <dd>
-        <input id="limit-header" ng-model="config.headerLimit" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-limit-header" placeholder="X-TransferQuota-Limit"></input>
+        <input id="limit-header" ng-model="config.headerLimit" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-limit-header" placeholder="X-TransferQuota-Limit" ng-disabled="getEntityStatus() !== 'Ready'"></input>
       </dd>
       <dt apiman-i18n-key="transfer-quota.remaining-header">Remaining Response Header</dt>
       <dd>
-        <input id="remaining-header" ng-model="config.headerRemaining" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-remaining-header" placeholder="X-TransferQuota-Remaining"></input>
+        <input id="remaining-header" ng-model="config.headerRemaining" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-remaining-header" placeholder="X-TransferQuota-Remaining" ng-disabled="getEntityStatus() !== 'Ready'"></input>
       </dd>
       <dt apiman-i18n-key="transfer-quota.reset-header">Reset Response Header</dt>
       <dd>
-        <input id="reset-header" ng-model="config.headerReset" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-reset-header" placeholder="X-TransferQuota-Reset"></input>
+        <input id="reset-header" ng-model="config.headerReset" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-reset-header" placeholder="X-TransferQuota-Reset" ng-disabled="getEntityStatus() !== 'Ready'"></input>
       </dd>
     </dl>
   </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/transfer-quota.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/transfer-quota.include
@@ -11,8 +11,8 @@
   <div>
     <form class="form-inline">
 	    <span apiman-i18n-key="transfer-quota.config-sentence-preamble">I want to set a transfer (data) quota of </span>
-        <input id="num-bytes" ng-model="limitAmount" type="text" class="form-control" style="width: 85px; height: 28px; margin-top: -2px; margin-left: 5px; margin-right: -8px" ng-disabled="getEntityStatus() !== 'Ready'"></input>
-        <select id="denomination" ng-model="limitDenomination" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: auto; margin-left: 0px" ng-disabled="getEntityStatus() !== 'Ready'">
+        <input id="num-bytes" ng-model="limitAmount" type="text" class="form-control" style="width: 85px; height: 28px; margin-top: -2px; margin-left: 5px; margin-right: -8px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <select id="denomination" ng-model="limitDenomination" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: auto; margin-left: 0px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
           <option apiman-i18n-key="transfer-quota.bytes" value="B">B</option>
           <option apiman-i18n-key="transfer-quota.kilobytes" value="KB">KB</option>
           <option apiman-i18n-key="transfer-quota.megabytes" value="MB">MB</option>
@@ -20,7 +20,7 @@
         </select>
 
 	    <span apiman-i18n-key="transfer-quota.of">of</span>
-	    <select id="direction" ng-model="config.direction" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: auto;" ng-disabled="getEntityStatus() !== 'Ready'">
+	    <select id="direction" ng-model="config.direction" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: auto;" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
 	      <option value="" data-content="<span class='apiman-label-faded'>transfer direction</span>" apiman-i18n-key="transfer-direction">transfer direction</option>
 	      <option apiman-i18n-key="upload" value="upload">upload</option>
 	      <option apiman-i18n-key="download" value="download">download</option>
@@ -28,7 +28,7 @@
 	    </select>
 	    
 	    <span apiman-i18n-key="transfer-quota.per">data per</span>
-	    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== 'Ready'">
+	    <select id="granularity" ng-model="config.granularity" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
 	      <option value="" data-content="<span class='apiman-label-faded'>Granularity</span>" apiman-i18n-key="granularity">Granularity</option>
 	      <option value="Application" apiman-i18n-key="rate-limiting.application">Application</option>
 	      <option value="User" apiman-i18n-key="rate-limiting.user">User</option>
@@ -36,7 +36,7 @@
 	    </select>
 	    
 	    <span apiman-i18n-key="per">per</span>
-	    <select id="period" ng-model="config.period" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== 'Ready'">
+	    <select id="period" ng-model="config.period" apiman-select-picker="" class="selectpicker inline-line apiman-inline-form-dropdown" data-style="btn-default apiman-inline-form-dropdown" style="width: 100px" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
 	      <option value="" data-content="<span class='apiman-label-faded'>Period</span>" apiman-i18n-key="rate-limiting.period">Period</option>
 	      <option value="Second" apiman-i18n-key="rate-limiting.second">Second</option>
 	      <option value="Minute" apiman-i18n-key="rate-limiting.minute">Minute</option>
@@ -49,7 +49,7 @@
   </div>
   <div style="margin-top: 8px;" id="userRow" ng-show="config.granularity == 'User'">
     <span apiman-i18n-key="reate-limiting.get-user-id-from">Get the user's id from:</span>
-    <input id="user-header" ng-model="config.userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="transfer-quota.enter-user-header" placeholder="Enter header (e.g. X-Identity)..." ng-disabled="getEntityStatus() !== 'Ready'"></input>
+    <input id="user-header" ng-model="config.userHeader" class="apiman-form-control form-control inline-apiman-form-control form-control" style="width: 250px" type="text" apiman-i18n-key="transfer-quota.enter-user-header" placeholder="Enter header (e.g. X-Identity)..." ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
   </div>
   <hr/>
   <div>
@@ -64,15 +64,15 @@
     <dl>
       <dt apiman-i18n-key="transfer-quota.limit-header">Limit Response Header</dt>
       <dd>
-        <input id="limit-header" ng-model="config.headerLimit" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-limit-header" placeholder="X-TransferQuota-Limit" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <input id="limit-header" ng-model="config.headerLimit" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-limit-header" placeholder="X-TransferQuota-Limit" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
       </dd>
       <dt apiman-i18n-key="transfer-quota.remaining-header">Remaining Response Header</dt>
       <dd>
-        <input id="remaining-header" ng-model="config.headerRemaining" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-remaining-header" placeholder="X-TransferQuota-Remaining" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <input id="remaining-header" ng-model="config.headerRemaining" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-remaining-header" placeholder="X-TransferQuota-Remaining" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
       </dd>
       <dt apiman-i18n-key="transfer-quota.reset-header">Reset Response Header</dt>
       <dd>
-        <input id="reset-header" ng-model="config.headerReset" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-reset-header" placeholder="X-TransferQuota-Reset" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <input id="reset-header" ng-model="config.headerReset" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="transfer-quota.enter-reset-header" placeholder="X-TransferQuota-Reset" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
       </dd>
     </dl>
   </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/url-rewriting.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/url-rewriting.include
@@ -10,18 +10,18 @@
       <dt apiman-i18n-key="urlrewriting.how-to-rewrite">How to Rewrite URLs</dt>
       <dd>
         <div apiman-i18n-key="urlrewriting.find-all-1">Find all URLs matching regular expression</div>
-        <input id="fromRegexp" ng-model="config.fromRegex" class="apiman-form-control form-control" type="text" apiman-i18n-key="urlrewriting.enter-from-rgexp" placeholder="Example: https?:\/\/host\.org\/api-endpoint"></input>
+        <input id="fromRegexp" ng-model="config.fromRegex" class="apiman-form-control form-control" type="text" apiman-i18n-key="urlrewriting.enter-from-rgexp" placeholder="Example: https?:\/\/host\.org\/api-endpoint" ng-disabled="getEntityStatus() !== 'Ready'"></input>
         <div apiman-i18n-key="urlrewriting.find-all-2">with this replacement</div>
-        <input id="toReplacement" ng-model="config.toReplacement" class="apiman-form-control form-control" type="text" apiman-i18n-key="urlrewriting.enter-to-replacement" placeholder="Example: https:\/\/apiman\.org\/orgId/serviceId/version"></input>
+        <input id="toReplacement" ng-model="config.toReplacement" class="apiman-form-control form-control" type="text" apiman-i18n-key="urlrewriting.enter-to-replacement" placeholder="Example: https:\/\/apiman\.org\/orgId/serviceId/version" ng-disabled="getEntityStatus() !== 'Ready'"></input>
       </dd>
       <dt style="margin-top: 25px" apiman-i18n-key="urlrewriting.where-to-find">Where to Find Them</dt>
       <dd>
         <div>
-          <input id="processHeaders" type="checkbox" ng-model="config.processHeaders"></input>
+          <input id="processHeaders" type="checkbox" ng-model="config.processHeaders" ng-disabled="getEntityStatus() !== 'Ready'"></input>
           <label for="processHeaders" apiman-i18n-key="urlrewriting.process-headers" title="When enabled, apiman will rewrite URLs found in the API response headers.">Response HTTP headers</label>
         </div>
         <div>
-          <input id="processBody" type="checkbox" ng-model="config.processBody"></input>
+          <input id="processBody" type="checkbox" ng-model="config.processBody" ng-disabled="getEntityStatus() !== 'Ready'"></input>
           <label for="processBody" apiman-i18n-key="urlrewriting.process-body" title="When enabled, apiman will rewrite URLs found in the API response body.">Response HTTP body</label>
         </div>
       </dd>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/url-rewriting.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/url-rewriting.include
@@ -10,18 +10,18 @@
       <dt apiman-i18n-key="urlrewriting.how-to-rewrite">How to Rewrite URLs</dt>
       <dd>
         <div apiman-i18n-key="urlrewriting.find-all-1">Find all URLs matching regular expression</div>
-        <input id="fromRegexp" ng-model="config.fromRegex" class="apiman-form-control form-control" type="text" apiman-i18n-key="urlrewriting.enter-from-rgexp" placeholder="Example: https?:\/\/host\.org\/api-endpoint" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <input id="fromRegexp" ng-model="config.fromRegex" class="apiman-form-control form-control" type="text" apiman-i18n-key="urlrewriting.enter-from-rgexp" placeholder="Example: https?:\/\/host\.org\/api-endpoint" ng-disabled="isEntityDisabled()"></input>
         <div apiman-i18n-key="urlrewriting.find-all-2">with this replacement</div>
-        <input id="toReplacement" ng-model="config.toReplacement" class="apiman-form-control form-control" type="text" apiman-i18n-key="urlrewriting.enter-to-replacement" placeholder="Example: https:\/\/apiman\.org\/orgId/serviceId/version" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+        <input id="toReplacement" ng-model="config.toReplacement" class="apiman-form-control form-control" type="text" apiman-i18n-key="urlrewriting.enter-to-replacement" placeholder="Example: https:\/\/apiman\.org\/orgId/serviceId/version" ng-disabled="isEntityDisabled()"></input>
       </dd>
       <dt style="margin-top: 25px" apiman-i18n-key="urlrewriting.where-to-find">Where to Find Them</dt>
       <dd>
         <div>
-          <input id="processHeaders" type="checkbox" ng-model="config.processHeaders" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+          <input id="processHeaders" type="checkbox" ng-model="config.processHeaders" ng-disabled="isEntityDisabled()"></input>
           <label for="processHeaders" apiman-i18n-key="urlrewriting.process-headers" title="When enabled, apiman will rewrite URLs found in the API response headers.">Response HTTP headers</label>
         </div>
         <div>
-          <input id="processBody" type="checkbox" ng-model="config.processBody" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+          <input id="processBody" type="checkbox" ng-model="config.processBody" ng-disabled="isEntityDisabled()"></input>
           <label for="processBody" apiman-i18n-key="urlrewriting.process-body" title="When enabled, apiman will rewrite URLs found in the API response body.">Response HTTP body</label>
         </div>
       </dd>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/url-rewriting.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/url-rewriting.include
@@ -10,18 +10,18 @@
       <dt apiman-i18n-key="urlrewriting.how-to-rewrite">How to Rewrite URLs</dt>
       <dd>
         <div apiman-i18n-key="urlrewriting.find-all-1">Find all URLs matching regular expression</div>
-        <input id="fromRegexp" ng-model="config.fromRegex" class="apiman-form-control form-control" type="text" apiman-i18n-key="urlrewriting.enter-from-rgexp" placeholder="Example: https?:\/\/host\.org\/api-endpoint" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <input id="fromRegexp" ng-model="config.fromRegex" class="apiman-form-control form-control" type="text" apiman-i18n-key="urlrewriting.enter-from-rgexp" placeholder="Example: https?:\/\/host\.org\/api-endpoint" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
         <div apiman-i18n-key="urlrewriting.find-all-2">with this replacement</div>
-        <input id="toReplacement" ng-model="config.toReplacement" class="apiman-form-control form-control" type="text" apiman-i18n-key="urlrewriting.enter-to-replacement" placeholder="Example: https:\/\/apiman\.org\/orgId/serviceId/version" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+        <input id="toReplacement" ng-model="config.toReplacement" class="apiman-form-control form-control" type="text" apiman-i18n-key="urlrewriting.enter-to-replacement" placeholder="Example: https:\/\/apiman\.org\/orgId/serviceId/version" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
       </dd>
       <dt style="margin-top: 25px" apiman-i18n-key="urlrewriting.where-to-find">Where to Find Them</dt>
       <dd>
         <div>
-          <input id="processHeaders" type="checkbox" ng-model="config.processHeaders" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+          <input id="processHeaders" type="checkbox" ng-model="config.processHeaders" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
           <label for="processHeaders" apiman-i18n-key="urlrewriting.process-headers" title="When enabled, apiman will rewrite URLs found in the API response headers.">Response HTTP headers</label>
         </div>
         <div>
-          <input id="processBody" type="checkbox" ng-model="config.processBody" ng-disabled="getEntityStatus() !== 'Ready'"></input>
+          <input id="processBody" type="checkbox" ng-model="config.processBody" ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
           <label for="processBody" apiman-i18n-key="urlrewriting.process-body" title="When enabled, apiman will rewrite URLs found in the API response body.">Response HTTP body</label>
         </div>
       </dd>

--- a/manager/ui/hawtio/plugins/api-manager/html/service/service-def.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/service/service-def.html
@@ -48,7 +48,7 @@
                       ng-model="selectedDefinitionType"
                       class="selectpicker"
                       ng-options="type.label for type in typeOptions track by type.value"
-                      ng-disabled="getEntityStatus() !== 'Ready'">
+                      ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
               </select>
               <textarea apiman-i18n-key="enter-service-definition"
                         id="service-definition"
@@ -58,7 +58,7 @@
                         ng-model="updatedServiceDefinition"
                         data-field="data"
                         class="apiman-form-control form-control apiman-form-data"
-                        ng-disabled="getEntityStatus() !== 'Ready'"></textarea>
+                        ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></textarea>
             </div>
             <div apiman-permission="svcEdit"
                  apiman-status="Created,Ready"

--- a/manager/ui/hawtio/plugins/api-manager/html/service/service-def.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/service/service-def.html
@@ -48,7 +48,7 @@
                       ng-model="selectedDefinitionType"
                       class="selectpicker"
                       ng-options="type.label for type in typeOptions track by type.value"
-                      ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+                      ng-disabled="isEntityDisabled()">
               </select>
               <textarea apiman-i18n-key="enter-service-definition"
                         id="service-definition"
@@ -58,7 +58,7 @@
                         ng-model="updatedServiceDefinition"
                         data-field="data"
                         class="apiman-form-control form-control apiman-form-data"
-                        ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></textarea>
+                        ng-disabled="isEntityDisabled()"></textarea>
             </div>
             <div apiman-permission="svcEdit"
                  apiman-status="Created,Ready"

--- a/manager/ui/hawtio/plugins/api-manager/html/service/service-def.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/service/service-def.html
@@ -2,14 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0"></meta>
   </head>
 
   <body>
   <div>
     
     <div ng-include="headerInclude"></div>
-    <div ng-controller="Apiman.ServiceDefController" class="page container" data-field="page" ng-cloak="" ng-show="pageState == 'loaded'">
+    <div ng-controller="Apiman.ServiceDefController"
+         class="page container"
+         data-field="page"
+         ng-cloak=""
+         ng-show="pageState == 'loaded'">
       <div ng-include="'plugins/api-manager/html/service/service_bc.include'"></div>
       <!-- Entity Summary Row -->
       <div ng-include="'plugins/api-manager/html/service/service_entity.include'"></div>
@@ -23,7 +28,8 @@
         <!-- Content -->
         <div class="col-md-10 apiman-entity-content">
           <div class="col-md-10">
-            <div class="title" apiman-i18n-key="service-def">Service Definition</div>
+            <div class="title"
+                 apiman-i18n-key="service-def">Service Definition</div>
             <div class="apiman-label-faded">
               <p apiman-i18n-key="service-def-explanation">
                 Here you can (optionally) provide definition information about your service.  This
@@ -34,14 +40,43 @@
               </p>
             </div>
             <div>
-              <span class="clearfix" apiman-i18n-key="svc-definition-label">Service Definition:</span>
-              <select apiman-i18n-key="service-def.choose-type" title="Choose a type..." apiman-select-picker="" ng-model="selectedDefinitionType" class="selectpicker" ng-options="type.label for type in typeOptions track by type.value">
+              <span class="clearfix"
+                    apiman-i18n-key="svc-definition-label">Service Definition:</span>
+              <select apiman-i18n-key="service-def.choose-type"
+                      title="Choose a type..."
+                      apiman-select-picker=""
+                      ng-model="selectedDefinitionType"
+                      class="selectpicker"
+                      ng-options="type.label for type in typeOptions track by type.value"
+                      ng-disabled="getEntityStatus() !== 'Ready'">
               </select>
-              <textarea apiman-i18n-key="enter-service-definition" id="service-definition" placeholder="Copy/paste or drag and drop your Service Definition in here!" style="width: 100%;" apiman-drop-text ng-model="updatedServiceDefinition" data-field="data" class="apiman-form-control form-control apiman-form-data"></textarea>
+              <textarea apiman-i18n-key="enter-service-definition"
+                        id="service-definition"
+                        placeholder="Copy/paste or drag and drop your Service Definition in here!"
+                        style="width: 100%;"
+                        apiman-drop-text
+                        ng-model="updatedServiceDefinition"
+                        data-field="data"
+                        class="apiman-form-control form-control apiman-form-data"
+                        ng-disabled="getEntityStatus() !== 'Ready'"></textarea>
             </div>
-            <div apiman-permission="svcEdit" apiman-status="Created,Ready" class="actions" style="margin-top: 20px">
-              <button ng-disabled="!isDirty" apiman-action-btn="" ng-click="saveService()" class="btn btn-primary" data-field="saveButton" apiman-i18n-key="save" placeholder="Saving..." data-icon="fa-cog" >Save</button>
-              <button ng-disabled="!isDirty" ng-click="reset()" class="btn btn-default" data-field="cancelButton" apiman-i18n-key="cancel">Cancel</button>
+            <div apiman-permission="svcEdit"
+                 apiman-status="Created,Ready"
+                 class="actions"
+                 style="margin-top: 20px">
+              <button ng-disabled="!isDirty"
+                      apiman-action-btn=""
+                      ng-click="saveService()"
+                      class="btn btn-primary"
+                      data-field="saveButton"
+                      apiman-i18n-key="save"
+                      placeholder="Saving..."
+                      data-icon="fa-cog" >Save</button>
+              <button ng-disabled="!isDirty"
+                      ng-click="reset()"
+                      class="btn btn-default"
+                      data-field="cancelButton"
+                      apiman-i18n-key="cancel">Cancel</button>
             </div>
           </div>
         </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/service/service-endpoint.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/service/service-endpoint.html
@@ -43,7 +43,7 @@
             <textarea class="apiman-endpoint form-control"
                       style="width:100%"
                       data-field="mangedEndpoint"
-                      ng-disabled="getEntityStatus() !== 'Ready'">
+                      ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
               {{ managedEndpoint.managedEndpoint }}
             </textarea>
           </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/service/service-endpoint.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/service/service-endpoint.html
@@ -43,7 +43,7 @@
             <textarea class="apiman-endpoint form-control"
                       style="width:100%"
                       data-field="mangedEndpoint"
-                      ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+                      ng-disabled="isEntityDisabled()">
               {{ managedEndpoint.managedEndpoint }}
             </textarea>
           </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/service/service-endpoint.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/service/service-endpoint.html
@@ -38,8 +38,14 @@
               <div apiman-i18n-key="warning-not-public" class="alert alert-warning">Warning: this Service is not public - this endpoint will only work if a valid Service Contract API key is included in requests made to it.</div>
             </div>
             <hr />
-            <div class="apiman-form-label" apiman-i18n-key="managed-endpoint">Managed Endpoint</div>
-            <textarea readonly="readonly" class="apiman-endpoint" style="width:100%" data-field="mangedEndpoint">{{ managedEndpoint.managedEndpoint }}</textarea>
+            <div class="apiman-form-label"
+                 apiman-i18n-key="managed-endpoint">Managed Endpoint</div>
+            <textarea class="apiman-endpoint form-control"
+                      style="width:100%"
+                      data-field="mangedEndpoint"
+                      ng-disabled="getEntityStatus() !== 'Ready'">
+              {{ managedEndpoint.managedEndpoint }}
+            </textarea>
           </div>
           <!-- /Content Summary -->
         </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/service/service-impl.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/service/service-impl.html
@@ -44,7 +44,7 @@
                      data-field="endpoint"
                      class="apiman-form-control form-control"
                      type="text"
-                     ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+                     ng-disabled="isEntityDisabled()"></input>
             </div>
             <div style="margin-top: 10px">
               <span class="clearfix"
@@ -55,7 +55,7 @@
                       ng-model="updatedService.endpointType"
                       class="selectpicker"
                       ng-options="type.toUpperCase() for type in typeOptions"
-                      ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+                      ng-disabled="isEntityDisabled()">
               </select>
             </div>
             
@@ -65,7 +65,7 @@
               <select apiman-select-picker=""
                       ng-model="apiSecurity.type"
                       class="selectpicker"
-                      ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+                      ng-disabled="isEntityDisabled()">
                 <option value="none"
                         apiman-i18n-key="none">None</option>
                 <option value="mtls"

--- a/manager/ui/hawtio/plugins/api-manager/html/service/service-impl.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/service/service-impl.html
@@ -2,14 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0"></meta>
   </head>
 
   <body>
   <div>
     
     <div ng-include="headerInclude"></div>
-    <div ng-controller="Apiman.ServiceImplController" class="page container" data-field="page" ng-cloak="" ng-show="pageState == 'loaded'">
+    <div ng-controller="Apiman.ServiceImplController"
+         class="page container"
+         data-field="page"
+         ng-cloak=""
+         ng-show="pageState == 'loaded'">
       <div ng-include="'plugins/api-manager/html/service/service_bc.include'"></div>
       <!-- Entity Summary Row -->
       <div ng-include="'plugins/api-manager/html/service/service_entity.include'"></div>
@@ -23,7 +28,8 @@
         <!-- Content -->
         <div class="col-md-10 apiman-entity-content">
           <div class="col-md-8">
-            <div class="title" apiman-i18n-key="service-impl">Service Implementation</div>
+            <div class="title"
+                 apiman-i18n-key="service-impl">Service Implementation</div>
             <div class="apiman-label-faded">
               <p apiman-i18n-key="service-impl-explanation">
                 Please provide us with details about the back-end service implementation
@@ -34,59 +40,123 @@
             </div>
             <div>
               <span apiman-i18n-key="api-endpoint-label">API Endpoint:</span>
-              <input ng-model="updatedService.endpoint" data-field="endpoint" class="apiman-form-control form-control" type="text"></input>
+              <input ng-model="updatedService.endpoint"
+                     data-field="endpoint"
+                     class="apiman-form-control form-control"
+                     type="text"
+                     ng-disabled="getEntityStatus() !== 'Ready'"></input>
             </div>
             <div style="margin-top: 10px">
-              <span class="clearfix" apiman-i18n-key="api-type-label">API Type:</span>
-              <select apiman-i18n-key="service-impl.choose-type" title="Choose a type..." apiman-select-picker="" ng-model="updatedService.endpointType" class="selectpicker" ng-options="type.toUpperCase() for type in typeOptions">
+              <span class="clearfix"
+                    apiman-i18n-key="api-type-label">API Type:</span>
+              <select apiman-i18n-key="service-impl.choose-type"
+                      title="Choose a type..."
+                      apiman-select-picker=""
+                      ng-model="updatedService.endpointType"
+                      class="selectpicker"
+                      ng-options="type.toUpperCase() for type in typeOptions"
+                      ng-disabled="getEntityStatus() !== 'Ready'">
               </select>
             </div>
             
             <div class="">
-              <span class="clearfix" apiman-i18n-key="api-security-label">API Security:</span>
-              <select apiman-select-picker="" ng-model="apiSecurity.type" class="selectpicker">
-                <option value="none" apiman-i18n-key="none">None</option>
-                <option value="mtls" apiman-i18n-key="mtls">MTLS/Two-Way-SSL</option>
-                <option value="basic" apiman-i18n-key="basic-auth">BASIC Authentication</option>
+              <span class="clearfix"
+                    apiman-i18n-key="api-security-label">API Security:</span>
+              <select apiman-select-picker=""
+                      ng-model="apiSecurity.type"
+                      class="selectpicker"
+                      ng-disabled="getEntityStatus() !== 'Ready'">
+                <option value="none"
+                        apiman-i18n-key="none">None</option>
+                <option value="mtls"
+                        apiman-i18n-key="mtls">MTLS/Two-Way-SSL</option>
+                <option value="basic"
+                        apiman-i18n-key="basic-auth">BASIC Authentication</option>
               </select>
             </div>
 
-            <div class="" ng-show="apiSecurity.type == 'mtls'">
-              <div class="alert alert-info" style="">
+            <div class=""
+                 ng-show="apiSecurity.type == 'mtls'">
+              <div class="alert alert-info"
+                   style="">
                  <span class="pficon pficon-info"></span>
                  <span apiman-i18n-key="service-impl.mtsl-info">When using MTLS/Two-Way-SSL you must configure the relevant settings globally in the apiman.properties file.  Please refer to the apiman Installation Guide for details.</span>
               </div>
             </div>
 
-            <div class="panel panel-default" ng-show="apiSecurity.type == 'basic'">
+            <div class="panel panel-default"
+                 ng-show="apiSecurity.type == 'basic'">
               <div class="panel-body">
-                <table width="100%" class="form-table">
+                <table width="100%"
+                       class="form-table">
                   <tr>
-                    <td width="1%" nowrap="nowrap" align="right"><span apiman-i18n-key="username-label" class="">Username:</span></td>
-                    <td><input id="basic-auth.username" ng-model="apiSecurity.basic.username" class="apiman-form-control form-control" width="100%" type="text"></input></td>
-                  </tr>
-                  <tr>
-                    <td width="1%" nowrap="nowrap" align="right"><span apiman-i18n-key="password-label" class="">Password:</span></td>
-                    <td><input id="basic-auth.password" ng-model="apiSecurity.basic.password" class="apiman-form-control form-control" width="100%" type="password"></input></td>
-                  </tr>
-                  <tr>
-                    <td width="1%" nowrap="nowrap" align="right"><span apiman-i18n-key="confirm-password-label" class="">Confirm Password:</span></td>
-                    <td><input id="basic-auth.confirm-password" ng-model="apiSecurity.basic.confirmPassword" class="apiman-form-control form-control" width="100%" type="password"></input></td>
-                  </tr>
-                  <tr>
-                    <td width="1%" nowrap="nowrap" align="right"></td>
+                    <td width="1%"
+                        nowrap="nowrap"
+                        align="right">
+                      <span apiman-i18n-key="username-label"
+                            class="">Username:</span>
+                    </td>
                     <td>
-                      <input ng-model="apiSecurity.basic.requireSSL" type="checkbox" id="require-ssl"></input>
-                      <label for="require-ssl" apiman-i18n-key="endpoint-security.require-ssl" style="padding-left: 3px">Require transport security (SSL)</label>
+                      <input id="basic-auth.username"
+                             ng-model="apiSecurity.basic.username"
+                             class="apiman-form-control form-control"
+                             width="100%"
+                             type="text"
+                             ng-disabled="getEntityStatus() != 'Created' || 'Ready'"></input>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td width="1%"
+                        nowrap="nowrap"
+                        align="right">
+                        <span apiman-i18n-key="password-label"
+                              class="">Password:</span>
+                    </td>
+                    <td>
+                        <input id="basic-auth.password"
+                               ng-model="apiSecurity.basic.password"
+                               class="apiman-form-control form-control"
+                               width="100%"
+                               type="password"></input>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td width="1%"
+                        nowrap="nowrap"
+                        align="right">
+                        <span apiman-i18n-key="confirm-password-label"
+                              class="">Confirm Password:</span>
+                    </td>
+                    <td>
+                        <input id="basic-auth.confirm-password"
+                               ng-model="apiSecurity.basic.confirmPassword"
+                               class="apiman-form-control form-control"
+                               width="100%"
+                               type="password"></input>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td width="1%"
+                        nowrap="nowrap"
+                        align="right"></td>
+                    <td>
+                      <input ng-model="apiSecurity.basic.requireSSL"
+                             type="checkbox"
+                             id="require-ssl"></input>
+                      <label for="require-ssl"
+                             apiman-i18n-key="endpoint-security.require-ssl"
+                             style="padding-left: 3px">Require transport security (SSL)</label>
                     </td>
                   </tr>
                 </table>
               </div>
             </div>
             
-            <div id="gateway-info" ng-show="gateways.length > 1">
+            <div id="gateway-info"
+                 ng-show="gateways.length > 1">
               <hr />
-              <div class="title" apiman-i18n-key="gateway">Gateway</div>
+              <div class="title"
+                   apiman-i18n-key="gateway">Gateway</div>
               <div class="apiman-label-faded">
                 <p apiman-i18n-key="service-impl-gateway-explanation">
                   There are multiple API Gateways configured - you'll need to tell us which one you
@@ -94,26 +164,36 @@
                 </p>
               </div>
               <div>
-                <span class="clearfix" apiman-i18n-key="publish-to">Publish To:</span>
-                <select ng-model="selectedGateway" apiman-select-picker="" class="selectpicker" ng-options="gateway.name for gateway in gateways | orderBy: name">
+                <span class="clearfix"
+                      apiman-i18n-key="publish-to">Publish To:</span>
+                <select ng-model="selectedGateway"
+                        apiman-select-picker=""
+                        class="selectpicker"
+                        ng-options="gateway.name for gateway in gateways | orderBy: name">
                 </select>
               </div>
             </div>
             
-            <div id="no-gateways-info" ng-show="gateways.length == 0">
+            <div id="no-gateways-info"
+                 ng-show="gateways.length == 0">
               <hr />
-              <div class="title" apiman-i18n-key="gateway">Gateway</div>
-              <div class="alert alert-warning" apiman-i18n-key="service-impl-no-gateways-explanation">
+              <div class="title"
+                   apiman-i18n-key="gateway">Gateway</div>
+              <div class="alert alert-warning"
+                   apiman-i18n-key="service-impl-no-gateways-explanation">
                   There are no API Gateways configured in apiman.  For this reason you will not
                   be able to complete the configuration of your service.  Please contact your
                   apiman administrator - at least one API Gateway must be configured!
               </div>
             </div>
             
-            <div id="new-gateway-info" ng-show="autoGateway">
+            <div id="new-gateway-info"
+                 ng-show="autoGateway">
               <hr />
-              <div class="title" apiman-i18n-key="gateway">Gateway</div>
-              <div class="alert alert-success" apiman-i18n-key="service-impl-new-gateway-explanation">
+              <div class="title"
+                   apiman-i18n-key="gateway">Gateway</div>
+              <div class="alert alert-success"
+                   apiman-i18n-key="service-impl-new-gateway-explanation">
                   An API Gateway has been added since this service was created.  The new
                   Gateway has been selected for you - all you need to do is click Save below
                   to make it stick.
@@ -121,9 +201,23 @@
             </div>
             
             
-            <div apiman-permission="svcEdit" apiman-status="Created,Ready" class="actions" style="margin-top: 20px">
-              <button ng-disabled="!isDirty || !isValid" apiman-action-btn="" ng-click="saveService()" class="btn btn-primary" data-field="saveButton" apiman-i18n-key="save" placeholder="Saving..." data-icon="fa-cog" >Save</button>
-              <button ng-disabled="!isDirty" ng-click="reset()" class="btn btn-default" data-field="cancelButton" apiman-i18n-key="cancel">Cancel</button>
+            <div apiman-permission="svcEdit"
+                 apiman-status="Created,Ready"
+                 class="actions"
+                 style="margin-top: 20px">
+              <button ng-disabled="!isDirty || !isValid"
+                      apiman-action-btn=""
+                      ng-click="saveService()"
+                      class="btn btn-primary"
+                      data-field="saveButton"
+                      apiman-i18n-key="save"
+                      placeholder="Saving..."
+                      data-icon="fa-cog" >Save</button>
+              <button ng-disabled="!isDirty"
+                      ng-click="reset()"
+                      class="btn btn-default"
+                      data-field="cancelButton"
+                      apiman-i18n-key="cancel">Cancel</button>
             </div>
           </div>
         </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/service/service-impl.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/service/service-impl.html
@@ -44,7 +44,7 @@
                      data-field="endpoint"
                      class="apiman-form-control form-control"
                      type="text"
-                     ng-disabled="getEntityStatus() !== 'Ready'"></input>
+                     ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
             </div>
             <div style="margin-top: 10px">
               <span class="clearfix"
@@ -55,7 +55,7 @@
                       ng-model="updatedService.endpointType"
                       class="selectpicker"
                       ng-options="type.toUpperCase() for type in typeOptions"
-                      ng-disabled="getEntityStatus() !== 'Ready'">
+                      ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
               </select>
             </div>
             
@@ -65,7 +65,7 @@
               <select apiman-select-picker=""
                       ng-model="apiSecurity.type"
                       class="selectpicker"
-                      ng-disabled="getEntityStatus() !== 'Ready'">
+                      ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
                 <option value="none"
                         apiman-i18n-key="none">None</option>
                 <option value="mtls"
@@ -102,7 +102,7 @@
                              class="apiman-form-control form-control"
                              width="100%"
                              type="text"
-                             ng-disabled="getEntityStatus() != 'Created' || 'Ready'"></input>
+                             ng-disabled="getEntityStatus() != ('Ready' || 'Created')"></input>
                     </td>
                   </tr>
                   <tr>
@@ -117,7 +117,8 @@
                                ng-model="apiSecurity.basic.password"
                                class="apiman-form-control form-control"
                                width="100%"
-                               type="password"></input>
+                               type="password"
+                               ng-disabled="getEntityStatus() != ('Ready' || 'Created')"></input>
                     </td>
                   </tr>
                   <tr>
@@ -132,7 +133,8 @@
                                ng-model="apiSecurity.basic.confirmPassword"
                                class="apiman-form-control form-control"
                                width="100%"
-                               type="password"></input>
+                               type="password"
+                               ng-disabled="getEntityStatus() != ('Ready' || 'Created')"></input>
                     </td>
                   </tr>
                   <tr>
@@ -142,7 +144,8 @@
                     <td>
                       <input ng-model="apiSecurity.basic.requireSSL"
                              type="checkbox"
-                             id="require-ssl"></input>
+                             id="require-ssl"
+                             ng-disabled="getEntityStatus() != ('Ready' || 'Created')"></input>
                       <label for="require-ssl"
                              apiman-i18n-key="endpoint-security.require-ssl"
                              style="padding-left: 3px">Require transport security (SSL)</label>
@@ -169,7 +172,8 @@
                 <select ng-model="selectedGateway"
                         apiman-select-picker=""
                         class="selectpicker"
-                        ng-options="gateway.name for gateway in gateways | orderBy: name">
+                        ng-options="gateway.name for gateway in gateways | orderBy: name"
+                        ng-disabled="getEntityStatus() != ('Ready' || 'Created')">
                 </select>
               </div>
             </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/service/service-plans.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/service/service-plans.html
@@ -39,7 +39,7 @@
                      type="checkbox"
                      id="public-service"
                      data-field="publicService"
-                     ng-disabled="getEntityStatus() !== 'Ready'"></input>
+                     ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
               <label for="public-service"
                      apiman-i18n-key="make-service-public"
                      style="padding-left: 3px">Make this service public</label>
@@ -64,7 +64,7 @@
                   <input ng-model="plan.checked"
                          data-field="checkbox"
                          type="checkbox"
-                         ng-disabled="getEntityStatus() !== 'Ready'"></input>
+                         ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
                   <span class="title">
                     <a href="{{ pluginName }}/orgs/{{ plan.organizationId }}/plans/{{ plan.id }}" data-field="name" title="{{ plan.description }}">{{ plan.name }}</a>
                   </span>
@@ -72,7 +72,7 @@
                           ng-model="plan.selectedVersion"
                           ng-options="version for version in plan.lockedVersions"
                           class="selectpicker pull-right"
-                          ng-disabled="getEntityStatus() !== 'Ready'">
+                          ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
                   </select>
                 </div>
                 <hr>

--- a/manager/ui/hawtio/plugins/api-manager/html/service/service-plans.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/service/service-plans.html
@@ -2,14 +2,20 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0"></meta>
   </head>
 
   <body>
   <div>
     
     <div ng-include="headerInclude"></div>
-    <div ng-controller="Apiman.ServicePlansController" id="page-content" class="page container" data-field="page" ng-cloak="" ng-show="pageState == 'loaded'">
+    <div ng-controller="Apiman.ServicePlansController"
+         id="page-content"
+         class="page container"
+         data-field="page"
+         ng-cloak=""
+         ng-show="pageState == 'loaded'">
       <div ng-include="'plugins/api-manager/html/service/service_bc.include'"></div>
       <!-- Entity Summary Row -->
       <div ng-include="'plugins/api-manager/html/service/service_entity.include'"></div>
@@ -23,19 +29,28 @@
         <!-- Content -->
         <div class="col-md-10 apiman-entity-content">
           <div class="col-md-10">
-            <div class="title" apiman-i18n-key="public-service">Public Service</div>
+            <div class="title"
+                 apiman-i18n-key="public-service">Public Service</div>
             <div>
               <span apiman-i18n-key="public-service-help">Select this option if you wish this service to be accessible directly, without a Service Contract.  Typically (but not always) this option is used instead of selecting plan(s).</span>
             </div>
             <div style="padding: 8px; margin-bottom: 10px">
-              <input ng-model="updatedService.publicService" type="checkbox" id="public-service" data-field="publicService"></input>
-              <label for="public-service" apiman-i18n-key="make-service-public" style="padding-left: 3px">Make this service public</label>
+              <input ng-model="updatedService.publicService"
+                     type="checkbox"
+                     id="public-service"
+                     data-field="publicService"
+                     ng-disabled="getEntityStatus() !== 'Ready'"></input>
+              <label for="public-service"
+                     apiman-i18n-key="make-service-public"
+                     style="padding-left: 3px">Make this service public</label>
             </div>
-            <div class="title" apiman-i18n-key="available-plans">Available Plans</div>
+            <div class="title"
+                 apiman-i18n-key="available-plans">Available Plans</div>
             <div>
               <span apiman-i18n-key="available-plans-help">Choose which plans should be presented when Applications create a link (Contract) to this Service. Note that only plans in a 'Locked' state show up in this list.</span>
             </div>
-            <div class="apiman-divider-40" ng-show="plans.length == 0">
+            <div class="apiman-divider-40"
+                 ng-show="plans.length == 0">
               <div class="alert alert-warning">
                 <span class="pficon pficon-info"></span>
                 <span apiman-i18n-key="service-plans.no-locked-plans-found">No locked plans were found in the Organization.  Please create and lock at least one plan before attempting to configure them here.  Or simply make your services "public" using the checkbox above!</span>
@@ -43,20 +58,43 @@
             </div>
             <!-- The plans to choose from -->
             <div class="apiman-plan-selector apiman-divider-40">
-              <div class="container-fluid apiman-summaryrow" ng-repeat="plan in plans">
+              <div class="container-fluid apiman-summaryrow"
+                   ng-repeat="plan in plans">
                 <div class="row">
-                  <input ng-model="plan.checked" data-field="checkbox" type="checkbox"></input>
-                  <span class="title"><a href="{{ pluginName }}/orgs/{{ plan.organizationId }}/plans/{{ plan.id }}" data-field="name" title="{{ plan.description }}">{{ plan.name }}</a></span>
-                  <select apiman-select-picker="" ng-model="plan.selectedVersion" ng-options="version for version in plan.lockedVersions" class="selectpicker pull-right">
+                  <input ng-model="plan.checked"
+                         data-field="checkbox"
+                         type="checkbox"
+                         ng-disabled="getEntityStatus() !== 'Ready'"></input>
+                  <span class="title">
+                    <a href="{{ pluginName }}/orgs/{{ plan.organizationId }}/plans/{{ plan.id }}" data-field="name" title="{{ plan.description }}">{{ plan.name }}</a>
+                  </span>
+                  <select apiman-select-picker=""
+                          ng-model="plan.selectedVersion"
+                          ng-options="version for version in plan.lockedVersions"
+                          class="selectpicker pull-right"
+                          ng-disabled="getEntityStatus() !== 'Ready'">
                   </select>
                 </div>
                 <hr>
               </div>
             </div>
             
-            <div apiman-permission="svcEdit" apiman-status="Created,Ready" class="actions">
-              <button ng-disabled="!isDirty" apiman-action-btn="" ng-click="saveService()" class="btn btn-primary" data-field="saveButton" apiman-i18n-key="save" placeholder="Saving..." data-icon="fa-cog">Save</button>
-              <button ng-disabled="!isDirty" class="btn btn-default" ng-click="reset()" data-field="cancelButton" apiman-i18n-key="cancel">Cancel</button>
+            <div apiman-permission="svcEdit"
+                 apiman-status="Created,Ready"
+                 class="actions">
+              <button ng-disabled="!isDirty"
+                      apiman-action-btn=""
+                      ng-click="saveService()"
+                      class="btn btn-primary"
+                      data-field="saveButton"
+                      apiman-i18n-key="save"
+                      placeholder="Saving..."
+                      data-icon="fa-cog">Save</button>
+              <button ng-disabled="!isDirty"
+                      class="btn btn-default"
+                      ng-click="reset()"
+                      data-field="cancelButton"
+                      apiman-i18n-key="cancel">Cancel</button>
             </div>
             
           </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/service/service-plans.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/service/service-plans.html
@@ -39,7 +39,7 @@
                      type="checkbox"
                      id="public-service"
                      data-field="publicService"
-                     ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+                     ng-disabled="isEntityDisabled() || getEntityStatus() !== 'Created'"></input>
               <label for="public-service"
                      apiman-i18n-key="make-service-public"
                      style="padding-left: 3px">Make this service public</label>
@@ -64,7 +64,7 @@
                   <input ng-model="plan.checked"
                          data-field="checkbox"
                          type="checkbox"
-                         ng-disabled="getEntityStatus() !== ('Ready' || 'Created')"></input>
+                         ng-disabled="isEntityDisabled()"></input>
                   <span class="title">
                     <a href="{{ pluginName }}/orgs/{{ plan.organizationId }}/plans/{{ plan.id }}" data-field="name" title="{{ plan.description }}">{{ plan.name }}</a>
                   </span>
@@ -72,7 +72,7 @@
                           ng-model="plan.selectedVersion"
                           ng-options="version for version in plan.lockedVersions"
                           class="selectpicker pull-right"
-                          ng-disabled="getEntityStatus() !== ('Ready' || 'Created')">
+                          ng-disabled="isEntityDisabled()">
                   </select>
                 </div>
                 <hr>

--- a/manager/ui/hawtio/plugins/api-manager/html/service/service-policies.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/service/service-policies.html
@@ -2,14 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0"></meta>
   </head>
 
   <body>
   <div>
     
     <div ng-include="headerInclude"></div>
-    <div ng-controller="Apiman.ServicePoliciesController" class="page container" data-field="page" ng-cloak="" ng-show="pageState == 'loaded'">
+    <div ng-controller="Apiman.ServicePoliciesController"
+         class="page container"
+         data-field="page"
+         ng-cloak=""
+         ng-show="pageState == 'loaded'">
       <div ng-include="'plugins/api-manager/html/service/service_bc.include'"></div>
       <!-- Entity Summary Row -->
       <div ng-include="'plugins/api-manager/html/service/service_entity.include'"></div>
@@ -24,28 +29,44 @@
         <div class="col-md-10 apiman-entity-content">
           <div class="col-md-9">
             <!-- Title and help text -->
-            <div class="title" apiman-i18n-key="service-policies">Service Policies</div>
-            <div class="description" apiman-i18n-key="service-policies-help">Here is a list of all Policies defined for this Service.  These Policies will be applied to all invocations of this Service by any Application, regardless of the Plan used in its Contract.</div>
+            <div class="title"
+                 apiman-i18n-key="service-policies">Service Policies</div>
+            <div class="description"
+                 apiman-i18n-key="service-policies-help">Here is a list of all Policies defined for this Service.  These Policies will be applied to all invocations of this Service by any Application, regardless of the Plan used in its Contract.</div>
             <hr />
             <!-- The list of policies -->
-            <div apiman-permission="svcEdit" apiman-status="Created,Ready" class="apiman-filters apiman-policies-filters">
-              <a apiman-i18n-key="add-policy" href="{{ pluginName }}/orgs/{{ org.id }}/services/{{ service.id }}/{{ version.version }}/new-policy" class="btn btn-primary pull-right">Add Policy</a>
+            <div apiman-permission="svcEdit"
+                 apiman-status="Created,Ready"
+                 class="apiman-filters apiman-policies-filters">
+              <a apiman-i18n-key="add-policy"
+                 href="{{ pluginName }}/orgs/{{ org.id }}/services/{{ service.id }}/{{ version.version }}/new-policy" class="btn btn-primary pull-right">Add Policy</a>
             </div>
             <div class="clearfix"></div>
-            <div class="apiman-policies" data-field="policies">
+            <div class="apiman-policies"
+                 data-field="policies">
 
-              <div class="apiman-no-content container-fluid" ng-hide="policies.length > 0">
+              <div class="apiman-no-content container-fluid"
+                   ng-hide="policies.length > 0">
                 <div class="row">
                   <div class="col-md-9">
-                    <p class="apiman-no-entities-description" apiman-i18n-key="no-policies-for-service">It looks like there aren't any policies defined! That may be exactly what you want (of course) but if not, you may try defining one using the Add Policy button above...</p>
+                    <p class="apiman-no-entities-description"
+                       apiman-i18n-key="no-policies-for-service">It looks like there aren't any policies defined! That may be exactly what you want (of course) but if not, you may try defining one using the Add Policy button above...</p>
                   </div>
-                  <div apiman-permission="svcEdit" apiman-status="Created,Ready" class="col-md-3">
+                  <div apiman-permission="svcEdit"
+                       apiman-status="Created,Ready"
+                       class="col-md-3">
                     <div class="apiman-no-entities-arrow"></div>
                   </div>
                 </div>
               </div>
               <div class="clearfix"></div>
-              <apiman-policy-list ng-model="policies" remove-function="removePolicy" reorder-function="reorderPolicies" type="services" org-id="{{ org.id }}" page-id="{{ service.id }}" version="{{ version.version }}"></policy-list>
+              <apiman-policy-list ng-model="policies"
+                                  remove-function="removePolicy"
+                                  reorder-function="reorderPolicies"
+                                  type="services"
+                                  org-id="{{ org.id }}"
+                                  page-id="{{ service.id }}"
+                                  version="{{ version.version }}"></apiman-policy-list>
             </div>
           </div>
         </div>

--- a/manager/ui/hawtio/plugins/api-manager/ts/apimanPlugin.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/apimanPlugin.ts
@@ -1,5 +1,5 @@
-/// <reference path="../../includes.ts"/>
-/// <reference path="apimanGlobals.ts"/>
+/// <reference path='../../includes.ts'/>
+/// <reference path='apimanGlobals.ts'/>
 module Apiman {
 
     export var _module = angular.module(Apiman.pluginName, [
@@ -311,8 +311,8 @@ module Apiman {
             && Configuration.api.auth.type == 'bearerTokenFromHash') {
             var bearerToken = null;
             var backTo = null;
-            var tokenKey = "Apiman.BearerToken";
-            var backToKey = "Apiman.BackToConsole";
+            var tokenKey = 'Apiman.BearerToken';
+            var backToKey = 'Apiman.BackToConsole';
 
             var hash = $location.hash();
 
@@ -361,15 +361,15 @@ module Apiman {
     hawtioPluginLoader.registerPreBootstrapTask((next) => {
         // Load the configuration jsonp script
         $.getScript('apiman/config.js').done((script, textStatus) => {
-            log.info("Loaded the config.js config!");
+            log.info('Loaded the config.js config!');
         }).fail((response) => {
-            log.debug("Error fetching configuration: ", response);
+            log.debug('Error fetching configuration: ', response);
         }).always(() => {
             // Load the i18n jsonp script
             $.getScript('apiman/translations.js').done((script, textStatus) => {
-                log.info("Loaded the translations.js bundle!");
+                log.info('Loaded the translations.js bundle!');
             }).fail((response) => {
-                log.debug("Error fetching translations: ", response);
+                log.debug('Error fetching translations: ', response);
             }).always(() => {
                 next();
             });

--- a/manager/ui/hawtio/plugins/api-manager/ts/directives.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/directives.ts
@@ -117,6 +117,7 @@ module Apiman {
                         return EntityStatusService.getEntityStatus();
                     }, function(newValue, oldValue) {
                         var entityStatus = newValue;
+                        console.log('entityStatus: ' + entityStatus);
                         var elem = element;
                         if (entityStatus) {
                             var validStatuses = attrs.apimanStatus.split(',');
@@ -158,7 +159,7 @@ module Apiman {
         }]);
 
     _module.directive('apimanEntityStatus',
-        ['Logger', 'EntityStatusService', 
+        ['Logger', 'EntityStatusService',
         function(Logger, EntityStatusService) {
             return {
                 restrict: 'A',

--- a/manager/ui/hawtio/plugins/api-manager/ts/forms/edit-policy.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/forms/edit-policy.ts
@@ -5,16 +5,24 @@ module Apiman {
         ['$q', '$location', '$scope', 'OrgSvcs', 'ApimanSvcs', 'PageLifecycle', 'Logger', '$routeParams', 'EntityStatusService', 'CurrentUser',
         ($q, $location, $scope, OrgSvcs, ApimanSvcs, PageLifecycle, Logger, $routeParams, EntityStatusService, CurrentUser) => {
             var params = $routeParams;
+
             $scope.organizationId = params.org;
+
             var requiredPermissionMap = {
                 applications: 'appEdit',
                 services: 'svcEdit',
                 plans: 'planEdit'
             };
+
             var etype = params.type;
+
             if (etype == 'apps') {
                 etype = 'applications';
             }
+
+            $scope.getEntityStatus = function() {
+                return EntityStatusService.getEntityStatus();
+            };
             
             var pageData = {
                 version: $q(function(resolve, reject) {
@@ -31,22 +39,28 @@ module Apiman {
                         policyId: params.policy
                     }, function(policy) {
                         var config = new Object();
+
                         try {
                             config = JSON.parse(policy.configuration);
                         } catch (e) {
                             // TODO handle this error better!
                         }
+
                         $scope.config = config;
+
                         if (policy.definition.formType == 'JsonSchema') {
                             $scope.include = 'plugins/api-manager/html/policyForms/JsonSchema.include';
                         } else {
                             var inc = ConfigForms[policy.definition.id];
+
                             if (!inc) {
                                 inc = 'Default.include';
                             }
+
                             $scope.include = 'plugins/api-manager/html/policyForms/' + inc;
                         }
                         $scope.selectedDef = policy.definition;
+
                         resolve(policy);
                     }, reject);
                 })
@@ -59,19 +73,24 @@ module Apiman {
             $scope.setConfig = function(config) {
                 $scope.config = config;
             };
+
             $scope.getConfig = function() {
                 return $scope.config;
             };
             
             $scope.updatePolicy = function() {
                 $scope.updateButton.state = 'in-progress';
+
                 var updatedPolicy = {
                     configuration: angular.toJson($scope.config)
                 };
+
                 var etype = params.type;
+
                 if (etype == 'apps') {
                     etype = 'applications';
                 }
+
                 OrgSvcs.update({
                     organizationId: params.org,
                     entityType: etype,
@@ -87,11 +106,14 @@ module Apiman {
             
             PageLifecycle.loadPage('EditPolicy', pageData, $scope, function() {
                 EntityStatusService.setEntityStatus($scope.version.status);
+
                 // Note: not using the apiman-permission directive in the template for this page because
                 // we cannot hard-code the required permission.  The required permission changes depending
                 // on the entity type of the parent of the policy.  Instead we figure it out and set it here.
                 $scope.hasPermission = CurrentUser.hasPermission(params.org, requiredPermissionMap[etype]);
+
                 PageLifecycle.setPageTitle('edit-policy');
+
                 $('#apiman-description').focus();
             });
         }]);

--- a/manager/ui/hawtio/plugins/api-manager/ts/policies.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/policies.ts
@@ -1,5 +1,5 @@
-/// <reference path="apimanPlugin.ts"/>
-/// <reference path="services.ts"/>
+/// <reference path='apimanPlugin.ts'/>
+/// <reference path='services.ts'/>
 module Apiman {
     
     export var isRegexpValid = function(v) {
@@ -14,9 +14,9 @@ module Apiman {
         return valid;
     };
     
-    _module.controller("Apiman.DefaultPolicyConfigFormController",
-        ['$scope', 'Logger',
-        ($scope, Logger) => {
+    _module.controller('Apiman.DefaultPolicyConfigFormController',
+        ['$scope', 'Logger', 'EntityStatusService',
+        ($scope, Logger, EntityStatusService) => {
             var validateRaw = function(config) {
                 var valid = true;
 
@@ -30,6 +30,12 @@ module Apiman {
                 $scope.setValid(valid);
             };
 
+            $scope.isEntityDisabled = function() {
+                var status = EntityStatusService.getEntityStatus();
+
+                return (status !== 'Created' && status !== 'Ready');
+            };
+
             if ($scope.getConfig()) {
                 $scope.rawConfig = JSON.stringify($scope.getConfig(), null, 2);
             }
@@ -38,8 +44,14 @@ module Apiman {
         }]);
 
     _module.controller('Apiman.JsonSchemaPolicyConfigFormController',
-        ['$scope', 'Logger', 'PluginSvcs',
-        ($scope, Logger, PluginSvcs) => {
+        ['$scope', 'Logger', 'PluginSvcs', 'EntityStatusService',
+        ($scope, Logger, PluginSvcs, EntityStatusService) => {
+            $scope.isEntityDisabled = function() {
+                var status = EntityStatusService.getEntityStatus();
+
+                return (status !== 'Created' && status !== 'Ready');
+            };
+
             var initEditor = function(schema) {
                 var holder = document.getElementById('json-editor-holder');
 
@@ -73,7 +85,7 @@ module Apiman {
                     });
                 });
 
-                if($scope.getEntityStatus() !== 'Ready') {
+                if ($scope.isEntityDisabled() === true) {
                     editor.disable();
                 }
 
@@ -123,9 +135,9 @@ module Apiman {
             loadSchema();
         }]);
 
-    _module.controller("Apiman.RateLimitingFormController",
-        ['$scope', 'Logger',
-        ($scope, Logger) => {
+    _module.controller('Apiman.RateLimitingFormController',
+        ['$scope', 'Logger', 'EntityStatusService',
+        ($scope, Logger, EntityStatusService) => {
             var validate = function(config) {
                 var valid = true;
 
@@ -148,6 +160,12 @@ module Apiman {
                 if (config.granularity == 'User' && !config.userHeader) {
                     valid = false;
                 }
+
+                $scope.isEntityDisabled = function() {
+                    var status = EntityStatusService.getEntityStatus();
+
+                    return (status !== 'Created' && status !== 'Ready');
+                };
 
                 $scope.setValid(valid);
             };
@@ -155,9 +173,9 @@ module Apiman {
             $scope.$watch('config', validate, true);
         }]);
 
-    _module.controller("Apiman.QuotaFormController",
-        ['$scope', 'Logger',
-        ($scope, Logger) => {
+    _module.controller('Apiman.QuotaFormController',
+        ['$scope', 'Logger', 'EntityStatusService',
+        ($scope, Logger, EntityStatusService) => {
             var validate = function(config) {
                 var valid = true;
                 if (config.limit) {
@@ -182,6 +200,13 @@ module Apiman {
 
                 $scope.setValid(valid);
             };
+
+            $scope.isEntityDisabled = function() {
+                var status = EntityStatusService.getEntityStatus();
+
+                return (status !== 'Created' && status !== 'Ready');
+            };
+
             $scope.$watch('config', validate, true);
         }]);
     
@@ -189,9 +214,9 @@ module Apiman {
     export var MB = 1024 * 1024;
     export var GB = 1024 * 1024 * 1024;
 
-    _module.controller("Apiman.TransferQuotaFormController",
-        ['$scope', 'Logger',
-        ($scope, Logger) => {
+    _module.controller('Apiman.TransferQuotaFormController',
+        ['$scope', 'Logger', 'EntityStatusService',
+        ($scope, Logger, EntityStatusService) => {
             $scope.limitDenomination = 'B';
             
             if ($scope.config && $scope.config.limit) {
@@ -266,14 +291,20 @@ module Apiman {
                 }
             };
 
+            $scope.isEntityDisabled = function() {
+                var status = EntityStatusService.getEntityStatus();
+
+                return (status !== 'Created' && status !== 'Ready');
+            };
+
             $scope.$watch('config', validate, true);
             $scope.$watch('limitDenomination', onLimitChange, false);
             $scope.$watch('limitAmount', onLimitChange, false);
         }]);
 
-    _module.controller("Apiman.IPListFormController",
-        ['$scope', 'Logger',
-        ($scope, Logger) => {
+    _module.controller('Apiman.IPListFormController',
+        ['$scope', 'Logger', 'EntityStatusService',
+        ($scope, Logger, EntityStatusService) => {
             var validate = function(config) {
                 var valid = true;
                 $scope.setValid(valid);
@@ -319,11 +350,17 @@ module Apiman {
                 $scope.config.ipList = [];
                 $scope.selectedIP = undefined;
             };
+
+            $scope.isEntityDisabled = function() {
+                var status = EntityStatusService.getEntityStatus();
+
+                return (status !== 'Created' && status !== 'Ready');
+            };
         }]);
 
-    _module.controller("Apiman.IgnoredResourcesFormController",
-        ['$scope', 'Logger',
-        ($scope, Logger) => {
+    _module.controller('Apiman.IgnoredResourcesFormController',
+        ['$scope', 'Logger', 'EntityStatusService',
+        ($scope, Logger, EntityStatusService) => {
             var validate = function(config) {
                 var valid = true;
 
@@ -366,11 +403,17 @@ module Apiman {
                 $scope.config.pathsToIgnore = [];
                 $scope.selectedPath = undefined;
             };
+
+            $scope.isEntityDisabled = function() {
+                var status = EntityStatusService.getEntityStatus();
+
+                return (status !== 'Created' && status !== 'Ready');
+            };
         }]);
 
-    _module.controller("Apiman.BasicAuthFormController",
-        ['$scope', 'Logger',
-        ($scope, Logger) => {
+    _module.controller('Apiman.BasicAuthFormController',
+        ['$scope', 'Logger', 'EntityStatusService',
+        ($scope, Logger, EntityStatusService) => {
             var validate = function(config) {
                 if (!config) {
                     return;
@@ -524,11 +567,16 @@ module Apiman {
                 $scope.selectedIdentity = undefined;
             };
 
+            $scope.isEntityDisabled = function() {
+                var status = EntityStatusService.getEntityStatus();
+
+                return (status !== 'Created' && status !== 'Ready');
+            };
         }]);
 
-    _module.controller("Apiman.AuthorizationFormController",
-        ['$scope', 'Logger',
-        ($scope, Logger) => {
+    _module.controller('Apiman.AuthorizationFormController',
+        ['$scope', 'Logger', 'EntityStatusService',
+        ($scope, Logger, EntityStatusService) => {
             var validate = function(config) {
                 var valid = config.rules && config.rules.length > 0;
 
@@ -555,9 +603,9 @@ module Apiman {
                 }
 
                 var rule = {
-                    "verb" : verb,
-                    "pathPattern" : path,
-                    "role" : role
+                    'verb' : verb,
+                    'pathPattern' : path,
+                    'role' : role
                 };
 
                 $scope.config.rules.push(rule);
@@ -585,11 +633,17 @@ module Apiman {
             $scope.clear = function() {
                 $scope.config.rules = [];
             };
+
+            $scope.isEntityDisabled = function() {
+                var status = EntityStatusService.getEntityStatus();
+
+                return (status !== 'Created' && status !== 'Ready');
+            };
         }]);
 
-    _module.controller("Apiman.CachingFormController",
-        ['$scope', 'Logger',
-        ($scope, Logger) => {
+    _module.controller('Apiman.CachingFormController',
+        ['$scope', 'Logger', 'EntityStatusService',
+        ($scope, Logger, EntityStatusService) => {
             var validate = function(config) {
                 var valid = false;
 
@@ -604,12 +658,18 @@ module Apiman {
                 $scope.setValid(valid);
             };
 
+            $scope.isEntityDisabled = function() {
+                var status = EntityStatusService.getEntityStatus();
+
+                return (status !== 'Created' && status !== 'Ready');
+            };
+
             $scope.$watch('config', validate, true);
         }]);
 
-    _module.controller("Apiman.URLRewritingFormController",
-        ['$scope', 'Logger',
-        ($scope, Logger) => {
+    _module.controller('Apiman.URLRewritingFormController',
+        ['$scope', 'Logger', 'EntityStatusService',
+        ($scope, Logger, EntityStatusService) => {
             var validate = function(config) {
                 var valid = true;
 
@@ -630,6 +690,12 @@ module Apiman {
                 }
 
                 $scope.setValid(valid);
+            };
+
+            $scope.isEntityDisabled = function() {
+                var status = EntityStatusService.getEntityStatus();
+
+                return (status !== 'Created' && status !== 'Ready');
             };
 
             $scope.$watch('config', validate, true);

--- a/manager/ui/hawtio/plugins/api-manager/ts/policies.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/policies.ts
@@ -4,11 +4,13 @@ module Apiman {
     
     export var isRegexpValid = function(v) {
         var valid = true;
+
         try {
-            new RegExp(v, "");
+            new RegExp(v, '');
         } catch(e) {
             valid = false;
         }
+
         return valid;
     };
     
@@ -17,25 +19,30 @@ module Apiman {
         ($scope, Logger) => {
             var validateRaw = function(config) {
                 var valid = true;
+
                 try {
                     var parsed = JSON.parse(config);
                     $scope.setConfig(parsed);
                 } catch (e) {
                     valid = false;
                 }
+
                 $scope.setValid(valid);
             };
+
             if ($scope.getConfig()) {
                 $scope.rawConfig = JSON.stringify($scope.getConfig(), null, 2);
             }
+
             $scope.$watch('rawConfig', validateRaw);
         }]);
 
-    _module.controller("Apiman.JsonSchemaPolicyConfigFormController",
+    _module.controller('Apiman.JsonSchemaPolicyConfigFormController',
         ['$scope', 'Logger', 'PluginSvcs',
         ($scope, Logger, PluginSvcs) => {
             var initEditor = function(schema) {
                 var holder = document.getElementById('json-editor-holder');
+
                 var editor = new window['JSONEditor'](holder, {
                     // Disable fetching schemas via ajax
                     ajax: false,
@@ -47,13 +54,15 @@ module Apiman {
                     required_by_default: true,
                     disable_edit_json: true,
                     disable_properties: true,
-                    iconlib: "fontawesome4",
-                    theme: "bootstrap3"
+                    iconlib: 'fontawesome4',
+                    theme: 'bootstrap3'
                 });
+
                 editor.on('change', function() {
                     $scope.$apply(function() {
                         // Get an array of errors from the validator
                         var errors = editor.validate();
+
                         // Not valid
                         if (errors.length) {
                             $scope.setValid(false);
@@ -63,8 +72,14 @@ module Apiman {
                         }
                     });
                 });
+
+                if($scope.getEntityStatus() !== 'Ready') {
+                    editor.disable();
+                }
+
                 $scope.editor = editor;
             };
+
             var destroyEditor = function() {
                 if ($scope.editor) {
                     $scope.editor.destroy();
@@ -74,8 +89,10 @@ module Apiman {
             
             var loadSchema = function() {
                 $scope.schemaState = 'loading';
+
                 var pluginId = $scope.selectedDef.pluginId;
                 var policyDefId = $scope.selectedDef.id;
+
                 PluginSvcs.getPolicyForm(pluginId, policyDefId, function(schema) {
                     destroyEditor();
                     initEditor(schema);
@@ -111,23 +128,30 @@ module Apiman {
         ($scope, Logger) => {
             var validate = function(config) {
                 var valid = true;
+
                 if (config.limit) {
                     config.limit = Number(config.limit);
                 }
+
                 if (!config.limit || config.limit < 1) {
                     valid = false;
                 }
+
                 if (!config.granularity) {
                     valid = false;
                 }
+
                 if (!config.period) {
                     valid = false;
                 }
+
                 if (config.granularity == 'User' && !config.userHeader) {
                     valid = false;
                 }
+
                 $scope.setValid(valid);
             };
+
             $scope.$watch('config', validate, true);
         }]);
 
@@ -139,18 +163,23 @@ module Apiman {
                 if (config.limit) {
                     config.limit = Number(config.limit);
                 }
+
                 if (!config.limit || config.limit < 1) {
                     valid = false;
                 }
+
                 if (!config.granularity) {
                     valid = false;
                 }
+
                 if (!config.period) {
                     valid = false;
                 }
+
                 if (config.granularity == 'User' && !config.userHeader) {
                     valid = false;
                 }
+
                 $scope.setValid(valid);
             };
             $scope.$watch('config', validate, true);
@@ -167,6 +196,7 @@ module Apiman {
             
             if ($scope.config && $scope.config.limit) {
                 var limit = Number($scope.config.limit);
+
                 if (limit > GB && ((limit % GB) == 0)) {
                     $scope.limitAmount = limit / GB;
                     $scope.limitDenomination = 'GB';
@@ -183,37 +213,49 @@ module Apiman {
 
             var validate = function(config) {
                 var valid = true;
+
                 if (!config.limit || config.limit < 1) {
                     valid = false;
                 }
+
                 if (!config.granularity) {
                     valid = false;
                 }
+
                 if (!config.period) {
                     valid = false;
                 }
+
                 if (config.granularity == 'User' && !config.userHeader) {
                     valid = false;
                 }
+
                 if (!config.direction) {
                     valid = false;
                 }
+
                 $scope.setValid(valid);
             };
+
             var onLimitChange = function() {
                 var amt = $scope.limitAmount;
+
                 if (amt) {
                     var den = $scope.limitDenomination;
                     var denFact = 1;
+
                     if (den == 'KB') {
                         denFact = 1024;
                     }
+
                     if (den == 'MB') {
                         denFact = 1024 * 1024;
                     }
+
                     if (den == 'GB') {
                         denFact = 1024 * 1024 * 1024;
                     }
+
                     try {
                         $scope.config.limit = Number(amt) * denFact;
                     } catch (e) {
@@ -223,6 +265,7 @@ module Apiman {
                     $scope.config.limit = null;
                 }
             };
+
             $scope.$watch('config', validate, true);
             $scope.$watch('limitDenomination', onLimitChange, false);
             $scope.$watch('limitAmount', onLimitChange, false);
@@ -235,11 +278,13 @@ module Apiman {
                 var valid = true;
                 $scope.setValid(valid);
             };
+
             $scope.$watch('config', validate, true);
             
             if (!$scope.config.ipList) {
                 $scope.config.ipList = [];
             }
+
             if (!$scope.config.responseCode) {
                 $scope.config.responseCode = 500;
             }
@@ -255,15 +300,18 @@ module Apiman {
             $scope.remove = function(ips) {
                 angular.forEach(ips, function(ip) {
                     var idx = -1;
+
                     angular.forEach($scope.config.ipList, function(item, index) {
                         if (item == ip) {
                             idx = index;
                         }
                     });
+
                     if (idx != -1) {
                         $scope.config.ipList.splice(idx, 1);
                     }
                 });
+
                 $scope.selectedIP = undefined;
             };
             
@@ -278,14 +326,17 @@ module Apiman {
         ($scope, Logger) => {
             var validate = function(config) {
                 var valid = true;
+
                 $scope.setValid(valid);
             };
+
             $scope.$watch('config', validate, true);
             
             $scope.add = function(path) {
                 if (!$scope.config.pathsToIgnore) {
                     $scope.config.pathsToIgnore = [];
                 }
+
                 $scope.remove(path);
                 $scope.config.pathsToIgnore.push(path);
                 $scope.selectedPath =  [ path ];
@@ -296,15 +347,18 @@ module Apiman {
             $scope.remove = function(paths) {
                 angular.forEach(paths, function(path) {
                     var idx = -1;
+
                     angular.forEach($scope.config.pathsToIgnore, function(item, index) {
                         if (item == path) {
                             idx = index;
                         }
                     });
+
                     if (idx != -1) {
                         $scope.config.pathsToIgnore.splice(idx, 1);
                     }
                 });
+
                 $scope.selectedPath = undefined;
             };
             
@@ -321,7 +375,9 @@ module Apiman {
                 if (!config) {
                     return;
                 }
+
                 var valid = true;
+
                 if (!config.realm) {
                     valid = false;
                 }
@@ -335,49 +391,62 @@ module Apiman {
                         valid = false;
                     }
                 }
+
                 if (config.ldapIdentity) {
                     if (!config.ldapIdentity.url) {
                         valid = false;
                     }
+
                     if (!config.ldapIdentity.dnPattern) {
                         valid = false;
                     }
+
                     if (config.ldapIdentity.bindAs == 'ServiceAccount') {
                         if (!config.ldapIdentity.credentials || !config.ldapIdentity.credentials.username || !config.ldapIdentity.credentials.password) {
                             valid = false;
                         }
+
                         if (config.ldapIdentity.credentials) {
                             if (config.ldapIdentity.credentials.password != $scope.repeatPassword) {
                                 valid = false;
                             }
                         }
+
                         if (!config.ldapIdentity.userSearch || !config.ldapIdentity.userSearch.baseDn || !config.ldapIdentity.userSearch.expression) {
                             valid = false;
                         }
                     }
+
                     if (config.ldapIdentity.extractRoles) {
                         if (!config.ldapIdentity.membershipAttribute) {
                             valid = false;
                         }
+
                         if (!config.ldapIdentity.rolenameAttribute) {
                             valid = false;
                         }
                     }
                 }
+
                 if (config.jdbcIdentity) {
                     if (!config.jdbcIdentity.datasourcePath) {
                         valid = false;
                     }
+
                     if (!config.jdbcIdentity.query) {
                         valid = false;
                     }
+
                     if (config.jdbcIdentity.extractRoles && !config.jdbcIdentity.roleQuery) {
                         valid = false;
                     }
                 }
+
                 $scope.setValid(valid);
             };
+
             $scope.$watch('config', validate, true);
+
             $scope.$watch('repeatPassword', function() {
                 validate($scope.config);
             });
@@ -385,7 +454,7 @@ module Apiman {
             if ($scope.config) {
                 if ($scope.config.staticIdentity) {
                     $scope.identitySourceType = 'static';
-                } else if ($scope.config.ldapIdentity) {
+                } else if ($scope.config.ldapIdentity && $scope.config.ldapIdentity.credentials) {
                     $scope.identitySourceType = 'ldap';
                     $scope.repeatPassword = $scope.config.ldapIdentity.credentials.password;
                 } else if ($scope.config.jdbcIdentity) {
@@ -418,29 +487,35 @@ module Apiman {
                     username: username,
                     password: password
                 };
+
                 if (!$scope.config.staticIdentity.identities) {
                     $scope.config.staticIdentity.identities = [];
                 }
+
                 $scope.remove([ item ]);
                 $scope.config.staticIdentity.identities.push(item);
                 $scope.selectedIdentity =  [ item ];
                 $scope.username = undefined;
                 $scope.password = undefined;
+
                 $('#username').focus();
             };
             
             $scope.remove = function(selectedIdentities) {
                 angular.forEach(selectedIdentities, function(identity) {
                     var idx = -1;
+
                     angular.forEach($scope.config.staticIdentity.identities, function(item, index) {
                         if (item.username == identity.username) {
                             idx = index;
                         }
                     });
+
                     if (idx != -1) {
                         $scope.config.staticIdentity.identities.splice(idx, 1);
                     }
                 });
+
                 $scope.selectedIdentity = undefined;
             };
             
@@ -456,15 +531,18 @@ module Apiman {
         ($scope, Logger) => {
             var validate = function(config) {
                 var valid = config.rules && config.rules.length > 0;
+
                 if (!config.requestUnmatched) {
                     config.requestUnmatched = 'fail';
                 }
+
                 if (!config.multiMatch) {
                     config.multiMatch = 'all';
                 }
                 
                 $scope.setValid(valid);
             };
+
             $scope.$watch('config', validate, true);
             
             $scope.currentItemInvalid = function() {
@@ -475,25 +553,30 @@ module Apiman {
                 if (!$scope.config.rules) {
                     $scope.config.rules = [];
                 }
+
                 var rule = {
                     "verb" : verb,
                     "pathPattern" : path,
                     "role" : role
                 };
+
                 $scope.config.rules.push(rule);
                 $scope.path = undefined;
                 $scope.verb = undefined;
                 $scope.role = undefined;
+
                 $('#path').focus();
             };
             
             $scope.remove = function(selectedRule) {
                 var idx = -1;
+
                 angular.forEach($scope.config.rules, function(item, index) {
                     if (item == selectedRule) {
                         idx = index;
                     }
                 });
+
                 if (idx != -1) {
                     $scope.config.rules.splice(idx, 1);
                 }
@@ -509,14 +592,18 @@ module Apiman {
         ($scope, Logger) => {
             var validate = function(config) {
                 var valid = false;
+
                 if (config.ttl) {
                     config.ttl = Number(config.ttl);
+
                     if (config.ttl && config.ttl > 0) {
                         valid = true;
                     }
                 }
+
                 $scope.setValid(valid);
             };
+
             $scope.$watch('config', validate, true);
         }]);
 
@@ -525,6 +612,7 @@ module Apiman {
         ($scope, Logger) => {
             var validate = function(config) {
                 var valid = true;
+
                 if (!config.fromRegex) {
                     valid = false;
                 } else {
@@ -532,14 +620,18 @@ module Apiman {
                         valid = false;
                     }
                 }
+
                 if (!config.toReplacement) {
                     valid = false;
                 }
+
                 if (!config.processBody && !config.processHeaders) {
                     valid = false;
                 }
+
                 $scope.setValid(valid);
             };
+
             $scope.$watch('config', validate, true);
         }]);
 

--- a/manager/ui/hawtio/plugins/api-manager/ts/service/service-activity.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/service/service-activity.ts
@@ -13,6 +13,7 @@ module Apiman {
             
             var getNextPage = function(successHandler, errorHandler) {
                 $scope.currentPage = $scope.currentPage + 1;
+
                 AuditSvcs.get({ organizationId: params.org, entityType: 'services', entityId: params.service, page: $scope.currentPage, count: 20 }, function(results) {
                     var entries = results.beans;
                     successHandler(entries);
@@ -20,6 +21,7 @@ module Apiman {
             };
              
             var pageData = ServiceEntityLoader.getCommonData($scope, $location);
+
             pageData = angular.extend(pageData, {
                 auditEntries: $q(function(resolve, reject) {
                     $scope.currentPage = 0;
@@ -28,6 +30,7 @@ module Apiman {
             });
             
             $scope.getNextPage = getNextPage;
+
             PageLifecycle.loadPage('ServiceActivity', pageData, $scope, function() {
                 PageLifecycle.setPageTitle('service-activity', [ $scope.service.name ]);
             });

--- a/manager/ui/hawtio/plugins/api-manager/ts/service/service-contracts.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/service/service-contracts.ts
@@ -14,6 +14,7 @@ module Apiman {
             var getNextPage = function(successHandler, errorHandler) {
                 var maxCount = 10;
                 $scope.currentPage = $scope.currentPage + 1;
+
                 OrgSvcs.query({ organizationId: params.org, entityType: 'services', entityId: params.service, versionsOrActivity: 'versions', version: params.version, policiesOrActivity: 'contracts', page: $scope.currentPage, count: maxCount  }, function(contracts) {
                    if (contracts.length == maxCount) {
                        $scope.hasMore = true;
@@ -25,6 +26,7 @@ module Apiman {
             };
 
             var pageData = ServiceEntityLoader.getCommonData($scope, $location);
+
             pageData = angular.extend(pageData, {
                 contracts: $q(function(resolve, reject) {
                     $scope.currentPage = 0;
@@ -33,14 +35,17 @@ module Apiman {
             });
             
             $scope.getNextPage = getNextPage;
+
             PageLifecycle.loadPage('ServiceContracts', pageData, $scope, function() {
                 Logger.debug("::: is public: {0}", $scope.version.publicService);
+
                 if ($scope.version.publicService) {
                     Logger.debug("::: num plans: {0}", $scope.version.plans.length);
                     if ($scope.version.plans.length == 0) {
                         $scope.isPublicOnly = true;
                     }
                 }
+
                 PageLifecycle.setPageTitle('service-contracts', [ $scope.service.name ]);
             });
         }])

--- a/manager/ui/hawtio/plugins/api-manager/ts/service/service-def.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/service/service-def.ts
@@ -3,8 +3,8 @@
 module Apiman {
 
  export var ServiceDefController = _module.controller("Apiman.ServiceDefController",
-        ['$q', '$rootScope', '$scope', '$location', 'PageLifecycle', 'ServiceEntityLoader', 'OrgSvcs', 'Logger', '$routeParams', 'ServiceDefinitionSvcs', 'Configuration',
-        ($q, $rootScope, $scope, $location, PageLifecycle, ServiceEntityLoader, OrgSvcs, Logger, $routeParams, ServiceDefinitionSvcs, Configuration) => {
+        ['$q', '$rootScope', '$scope', '$location', 'PageLifecycle', 'ServiceEntityLoader', 'OrgSvcs', 'Logger', '$routeParams', 'ServiceDefinitionSvcs', 'Configuration', 'EntityStatusService',
+        ($q, $rootScope, $scope, $location, PageLifecycle, ServiceEntityLoader, OrgSvcs, Logger, $routeParams, ServiceDefinitionSvcs, Configuration, EntityStatusService) => {
             var params = $routeParams;
             $scope.organizationId = params.org;
             $scope.tab = 'def';
@@ -23,15 +23,22 @@ module Apiman {
                     }
                 });
             };
+
             selectType('None');
+
+            $scope.getEntityStatus = function() {
+                return EntityStatusService.getEntityStatus();
+            };
 
             jQuery('#service-definition').height(100);
             jQuery('#service-definition').focus(function() {
                 jQuery('#service-definition').height(450);
             });
+
             jQuery('#service-definition').blur(function() {
                 jQuery('#service-definition').height(100);
             });
+
             $scope.$on('afterdrop', function(event, data) {
                 var newValue = data.value;
                 if (newValue) {

--- a/manager/ui/hawtio/plugins/api-manager/ts/service/service-endpoint.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/service/service-endpoint.ts
@@ -3,8 +3,8 @@
 module Apiman {
 
  export var ServiceEndpointController = _module.controller("Apiman.ServiceEndpointController",
-        ['$q', '$scope', '$location', 'PageLifecycle', 'ServiceEntityLoader', 'OrgSvcs', 'ApimanSvcs', '$routeParams', 'Configuration',
-        ($q, $scope, $location, PageLifecycle, ServiceEntityLoader, OrgSvcs, ApimanSvcs, $routeParams, Configuration) => {
+        ['$q', '$scope', '$location', 'PageLifecycle', 'ServiceEntityLoader', 'OrgSvcs', 'ApimanSvcs', '$routeParams', 'Configuration', 'EntityStatusService',
+        ($q, $scope, $location, PageLifecycle, ServiceEntityLoader, OrgSvcs, ApimanSvcs, $routeParams, Configuration, EntityStatusService) => {
             var params = $routeParams;
             $scope.organizationId = params.org;
             $scope.tab = 'endpoint';
@@ -12,11 +12,16 @@ module Apiman {
             $scope.showMetrics = Configuration.ui.metrics;
 
             var pageData = ServiceEntityLoader.getCommonData($scope, $location);
+
             pageData = angular.extend(pageData, {
                 managedEndpoint: $q(function(resolve, reject) {
                     OrgSvcs.get({ organizationId: params.org, entityType: 'services', entityId: params.service, versionsOrActivity: 'versions', version: params.version, policiesOrActivity: 'endpoint' }, resolve, reject);
                 })
             });
+
+            $scope.getEntityStatus = function() {
+                return EntityStatusService.getEntityStatus();
+            };
             
 
             PageLifecycle.loadPage('ServiceEndpoint', pageData, $scope, function() {

--- a/manager/ui/hawtio/plugins/api-manager/ts/service/service-endpoint.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/service/service-endpoint.ts
@@ -19,10 +19,11 @@ module Apiman {
                 })
             });
 
-            $scope.getEntityStatus = function() {
-                return EntityStatusService.getEntityStatus();
+            $scope.isEntityDisabled = function() {
+                var status = EntityStatusService.getEntityStatus();
+
+                return (status !== 'Created' && status !== 'Ready');
             };
-            
 
             PageLifecycle.loadPage('ServiceEndpoint', pageData, $scope, function() {
                 PageLifecycle.setPageTitle('service-endpoint', [ $scope.service.name ]);

--- a/manager/ui/hawtio/plugins/api-manager/ts/service/service-impl.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/service/service-impl.ts
@@ -6,6 +6,7 @@ module Apiman {
         ['$q', '$rootScope', '$scope', '$location', 'PageLifecycle', 'ServiceEntityLoader', 'OrgSvcs', 'ApimanSvcs', '$routeParams', 'EntityStatusService', 'Logger', 'Configuration',
         ($q, $rootScope, $scope, $location, PageLifecycle, ServiceEntityLoader, OrgSvcs, ApimanSvcs, $routeParams, EntityStatusService, Logger, Configuration) => {
             var params = $routeParams;
+
             $scope.organizationId = params.org;
             $scope.tab = 'impl';
             $scope.version = params.version;
@@ -24,8 +25,10 @@ module Apiman {
                 });
             }
 
-            $scope.getEntityStatus = function() {
-                return EntityStatusService.getEntityStatus();
+            $scope.isEntityDisabled = function() {
+                var status = EntityStatusService.getEntityStatus();
+
+                return (status !== 'Created' && status !== 'Ready');
             };
             
             var epValue = function(endpointProperties, key) {
@@ -181,6 +184,5 @@ module Apiman {
                     }
                 }
             });
-        }])
-
+        }]);
 }

--- a/manager/ui/hawtio/plugins/api-manager/ts/service/service-impl.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/service/service-impl.ts
@@ -15,6 +15,7 @@ module Apiman {
             $scope.showMetrics = Configuration.ui.metrics;
 
             var pageData = ServiceEntityLoader.getCommonData($scope, $location);
+
             if (params.version != null) {
                 pageData = angular.extend(pageData, {
                     gateways: $q(function(resolve, reject) {
@@ -22,6 +23,10 @@ module Apiman {
                     })
                 });
             }
+
+            $scope.getEntityStatus = function() {
+                return EntityStatusService.getEntityStatus();
+            };
             
             var epValue = function(endpointProperties, key) {
                 if (endpointProperties && endpointProperties[key]) {

--- a/manager/ui/hawtio/plugins/api-manager/ts/service/service-plans.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/service/service-plans.ts
@@ -95,12 +95,10 @@ module Apiman {
                 $rootScope.isDirty = false;
 
                 if (newValue.publicService != $scope.version.publicService) {
-                    console.log('Public Service is not the same');
                     $rootScope.isDirty = true;
                 }
 
                 if (newValue.plans && $scope.version.plans && newValue.plans.length != $scope.version.plans.length) {
-                    console.log('Plans are not the same');
                     $rootScope.isDirty = true;
                 } else if (newValue.plans && $scope.version.plans) {
                     newValue.plans = _.sortBy(newValue.plans, 'planId');

--- a/manager/ui/hawtio/plugins/api-manager/ts/service/service-plans.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/service/service-plans.ts
@@ -13,6 +13,7 @@ module Apiman {
             $scope.showMetrics = Configuration.ui.metrics;
 
             var lockedPlans = [];
+
             var getSelectedPlans = function() {
                 var selectedPlans = [];
                 for (var i = 0; i < lockedPlans.length; i++) {
@@ -25,6 +26,10 @@ module Apiman {
                     }
                 }
                 return selectedPlans;
+            };
+
+            $scope.getEntityStatus = function() {
+                return EntityStatusService.getEntityStatus();
             };
 
             var pageData = ServiceEntityLoader.getCommonData($scope, $location);

--- a/manager/ui/hawtio/plugins/api-manager/ts/service/service-plans.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/service/service-plans.ts
@@ -6,6 +6,7 @@ module Apiman {
         ['$q', '$rootScope', '$scope', '$location', 'PageLifecycle', 'ServiceEntityLoader', 'OrgSvcs', 'ApimanSvcs', '$routeParams', 'EntityStatusService', 'Configuration',
         ($q, $rootScope, $scope, $location, PageLifecycle, ServiceEntityLoader, OrgSvcs, ApimanSvcs, $routeParams, EntityStatusService, Configuration) => {
             var params = $routeParams;
+
             $scope.organizationId = params.org;
             $scope.tab = 'plans';
             $scope.version = params.version;
@@ -16,8 +17,10 @@ module Apiman {
 
             var getSelectedPlans = function() {
                 var selectedPlans = [];
+
                 for (var i = 0; i < lockedPlans.length; i++) {
                     var plan = lockedPlans[i];
+
                     if (plan.checked) {
                         var selectedPlan:any = {};
                         selectedPlan.planId = plan.id;
@@ -25,14 +28,18 @@ module Apiman {
                         selectedPlans.push(selectedPlan);
                     }
                 }
+
                 return selectedPlans;
             };
 
-            $scope.getEntityStatus = function() {
-                return EntityStatusService.getEntityStatus();
+            $scope.isEntityDisabled = function() {
+                var status = EntityStatusService.getEntityStatus();
+
+                return (status !== 'Created' && status !== 'Ready');
             };
 
             var pageData = ServiceEntityLoader.getCommonData($scope, $location);
+
             if (params.version != null) {
                 pageData = angular.extend(pageData, {
                     plans: $q(function(resolve, reject) {
@@ -59,6 +66,7 @@ module Apiman {
                                     }, reject);
                                 }))
                             });
+
                             $q.all(promises).then(function() {
                                 lockedPlans.sort(function(a,b) {
                                     if (a.id.toLowerCase() < b.id.toLowerCase()) {
@@ -69,6 +77,7 @@ module Apiman {
                                         return 0;
                                     }
                                 });
+
                                 resolve(lockedPlans);
                             });
                         }, reject);
@@ -78,9 +87,11 @@ module Apiman {
 
             $scope.$watch('updatedService', function(newValue) {
                 var dirty = false;
+
                 if (newValue.publicService != $scope.version.publicService) {
                     dirty = true;
                 }
+
                 if (newValue.plans && $scope.version.plans && newValue.plans.length != $scope.version.plans.length) {
                     dirty = true;
                 } else if (newValue.plans && $scope.version.plans) {
@@ -92,6 +103,7 @@ module Apiman {
                         }
                     }
                 }
+
                 $rootScope.isDirty = dirty;
             }, true);
 
@@ -101,8 +113,10 @@ module Apiman {
 
             $scope.reset = function() {
                 $scope.updatedService.publicService = $scope.version.publicService;
+
                 for (var i = 0; i < lockedPlans.length; i++) {
                     lockedPlans[i].selectedVersion = lockedPlans[i].lockedVersions[0];
+
                     for (var j = 0; j < $scope.version.plans.length; j++) {
                         if (lockedPlans[i].id == $scope.version.plans[j].planId) {
                             lockedPlans[i].checked = true;
@@ -111,6 +125,7 @@ module Apiman {
                         }
                     }
                 }
+
                 $scope.updatedService.plans = getSelectedPlans();
                 $rootScope.isDirty = false;
             };
@@ -131,6 +146,5 @@ module Apiman {
                 $scope.reset();
                 PageLifecycle.setPageTitle('service-plans', [ $scope.service.name ]);
             });
-        }])
-
+        }]);
 }

--- a/manager/ui/hawtio/plugins/api-manager/ts/service/service-plans.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/service/service-plans.ts
@@ -105,15 +105,12 @@ module Apiman {
                 } else if (newValue.plans && $scope.version.plans) {
                     newValue.plans = _.sortBy(newValue.plans, 'planId');
                     $scope.version.plans = _.sortBy($scope.version.plans, 'planId');
-                    
+
                     for (var i = 0 ; i < newValue.plans.length; i++) {
                         var p1 = newValue.plans[i];
                         var p2 = $scope.version.plans[i];
 
                         if (p1.planId != p2.planId || p1.version != p2.version) {
-                            console.log('p1: ' + JSON.stringify(p1));
-                            console.log('p2: ' + JSON.stringify(p2));
-                            console.log('Versions are not the same');
                             $rootScope.isDirty = true;
                         }
                     }

--- a/manager/ui/hawtio/plugins/api-manager/ts/service/service-policies.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/service/service-policies.ts
@@ -2,10 +2,11 @@
 /// <reference path="../services.ts"/>
 module Apiman {
 
- export var ServicePoliciesController = _module.controller("Apiman.ServicePoliciesController",
-        ['$q', '$scope', '$location', 'PageLifecycle', 'ServiceEntityLoader', 'OrgSvcs', 'Dialogs', '$routeParams', 'Configuration',
-        ($q, $scope, $location, PageLifecycle, ServiceEntityLoader, OrgSvcs, Dialogs, $routeParams, Configuration) => {
+ export var ServicePoliciesController = _module.controller('Apiman.ServicePoliciesController',
+        ['$q', '$scope', '$location', 'PageLifecycle', 'ServiceEntityLoader', 'OrgSvcs', 'Dialogs', '$routeParams', 'Configuration', 'EntityStatusService',
+        ($q, $scope, $location, PageLifecycle, ServiceEntityLoader, OrgSvcs, Dialogs, $routeParams, Configuration, EntityStatusService) => {
             var params = $routeParams;
+
             $scope.organizationId = params.org;
             $scope.tab = 'policies';
             $scope.version = params.version;
@@ -17,6 +18,12 @@ module Apiman {
                         $scope.policies.splice(index, 1);
                     }
                 });
+            };
+
+            $scope.isEntityDisabled = function() {
+                var status = EntityStatusService.getEntityStatus();
+
+                return (status !== 'Created' && status !== 'Ready');
             };
 
             $scope.removePolicy = function(policy) {
@@ -39,9 +46,10 @@ module Apiman {
                     }, function() {
                         Logger.debug("Reordering POST failed.")
                     });
-            }
+            };
 
             var pageData = ServiceEntityLoader.getCommonData($scope, $location);
+
             pageData = angular.extend(pageData, {
                 policies: $q(function(resolve, reject) {
                     OrgSvcs.query({ organizationId: params.org, entityType: 'services', entityId: params.service, versionsOrActivity: 'versions', version: params.version, policiesOrActivity: 'policies' }, resolve, reject);
@@ -52,6 +60,5 @@ module Apiman {
             PageLifecycle.loadPage('ServicePolicies', pageData, $scope, function() {
                 PageLifecycle.setPageTitle('service-policies', [ $scope.service.name ]);
             });
-        }])
-
+        }]);
 }

--- a/manager/ui/hawtio/plugins/api-manager/ts/service/service.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/service/service.ts
@@ -56,7 +56,8 @@ module Apiman {
             $scope.setEntityStatus = function(status) {
                 EntityStatusService.setEntityStatus(status);
             };
-            $scope.getEntityStatus = function(){
+
+            $scope.getEntityStatus = function() {
                 return EntityStatusService.getEntityStatus();
             };
 

--- a/manager/ui/hawtio/plugins/api-manager/ts/service/service.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/service/service.ts
@@ -30,6 +30,7 @@ module Apiman {
             return {
                 getCommonData: function($scope, $location) {
                     var params = $routeParams;
+
                     return {
                         version: $q(function(resolve, reject) {
                             OrgSvcs.get({ organizationId: params.org, entityType: 'services', entityId: params.service, versionsOrActivity: 'versions', version: params.version }, function(version) {
@@ -74,12 +75,14 @@ module Apiman {
 
             $scope.publishService = function() {
                 $scope.publishButton.state = 'in-progress';
+
                 var publishAction = {
                     type: 'publishService',
                     entityId: params.service,
                     organizationId: params.org,
                     entityVersion: params.version
                 };
+                
                 ActionSvcs.save(publishAction, function(reply) {
                     $scope.version.status = 'Published';
                     $scope.publishButton.state = 'complete';
@@ -89,6 +92,7 @@ module Apiman {
 
             $scope.retireService = function() {
                 $scope.retireButton.state = 'in-progress';
+
                 Dialogs.confirm('Confirm Retire Service', 'Do you really want to retire this service?  This action cannot be undone.', function() {
                     var retireAction = {
                         type: 'retireService',
@@ -96,11 +100,13 @@ module Apiman {
                         organizationId: params.org,
                         entityVersion: params.version
                     };
+
                     ActionSvcs.save(retireAction, function(reply) {
                         $scope.version.status = 'Retired';
                         $scope.retireButton.state = 'complete';
                         $scope.setEntityStatus($scope.version.status);
                     }, PageLifecycle.handleError);
+
                 }, function() {
                     $scope.retireButton.state = 'complete';
                 });
@@ -109,7 +115,7 @@ module Apiman {
             $scope.updateServiceDescription = function(updatedDescription) {
                 var updateServiceBean = {
                     description: updatedDescription
-                }
+                };
 
                 OrgSvcs.update({
                     organizationId: $scope.organizationId,
@@ -124,5 +130,5 @@ module Apiman {
                     Logger.error("Unable to update service description:  {0}", error);
                 });
             };
-        }])
+        }]);
 }

--- a/manager/ui/hawtio/plugins/api-manager/ts/service/service.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/service/service.ts
@@ -7,6 +7,7 @@ module Apiman {
         ($q, $scope, $location, OrgSvcs, PageLifecycle, $rootScope, CurrentUser, $routeParams) => {
             var orgId = $routeParams.org;
             var serviceId = $routeParams.service;
+
             var pageData = {
                 versions: $q(function(resolve, reject) {
                     OrgSvcs.query({ organizationId: orgId, entityType: 'services', entityId: serviceId, versionsOrActivity: 'versions' }, resolve, reject);
@@ -59,6 +60,12 @@ module Apiman {
 
             $scope.getEntityStatus = function() {
                 return EntityStatusService.getEntityStatus();
+            };
+
+            $scope.isEntityDisabled = function() {
+                var status = EntityStatusService.getEntityStatus();
+
+                return (status !== 'Created' && status !== 'Ready');
             };
 
             $scope.setVersion = function(service) {


### PR DESCRIPTION
Changes:
- Added public method to policies file (parent controller), to allow check for entity status.
- Added `ng-disabled` directive to each field for each service tab, if said check returns a status other than 'Ready'.
- To handle custom forms, which are currently generated with JSON-Editor: Added a few statements to the `JsonSchemaPolicyConfigFormController`, which checks the entity status and disables the entire custom form if the status is anything other than 'Ready'. In the future, we can disable individual fields, but for the moment it seems to be a little bit more trouble than it's worth, so, for now, disabling the entire form seems to be the way to go.

Reference
- ["Page is dirty" warning sometimes happen when the page isn't dirty](https://issues.jboss.org/browse/APIMAN-714)
- [Grey out disabled fields](https://issues.jboss.org/browse/APIMAN-485)

cc @EricWittmann 