### PR TITLE
Updates POM versions for standalone WARs to 1.1.10-SNAPSHOT.

### DIFF
--- a/gateway/platforms/war/standalone/api/pom.xml
+++ b/gateway/platforms/war/standalone/api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>apiman-gateway-platforms-war-standalone</artifactId>
         <groupId>io.apiman</groupId>
-        <version>1.1.9.Final</version>
+        <version>1.1.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
     <dependencies>
         <dependency>
             <groupId>io.apiman</groupId>
-            <version>1.1.9.Final</version>
+            <version>1.1.10-SNAPSHOT</version>
             <artifactId>apiman-gateway-platforms-war-standalone-common</artifactId>
         </dependency>
 

--- a/gateway/platforms/war/standalone/common/pom.xml
+++ b/gateway/platforms/war/standalone/common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>apiman-gateway-platforms-war-standalone</artifactId>
         <groupId>io.apiman</groupId>
-        <version>1.1.9.Final</version>
+        <version>1.1.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gateway/platforms/war/standalone/es/pom.xml
+++ b/gateway/platforms/war/standalone/es/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>apiman-gateway-platforms-war-standalone</artifactId>
     <groupId>io.apiman</groupId>
-    <version>1.1.9.Final</version>
+    <version>1.1.10-SNAPSHOT</version>
   </parent>
   <packaging>war</packaging>
   <artifactId>apiman-gateway-platforms-war-standalone-es</artifactId>

--- a/gateway/platforms/war/standalone/gateway/pom.xml
+++ b/gateway/platforms/war/standalone/gateway/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>apiman-gateway-platforms-war-standalone</artifactId>
         <groupId>io.apiman</groupId>
-        <version>1.1.9.Final</version>
+        <version>1.1.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
     <dependencies>
         <dependency>
             <groupId>io.apiman</groupId>
-            <version>1.1.9.Final</version>
+            <version>1.1.10-SNAPSHOT</version>
             <artifactId>apiman-gateway-platforms-war-standalone-common</artifactId>
         </dependency>
     </dependencies>

--- a/gateway/platforms/war/standalone/pom.xml
+++ b/gateway/platforms/war/standalone/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.apiman</groupId>
     <artifactId>apiman-gateway-platforms</artifactId>
-    <version>1.1.9.Final</version>
+    <version>1.1.10-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <packaging>pom</packaging>


### PR DESCRIPTION
# Purpose

In the `1.1.x` branch, the POM versions for the standalone WARs are currently 1.1.9-Final, whereas in the rest of the POMs in the branch they are `1.1.10-SNAPSHOT`.