### PR TITLE
Set direct access grants only for apiman-gateway-api

### DIFF
--- a/distro/data/src/main/resources/data/apiman-realm.json
+++ b/distro/data/src/main/resources/data/apiman-realm.json
@@ -25,7 +25,7 @@
             "credentials" : [
                 {
                     "type" : "password",
-                    "value" : "admin123!" 
+                    "value" : "admin123!"
                 }
             ],
             "realmRoles" : [ "apiuser", "apiadmin" ],
@@ -97,6 +97,7 @@
                 "/apiman-gateway-api/*"
             ],
             "secret" : "password",
+            "directGrantsOnly" : true,
             "webOrigins" : [ "*" ]
         }
     ]


### PR DESCRIPTION
This change should allow newer versions of KC to work with our deployment guide, and doesn't break with our shipping version of KC.

I've tested it several times, and it all seems to work fine, but would appreciate @EricWittmann and @kahboom testing it to see if you can break it (delete your existing apiman realm in KC and import this one).

One item of discussion is the fact that the KC import/export format of the version we share in our developer's guide is actually [very different to the one which ship with](https://gist.github.com/msavy/4c94bd70483a814c7a32) - however it still works (for now).  I suggest we update it once we move to the new version of KC. I'll make a JIRA ticket for that.