### PR TITLE
re #768 Remove disable styling from read-only fields

### DIFF
--- a/manager/ui/hawtio/plugins/api-manager/html/app/apiModal.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/app/apiModal.html
@@ -18,6 +18,7 @@
           <input readonly
                  type="text"
                  class="apiman-form-control form-control readonly apiman-readonly"
+                 style="background-color: white; color: black;"
                  value="{{ asQueryParam }}">
             <!--
           <span class="input-group-btn">
@@ -43,6 +44,7 @@
               <input readonly
                      type="text"
                      class="apiman-form-control form-control readonly apiman-readonly"
+                     style="background-color: white; color: black;"
                      value="{{ asRequestHeader }}">
               <!--
               <span class="input-group-btn">

--- a/manager/ui/hawtio/plugins/api-manager/html/app/app-apis.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/app/app-apis.html
@@ -63,10 +63,11 @@
                           <div class="form-group">
                             <label apiman-i18n-key="api-key">API Key</label>
                             <div class="input-group"
-                                 style="width:100%; background-color: white; color: black">
+                                 style="width:100%;">
                               <input readonly
                                      type="text"
                                      class="apiman-form-control form-control readonly apiman-readonly"
+                                     style="background-color: white; color: black;"
                                      value="{{ api.apiKey }}">
                               <!--
                               <span class="input-group-btn">


### PR DESCRIPTION
Changes:
- Re-added CSS styling to read-only fields that remove the disabled styling appearance.

JIRA: https://issues.jboss.org/browse/APIMAN-768

cc @EricWittmann 