### PR TITLE
re #790 FE Endpoint Validation

### DIFF
--- a/manager/ui/hawtio/plugins/api-manager/html/service/service-impl.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/service/service-impl.html
@@ -46,6 +46,9 @@
                      type="text"
                      ng-disabled="isEntityDisabled()"></input>
             </div>
+            <div style="color: #ff0000" ng-show="invalidEndpoint === true">
+              <p>Please enter a valid endpoint that begins with http:// or https://.</p>
+            </div>
             <div style="margin-top: 10px">
               <span class="clearfix"
                     apiman-i18n-key="api-type-label">API Type:</span>
@@ -222,7 +225,7 @@
                  style="margin-top: 20px">
               <button ng-disabled="!isDirty || !isValid"
                       apiman-action-btn=""
-                      ng-click="saveService()"
+                      ng-click="validateEndpoint()"
                       class="btn btn-primary"
                       data-field="saveButton"
                       apiman-i18n-key="save"

--- a/manager/ui/hawtio/plugins/api-manager/ts/app/app-apis.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/app/app-apis.ts
@@ -107,28 +107,6 @@ module Apiman {
         }]);
 
     
-    _module.directive('apimanApiModal',
-        ['Logger', function(Logger) {
-            return {
-                templateUrl: 'plugins/api-manager/html/app/apiModal.html',
-                replace: true,
-                restrict: 'E',
-                link: function(scope, element, attrs) {
-                    $(element).on('hidden.bs.modal', function() {
-                        $(element).remove();
-                    });
 
-                    // Called if copy-to-clipboard functionality was successful
-                    scope.copySuccess = function () {
-                        console.log('Copied!');
-                    };
-
-                    // Called if copy-to-clipboard functionality was unsuccessful
-                    scope.copyFail = function (err) {
-                        //console.error('Error!', err);
-                    };
-                }
-            };
-        }]);
 
 }

--- a/manager/ui/hawtio/plugins/api-manager/ts/directives.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/directives.ts
@@ -30,6 +30,29 @@ module Apiman {
             };
         }]);
 
+    _module.directive('apimanApiModal',
+        ['Logger', function(Logger) {
+            return {
+                templateUrl: 'plugins/api-manager/html/app/apiModal.html',
+                replace: true,
+                restrict: 'E',
+                link: function(scope, element, attrs) {
+                    $(element).on('hidden.bs.modal', function() {
+                        $(element).remove();
+                    });
+
+                    // Called if copy-to-clipboard functionality was successful
+                    scope.copySuccess = function () {
+                        console.log('Copied!');
+                    };
+
+                    // Called if copy-to-clipboard functionality was unsuccessful
+                    scope.copyFail = function (err) {
+                        //console.error('Error!', err);
+                    };
+                }
+            };
+        }]);
 
     _module.directive('apimanSelectPicker',
         ['Logger', '$timeout', '$parse', 'TranslationService',

--- a/manager/ui/hawtio/plugins/api-manager/ts/service/service-impl.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/service/service-impl.ts
@@ -184,7 +184,32 @@ module Apiman {
                     EntityStatusService.setEntityStatus(reply.status);
                 }, PageLifecycle.handleError);
             };
-            
+
+
+            // Endpoint Validation
+            $scope.invalidEndpoint = false;
+
+            $scope.validateEndpoint = function() {
+                var first7 = $scope.updatedService.endpoint.substring(0, 7);
+                var first8 = $scope.updatedService.endpoint.substring(0, 8);
+
+                var re = new RegExp('^(http|https):\/\/', 'i');
+
+                // Test first 7 letters for http:// first
+                if(re.test(first7) === true) {
+                    $scope.saveService();
+                } else {
+                    // If it fails, test first 8 letters for https:// next
+                    if(re.test(first8) === true) {
+                        $scope.saveService();
+                    } else {
+                        console.log('Invalid input.');
+                        $scope.invalidEndpoint = true;
+                    }
+                }
+            };
+
+
             PageLifecycle.loadPage('ServiceImpl', pageData, $scope, function() {
                 $scope.reset();
                 PageLifecycle.setPageTitle('service-impl', [ $scope.service.name ]);


### PR DESCRIPTION
Changes:
Added a function that is called when the form is submitted. The function, using Regex, checks the first 7 characters of the endpoint to see if it contains `http://`. If it does, then the `saveService()` method is called. If it doesn't, it will then check to see if the first 8 characters of the endpoint contains `https://`. If it does, then the `saveService()` method is called. If that fails, then the user will see an error that reads `Please ender a valid endpoint that begins with http:// or https://.`. See screenshot below:

<img width="835" alt="screen shot 2015-11-18 at 2 10 05 pm" src="https://cloud.githubusercontent.com/assets/3844502/11251237/6f041aea-8dfe-11e5-832f-11931ee78f0b.png">

I also moved the `apimanApiModal` directive to the directives file, because it was really confusing to have it hidden at the bottom of a controller file.

JIRA: https://issues.jboss.org/browse/APIMAN-790

cc @EricWittmann 