### PR TITLE
re #826 Add ability to dismiss popover with close button

### DIFF
--- a/manager/ui/hawtio/plugins/api-manager/html/api/api_entity.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/api/api_entity.include
@@ -73,7 +73,7 @@
                style="background-color: #FFFFFF; background-image: none; border-color: #0099D3; color: #0099D3;"
                uib-popover-template="checklistPopover.templateUrl"
                popover-title="{{ checklistPopover.title }}"
-               popover-toggle="isOpen"
+               popover-is-open="isOpen"
                popover-placement="right"
                ng-click="getStatusDetails()">
               <span class="fa fa-info"></span><span style="margin-left: 6px" apiman-i18n-key="why-cannot-publish">Why can't I publish?</span>
@@ -86,6 +86,9 @@
         <!-- Checklist Template -->
         <script type="text/ng-template"
                 id="checklistTemplate.html">
+          <span style="cursor: default; position: absolute; top: 9px; right: 10px; color: #777;"
+                ng-click="closePopover()"
+                class="fa fa-close"></span>
           <uib-accordion close-others="oneAtATime">
             <uib-accordion-group ng-repeat="item in checklist | checklist"
                                  panel-class="checklist-panel"

--- a/manager/ui/hawtio/plugins/api-manager/ts/api/api.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/api/api.ts
@@ -82,20 +82,30 @@ module Apiman {
                 title: 'Publish Checklist'
             };
 
+            // Programmatically close popover
+            $scope.closePopover = function() {
+                $scope.isOpen = false;
+            };
+
+
             // Called when user clicks 'Why can't I publish?' & opens modal
             $scope.getStatusDetails = function() {
-                return OrgSvcs.get({
-                    organizationId: params.org,
-                    entityType: 'apis',
-                    entityId: params.api,
-                    versionsOrActivity: 'versions',
-                    version: params.version,
-                    policiesOrActivity: 'status'
-                }, function(response) {
-                    $scope.checklist = response.items;
+                if($scope.isOpen === false) {
+                    return OrgSvcs.get({
+                        organizationId: params.org,
+                        entityType: 'apis',
+                        entityId: params.api,
+                        versionsOrActivity: 'versions',
+                        version: params.version,
+                        policiesOrActivity: 'status'
+                    }, function(response) {
+                        $scope.checklist = response.items;
 
-                    $scope.isOpen = true;
-                });
+                        $scope.isOpen = true;
+                    });
+                } else if($scope.isOpen === true) {
+                    $scope.isOpen = false;
+                }
             };
 
             $scope.oneAtATime = true;


### PR DESCRIPTION
Changes:
- Added a close icon to the top right hand corner of the 'Why Can't I Publish?' checklist popover. Clicking the icon results in a closed popover.
- Needed to re-add the ability to toggle the popover by clicking on the same 'Why Can't I Publish?' button that opens the popover. Added a check in the controller for this.

JIRA: https://issues.jboss.org/browse/APIMAN-826

Screenshot:
<img width="468" alt="screen shot 2015-12-18 at 11 09 15 am" src="https://cloud.githubusercontent.com/assets/3844502/11901112/d22ece04-a577-11e5-96a0-e3ee2c98faae.png">


cc @EricWittmann 