### PR TITLE
Bumping KC version to 1.6.1.Final

### DIFF
--- a/manager/ui/hawtio/wildfly8/src/main/java/io/apiman/manager/ui/server/wildfly8/KeyCloakBearerTokenGenerator.java
+++ b/manager/ui/hawtio/wildfly8/src/main/java/io/apiman/manager/ui/server/wildfly8/KeyCloakBearerTokenGenerator.java
@@ -21,7 +21,7 @@ import io.apiman.manager.ui.server.beans.BearerTokenCredentialsBean;
 import javax.servlet.http.HttpServletRequest;
 
 import org.keycloak.KeycloakSecurityContext;
-import org.keycloak.util.Time;
+import org.keycloak.common.util.Time;
 
 /**
  * A token generator when using KeyCloak as the authentication provider for apiman.

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <version.org.jboss.resteasy>2.3.10.Final</version.org.jboss.resteasy>
     <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.0_spec>1.0.2.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.0_spec>
     <version.org.jboss.weld.weld>2.3.0.Final</version.org.jboss.weld.weld>
-    <version.org.keycloak>1.2.0.Final</version.org.keycloak>
+    <version.org.keycloak>1.6.1.Final</version.org.keycloak>
     <version.org.mockito>1.9.5</version.org.mockito>
     <version.org.mvel>2.2.2.Final</version.org.mvel>
     <version.org.osgi>4.2.0</version.org.osgi>


### PR DESCRIPTION
The old version of KC (1.2.0.Final) contains a bug which prevents configuration reload via cli

Running the following command right after starting a fresh distribution of apiman will crash it.

```
./bin/jboss-cli.sh -c ":reload"
```