### PR TITLE
Feature: When creating a contract with a custom "apiKey" so we can override original key generation.

### DIFF
--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/contracts/NewContractBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/contracts/NewContractBean.java
@@ -31,11 +31,16 @@ public class NewContractBean implements Serializable {
     private String apiVersion;
 
     private String planId;
+    private String apiKey;
 
     /**
      * Constructor.
      */
     public NewContractBean() {
+    }
+
+    public static long getSerialVersionUID() {
+        return serialVersionUID;
     }
 
     /**
@@ -95,6 +100,20 @@ public class NewContractBean implements Serializable {
     }
 
     /**
+     * @return the contractKey
+     */
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    /**
+     * @param apiKey to set
+     */
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    /**
      * @see java.lang.Object#hashCode()
      */
     @Override
@@ -105,6 +124,7 @@ public class NewContractBean implements Serializable {
         result = prime * result + ((apiId == null) ? 0 : apiId.hashCode());
         result = prime * result + ((apiOrgId == null) ? 0 : apiOrgId.hashCode());
         result = prime * result + ((apiVersion == null) ? 0 : apiVersion.hashCode());
+        result = prime * result + ((apiKey == null) ? 0 : apiKey.hashCode());
         return result;
     }
 
@@ -140,6 +160,11 @@ public class NewContractBean implements Serializable {
                 return false;
         } else if (!apiVersion.equals(other.apiVersion))
             return false;
+        if (apiKey == null) {
+            if (other.apiKey != null)
+                return false;
+        } else if (!apiKey.equals(other.apiKey))
+            return false;
         return true;
     }
 
@@ -149,8 +174,8 @@ public class NewContractBean implements Serializable {
     @Override
     @SuppressWarnings("nls")
     public String toString() {
-        return "NewContractBean [apiOrgId=" + apiOrgId + ", apiId=" + apiId
-                + ", apiVersion=" + apiVersion + ", planId=" + planId + "]";
+        return "NewContractBean [apiOrgId=" + apiOrgId + ", apiId=" + apiId + ", apiVersion=" + apiVersion
+                + ", planId=" + planId + ", apiKey=" + apiKey + "]";
     }
 
 }

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/OrganizationResourceImpl.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/OrganizationResourceImpl.java
@@ -797,7 +797,7 @@ public class OrganizationResourceImpl implements IOrganizationResource {
         contract.setPlan(pvb);
         contract.setCreatedBy(securityContext.getCurrentUser());
         contract.setCreatedOn(new Date());
-        contract.setApikey(apiKeyGenerator.generate());
+        contract.setApikey((bean.getApiKey() == null) ? apiKeyGenerator.generate() : bean.getApiKey());
 
         // Move the client to the "Ready" state if necessary.
         if (cvb.getStatus() == ClientStatus.Created && clientValidator.isReady(cvb, true)) {

--- a/manager/test/api/src/test/resources/test-plan-data/contracts/contracts/003_create-contract1.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/contracts/contracts/003_create-contract1.resttest
@@ -5,7 +5,8 @@ Content-Type: application/json
   "apiOrgId" : "Organization1",
   "apiId" : "API1",
   "apiVersion" : "1.0",
-  "planId" : "Plan1"
+  "planId" : "Plan1",
+  "apiKey" : "customApiKey"
 }
 ----
 200
@@ -60,5 +61,6 @@ X-RestTest-BindTo-contractId: id
     "status" : "Locked",
     "version" : "1.0",
     "createdBy" : "admin"
-  }
+  },
+  "apikey" : "customApiKey"
 }

--- a/manager/test/api/src/test/resources/test-plans/contracts-testPlan.xml
+++ b/manager/test/api/src/test/resources/test-plans/contracts-testPlan.xml
@@ -38,7 +38,7 @@
     <test name="Publish API 1">test-plan-data/contracts/publish/001_publish-api-1.resttest</test>
     <test name="Publish API 2">test-plan-data/contracts/publish/002_publish-api-2.resttest</test>
 
-    <test name="Create Contract to API 1">test-plan-data/contracts/contracts/003_create-contract1.resttest</test>
+    <test name="Create Contract to API 1 (with custom apiKey)">test-plan-data/contracts/contracts/003_create-contract1.resttest</test>
     <test name="List Contracts for Client 1 [1]">test-plan-data/contracts/contracts/004_get-contracts.resttest</test>
     <test name="Create Contract to API 2">test-plan-data/contracts/contracts/005_create-contract2.resttest</test>
     <test name="List Contracts for Client 1 [2]">test-plan-data/contracts/contracts/006_get-contracts.resttest</test>


### PR DESCRIPTION
Hi Eric, 

i've extended the Apiman REST call which creates a contract. Now it also takes an optional parameter which allows the creation of a contract with custom "apiKey". I thought it would also be useful to others. 

I've installed the code formatter but intelliJ had an opinion of its own, so you will see come commits reverting the file and manually apply the changes.

I've also extended a current test *.resttet to test this.

Maybe it would be work having a small section on the README, specifying how the test works, it took me a while to figure it out. (especially the resttest). 

Thanks

Andrea