### PR TITLE
Specify test policy configuration as a file on the classpath

### DIFF
--- a/test/policies/src/main/java/io/apiman/test/policies/Configuration.java
+++ b/test/policies/src/main/java/io/apiman/test/policies/Configuration.java
@@ -32,4 +32,10 @@ public @interface Configuration {
 
     String value() default "";
 
+    /**
+     * The path to a policy configuration file on the classpath, such as: <code>/my-api-config.json</code>
+     *
+     * @return the classpath file path
+     */
+    String classpathConfigFile();
 }

--- a/test/policies/src/main/java/io/apiman/test/policies/Configuration.java
+++ b/test/policies/src/main/java/io/apiman/test/policies/Configuration.java
@@ -37,5 +37,5 @@ public @interface Configuration {
      *
      * @return the classpath file path
      */
-    String classpathConfigFile();
+    String classpathConfigFile() default "";
 }


### PR DESCRIPTION
# Purpose

Allows the developer to specify the test policy configuration as a file on the classpath, rather than inline in the `@Configuration` annotation. An example would be to hold test policy configurations in the `src/test/resources` folder in the plugin project.

# Rationale

Specifying all but trivial configuration in policy tests as a string can make the configuration values difficult to read and maintain. This is because policy configuration is often held in JSON format, requiring escaping of the string. Example:

```java
private static final String PASSTHROUGH_CONFIG = "{\"cookieName\":\"XSESSION\",\"cookiePath\":\"/\",\"invalidateSession\":true,\"responseBehaviour\":\"PassThrough\",\"skipBackendCall\":false}";
    
@Test
@Configuration(PASSTHROUGH_CONFIG)
@BackEndService(EchoBackEndService.class)
public void testLogoutSuccess() throws Throwable {
    // test implementation
}
```

Instead, developers should be able to externalise the test policy configuration as a file; for example, a JSON file within `src/test/resources`:

```json
{
    "cookieName": "XSESSION",
    "cookiePath": "/",
    "invalidateSession": true,
    "responseBehaviour": "PassThrough",
    "skipBackendCall": false
}
```

...and refer to this in the `Configuration` test annotation as follows:

```java
@Test
@Configuration(classpathConfigFile="/passthrough-config.json")
@BackEndService(EchoBackEndService.class)
public void testLogoutSuccess() throws Throwable {
    // test implementation
}
```

# Implementation

A new `classpathConfigFile` property has been added to the `Configuration` annotation. When non-blank, the `PolicyTester` will attempt to load the configuration from file.