### PR TITLE
#861 Fix for inability to save API definition

### DIFF
--- a/manager/ui/hawtio/plugins/api-manager/html/api/api-def.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/api/api-def.html
@@ -43,7 +43,7 @@
               <span class="clearfix"
                     style="margin-top:10px; margin-bottom: 10px"
                     apiman-i18n-key="api-definition-label">API Definition:</span>
-              <select apiman-i18n-key="api-def.choose-type" title="Choose a type..." apiman-select-picker="" ng-model="selectedDefinitionType" class="selectpicker" ng-options="type.label for type in typeOptions track by type.value">
+              <select apiman-i18n-key="api-def.choose-type" title="Choose a type..." apiman-select-picker="" ng-model="selectedDefinitionType" class="selectpicker" ng-disabled="isEntityDisabled()" ng-options="type.label for type in typeOptions track by type.value">
               </select>
               <textarea style="margin-top:10px"
                         apiman-i18n-key="enter-api-definition"

--- a/manager/ui/hawtio/plugins/api-manager/html/api/api-def.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/api/api-def.html
@@ -43,17 +43,8 @@
               <span class="clearfix"
                     style="margin-top:10px; margin-bottom: 10px"
                     apiman-i18n-key="api-definition-label">API Definition:</span>
-              <ui-select ng-model="selectedDefinitionType"
-                         ng-disabled="isEntityDisabled()"
-                         style="width: 30%; max-width: 300px;">
-                <ui-select-match placeholder="Choose a type..."
-                                 apiman-i18n-key="api-def.choose-type">
-                  <span ng-bind="$select.selected.label"></span>
-                </ui-select-match>
-                <ui-select-choices repeat="type in (typeOptions | filter: $select.search) track by type.value">
-                  <span ng-bind="type.label"></span>
-                </ui-select-choices>
-              </ui-select>
+              <select apiman-i18n-key="api-def.choose-type" title="Choose a type..." apiman-select-picker="" ng-model="selectedDefinitionType" class="selectpicker" ng-options="type.label for type in typeOptions track by type.value">
+              </select>
               <textarea style="margin-top:10px"
                         apiman-i18n-key="enter-api-definition"
                         id="api-definition"


### PR DESCRIPTION
Since this is a blocking issue I just decided to revert the addition of UI-Select for this page.

I may be getting a little overeager here in trying to switch to UI-Select, but as I'm diving in, this switch is more problematic for some views than others. It seems like there are many `$watch`'s that are also integrated with other functionality, such as dirty checking and sometimes state setting.

While I'd prefer to have a cleaner implementation of these features, I know it's certainly not ideal nor efficient to rewrite these on the go, especially without testing in place. I think we should still switch to UI-Select, but it may be a while before we can transition completely.

JIRA: https://issues.jboss.org/browse/APIMAN-861

cc @EricWittmann 