### PR TITLE
Make sure WF8 UI is built

### DIFF
--- a/manager/ui/pom.xml
+++ b/manager/ui/pom.xml
@@ -9,4 +9,8 @@
   <artifactId>apiman-manager-ui</artifactId>
   <packaging>pom</packaging>
   <name>apiman-manager-ui</name>
+  <modules>
+    <module>hawtio</module>
+    <module>hawtio/wildfly8</module>
+  </modules>
 </project>


### PR DESCRIPTION
This is the small tweak that makes it get past the previous build issue we discussed.

Now hitting issues with NPM deps and TS compilation errors, but think that's a separate concern.