### PR TITLE
Improves README to indicate successful testing on both Tomcat 7 and 8…

### DIFF
--- a/gateway/platforms/war/standalone/README.md
+++ b/gateway/platforms/war/standalone/README.md
@@ -34,7 +34,7 @@ If you want to build them again, install from the _standalone_ directory:
 
 ## Deployment
 
-These instructions been tested on Tomcat 8 (apache-tomcat-8.0.30 to be precise).
+These instructions have been tested on Tomcat 7 and 8 (apache-tomcat-7.0.65 and apache-tomcat-8.0.30 to be precise).
 
   1. Copy the WAR files to your Tomcat `webapps` directory
   2. Add a role and users to `conf/tomcat-users.xml`
@@ -57,8 +57,8 @@ You can access them at:
 
 ## Dependencies
 
-  * Since Tomcat (<=8) doesn't provide a CDI implementation, we use JBoss Weld.
-  * Currently expects an Elasticsearch instance running on port `localhost:9200` with a cluster named _apiman_. In order to get up and running quickly, you can use the ES embedded WAR, but a proper Elasticsearch cluster is strongly recommended.
+  * Currently expects an Elasticsearch instance running on port `localhost:9200` with a cluster named _apiman_.
+    * In order to get up and running quickly, you can use the ES embedded WAR, but a proper Elasticsearch cluster is strongly recommended.
 
 ## Implementation
 
@@ -68,3 +68,6 @@ The standalone WARs are based on the _apiman_ micro WAR implementation.
 
   * Consider refactoring `io.apiman.common.config.ConfigFileConfiguration.create(String)` to remove coupling to JBoss/Wildfly with dependency on `jboss.server.config.dir` System property.
   * Tidy up standalone ES WAR project and externalise configuration.
+  * Port _manager_ WARs.
+    * (Re-)introduce _resteasy-cdi_ dependency
+    * Since Tomcat (<=8) doesn't provide a CDI implementation, consider using JBoss Weld.

--- a/gateway/platforms/war/standalone/api/pom.xml
+++ b/gateway/platforms/war/standalone/api/pom.xml
@@ -19,9 +19,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.weld.servlet</groupId>
-            <artifactId>weld-servlet</artifactId>
-            <version>2.2.14.Final</version>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/gateway/platforms/war/standalone/common/pom.xml
+++ b/gateway/platforms/war/standalone/common/pom.xml
@@ -78,16 +78,6 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-cdi</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.resteasy</groupId>
-                    <artifactId>resteasy-jaxrs</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson-provider</artifactId>
         </dependency>
         <dependency>
@@ -111,6 +101,8 @@
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
             <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+            <!-- don't bundle the servlet API -->
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
… and removes note about use of Weld. Removes unneeded CDI dependencies.

Updated README: https://github.com/outofcoffee/apiman/blob/feature/standalone-war-improvements/gateway/platforms/war/standalone/README.md