### PR TITLE
re #711 Add invalidMetricCriteriaException for Metrics Endpoints

### DIFF
--- a/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/CachingESRegistry.java
+++ b/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/CachingESRegistry.java
@@ -235,7 +235,7 @@ public class CachingESRegistry extends ESRegistry {
      * @param application
      */
     protected void loadAndCacheApp(Application application) {
-        String id = getApplicationKey(application);
+        String id = getApplicationId(application);
         Get get = new Get.Builder(getIndexName(), id).type("application").build(); //$NON-NLS-1$
         getClient().executeAsync(get, new JestResultHandler<JestResult>() {
             @Override

--- a/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/ESRegistry.java
+++ b/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/ESRegistry.java
@@ -359,7 +359,7 @@ public class ESRegistry extends AbstractESComponent implements IRegistry {
      * @param app an application
      * @return an application key
      */
-    private String getApplicationId(Application app) {
+    protected String getApplicationId(Application app) {
         return app.getOrganizationId() + ":" + app.getApplicationId() + ":" + app.getVersion(); //$NON-NLS-1$ //$NON-NLS-2$
     }
 

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/OrganizationResourceImpl.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/OrganizationResourceImpl.java
@@ -662,7 +662,6 @@ public class OrganizationResourceImpl implements IOrganizationResource {
             InvalidMetricCriteriaException {
         if (!securityContext.hasPermission(PermissionType.appView, organizationId))
             throw ExceptionFactory.notAuthorizedException();
-
         
         if (fromDate == null) {
             throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'fromDate'."));
@@ -676,23 +675,7 @@ public class OrganizationResourceImpl implements IOrganizationResource {
         DateTime to = parseToDate(toDate);
         validateMetricRange(from, to);
         
-        try {
-            return metrics.getAppUsagePerService(organizationId, applicationId, version, from, to);
-        } catch (Exception e) {
-            if (organizationId == null) {
-                throw ExceptionFactory.invalidMetricCriteriaException("Missing or invalid 'organizationId'.");
-            }
-            
-            if (applicationId == null) {
-                throw ExceptionFactory.invalidMetricCriteriaException("Missing or invalid 'applicationId'.");
-            }
-            
-            if (version == null) {
-                throw ExceptionFactory.invalidMetricCriteriaException("Missing or invalid 'version'.");
-            }
-            
-            throw new SystemErrorException(e);
-        }
+        return metrics.getAppUsagePerService(organizationId, applicationId, version, from, to);
     }
 
     /**
@@ -2167,8 +2150,17 @@ public class OrganizationResourceImpl implements IOrganizationResource {
         if (!securityContext.hasPermission(PermissionType.svcView, organizationId))
             throw ExceptionFactory.notAuthorizedException();
 
+        if (fromDate == null) {
+            throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'fromDate'."));
+        }
+        
+        if (toDate == null) {
+            throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'toDate'."));
+        }
+        
         DateTime from = parseFromDate(fromDate);
         DateTime to = parseToDate(toDate);
+        
         if (interval == null) {
             interval = HistogramIntervalType.day;
         }
@@ -2185,6 +2177,14 @@ public class OrganizationResourceImpl implements IOrganizationResource {
             String fromDate, String toDate) throws NotAuthorizedException, InvalidMetricCriteriaException {
         if (!securityContext.hasPermission(PermissionType.svcView, organizationId))
             throw ExceptionFactory.notAuthorizedException();
+        
+        if (fromDate == null) {
+            throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'fromDate'."));
+        }
+        
+        if (toDate == null) {
+            throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'toDate'."));
+        }
 
         DateTime from = parseFromDate(fromDate);
         DateTime to = parseToDate(toDate);
@@ -2200,6 +2200,14 @@ public class OrganizationResourceImpl implements IOrganizationResource {
             String fromDate, String toDate) throws NotAuthorizedException, InvalidMetricCriteriaException {
         if (!securityContext.hasPermission(PermissionType.svcView, organizationId))
             throw ExceptionFactory.notAuthorizedException();
+        
+        if (fromDate == null) {
+            throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'fromDate'."));
+        }
+        
+        if (toDate == null) {
+            throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'toDate'."));
+        }
 
         DateTime from = parseFromDate(fromDate);
         DateTime to = parseToDate(toDate);
@@ -2216,6 +2224,14 @@ public class OrganizationResourceImpl implements IOrganizationResource {
             throws NotAuthorizedException, InvalidMetricCriteriaException {
         if (!securityContext.hasPermission(PermissionType.svcView, organizationId))
             throw ExceptionFactory.notAuthorizedException();
+        
+        if (fromDate == null) {
+            throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'fromDate'."));
+        }
+        
+        if (toDate == null) {
+            throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'toDate'."));
+        }
 
         DateTime from = parseFromDate(fromDate);
         DateTime to = parseToDate(toDate);
@@ -2236,6 +2252,14 @@ public class OrganizationResourceImpl implements IOrganizationResource {
             InvalidMetricCriteriaException {
         if (!securityContext.hasPermission(PermissionType.svcView, organizationId))
             throw ExceptionFactory.notAuthorizedException();
+        
+        if (fromDate == null) {
+            throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'fromDate'."));
+        }
+        
+        if (toDate == null) {
+            throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'toDate'."));
+        }
 
         DateTime from = parseFromDate(fromDate);
         DateTime to = parseToDate(toDate);
@@ -2252,6 +2276,14 @@ public class OrganizationResourceImpl implements IOrganizationResource {
             InvalidMetricCriteriaException {
         if (!securityContext.hasPermission(PermissionType.svcView, organizationId))
             throw ExceptionFactory.notAuthorizedException();
+        
+        if (fromDate == null) {
+            throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'fromDate'."));
+        }
+        
+        if (toDate == null) {
+            throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'toDate'."));
+        }
 
         DateTime from = parseFromDate(fromDate);
         DateTime to = parseToDate(toDate);
@@ -2268,6 +2300,14 @@ public class OrganizationResourceImpl implements IOrganizationResource {
             InvalidMetricCriteriaException {
         if (!securityContext.hasPermission(PermissionType.svcView, organizationId))
             throw ExceptionFactory.notAuthorizedException();
+        
+        if (fromDate == null) {
+            throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'fromDate'."));
+        }
+        
+        if (toDate == null) {
+            throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'toDate'."));
+        }
 
         DateTime from = parseFromDate(fromDate);
         DateTime to = parseToDate(toDate);

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/OrganizationResourceImpl.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/OrganizationResourceImpl.java
@@ -663,10 +663,36 @@ public class OrganizationResourceImpl implements IOrganizationResource {
         if (!securityContext.hasPermission(PermissionType.appView, organizationId))
             throw ExceptionFactory.notAuthorizedException();
 
+        
+        if (fromDate == null) {
+            throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'fromDate'."));
+        }
+        
+        if (toDate == null) {
+            throw ExceptionFactory.invalidMetricCriteriaException(String.format("Missing or invalid 'toDate'."));
+        }
+        
         DateTime from = parseFromDate(fromDate);
         DateTime to = parseToDate(toDate);
         validateMetricRange(from, to);
-        return metrics.getAppUsagePerService(organizationId, applicationId, version, from, to);
+        
+        try {
+            return metrics.getAppUsagePerService(organizationId, applicationId, version, from, to);
+        } catch (Exception e) {
+            if (organizationId == null) {
+                throw ExceptionFactory.invalidMetricCriteriaException("Missing or invalid 'organizationId'.");
+            }
+            
+            if (applicationId == null) {
+                throw ExceptionFactory.invalidMetricCriteriaException("Missing or invalid 'applicationId'.");
+            }
+            
+            if (version == null) {
+                throw ExceptionFactory.invalidMetricCriteriaException("Missing or invalid 'version'.");
+            }
+            
+            throw new SystemErrorException(e);
+        }
     }
 
     /**


### PR DESCRIPTION
Changes:
- For each method that involves parsing data for metrics (located in the `OrganizationResourceImpl` class), add a check for existence of `fromDate` to `toDate`, and throw `invalidMetricCriteriaException` error if either doesn't exist.
- Make `getApplicationId` method public in `CachingESRegistry` class.
- Change call from `getApplicationKey` to `getApplicationId` in the `loadAndCacheApp` method within the `CachingESRegistry` class.

JIRA: https://issues.jboss.org/browse/APIMAN-711

cc @EricWittmann @msavy 