### PR TITLE
re #876 Login Failure

### DIFF
--- a/manager/ui/hawtio/plugins/api-manager/ts/forms/edit-gateway.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/forms/edit-gateway.ts
@@ -79,6 +79,13 @@ module Apiman {
                         $scope.testErrorMessage = reply.detail;
                     }
                 }, function(error) {
+                    var charRegExp = /([\\]*)?"(pass|password)([\\]*)?":([\\]*)?"(.+?)([\\]*)?"/g;
+                    var regTest = charRegExp.test(JSON.stringify(error));
+
+                    if (regTest === true) {
+                        error = JSON.stringify(error).replace(charRegExp, '\\"password\\":\\"*****\\"');
+                    }
+
                     $scope.testButton.state = 'error';
                     $scope.testResult = 'error';
                     $scope.testErrorMessage = error;

--- a/manager/ui/hawtio/plugins/api-manager/ts/forms/new-gateway.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/forms/new-gateway.ts
@@ -56,6 +56,13 @@ module Apiman {
                         $scope.testErrorMessage = reply.detail;
                     }
                 }, function(error) {
+                    var charRegExp = /([\\]*)?"(pass|password)([\\]*)?":([\\]*)?"(.+?)([\\]*)?"/g;
+                    var regTest = charRegExp.test(JSON.stringify(error));
+
+                    if (regTest === true) {
+                        error = JSON.stringify(error).replace(charRegExp, '\\"password\\":\\"*****\\"');
+                    }
+
                     $scope.testButton.state = 'error';
                     $scope.testResult = 'error';
                     $scope.testErrorMessage = error;

--- a/manager/ui/hawtio/plugins/api-manager/ts/forms/new-gateway.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/forms/new-gateway.ts
@@ -60,7 +60,7 @@ module Apiman {
                     $scope.testResult = 'error';
                     $scope.testErrorMessage = error;
                 });
-            }
+            };
             
             $scope.createGateway = function() {
                 $scope.createButton.state = 'in-progress';

--- a/manager/ui/hawtio/plugins/api-manager/ts/rpc.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/rpc.ts
@@ -13,28 +13,28 @@ module ApimanRPC {
         function($resource, Configuration) {
             var endpoint = Configuration.api.endpoint + '/:entityType/:secondaryType';
 
+            /*
             // Intercept Errors
             function resourceErrorResponseHandler(response) {
-                if(response.config
-                    && response.config.data
-                    && response.config.data.configuration) {
-                    response.config.data.configuration = JSON.parse(response.config.data.configuration);
+                var charRegExp = /([\\]*)?"(pass|password)([\\]*)?":([\\]*)?"(.+?)([\\]*)?"/g;
+                var regTest = charRegExp.test(JSON.stringify(response));
 
-                    // Check if Password is Showing
-                    if(response.config.data.configuration.password) {
-                        // Remove Password from Response
-                        response.config.data.configuration.password = '*****';
-                    }
+                if (regTest === true) {
+                    var newResponse = JSON.stringify(response).replace(charRegExp, '\\"password\\":\\"*****\\"');
+                    console.log('Formatted response: ' + newResponse);
+
+                    return newResponse;
                 }
 
                 return response;
             }
+            */
 
             return $resource(endpoint,
                 { entityType: '@entityType', secondaryType: '@secondaryType' }, {
                 update: {
-                  method: 'PUT', // this method issues a PUT request
-                    interceptor : {responseError : resourceErrorResponseHandler }
+                  method: 'PUT'//, // this method issues a PUT request
+                    //interceptor : {responseError : resourceErrorResponseHandler }
                 }});
         }]);
 

--- a/manager/ui/hawtio/plugins/api-manager/ts/rpc.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/rpc.ts
@@ -12,10 +12,29 @@ module ApimanRPC {
     export var ApimanSvcs = _module.factory('ApimanSvcs', ['$resource', 'Configuration',
         function($resource, Configuration) {
             var endpoint = Configuration.api.endpoint + '/:entityType/:secondaryType';
+
+            // Intercept Errors
+            function resourceErrorResponseHandler(response) {
+                if(response.config
+                    && response.config.data
+                    && response.config.data.configuration) {
+                    response.config.data.configuration = JSON.parse(response.config.data.configuration);
+
+                    // Check if Password is Showing
+                    if(response.config.data.configuration.password) {
+                        // Remove Password from Response
+                        response.config.data.configuration.password = '*****';
+                    }
+                }
+
+                return response;
+            }
+
             return $resource(endpoint,
                 { entityType: '@entityType', secondaryType: '@secondaryType' }, {
                 update: {
-                  method: 'PUT' // this method issues a PUT request
+                  method: 'PUT', // this method issues a PUT request
+                    interceptor : {responseError : resourceErrorResponseHandler }
                 }});
         }]);
 


### PR DESCRIPTION
Changes:
- Add regex check for JSON key `password` in all responses that result in an error when testing a new or existing gateway.

JIRA: https://issues.jboss.org/browse/APIMAN-876

Notes:
We need to make some big improvements here. The regex is only checking for JSON, not accounting for the fact that users can configure their policies to return a response in XML or YAML. We need to support these as well.

In addition, the check is only done for the Edit Gateway and New Gateway views, and in their respective controllers. This check should be done at the service level for all failed requests. The regex check was returning the original error before the formatted error and was causing some issues from within the service, so it had to be moved to the controller for now. I was able to do this from the service only when parsing JSON responses and emptying the `password` value, but regex would be a lot more flexible as passwords can appear in different places. Another alternative would be to iterate over all keys and look for any that are called `password`, just not as flexible as regex. Either way, it is likely we will need to use regex for YAML (maybe not for XML, it depends).

We also should be adding these checks to the Logger service we are using as well.

cc @EricWittmann @msavy 