### PR TITLE
re #864 Change cursor to pointer instead of default

### DIFF
--- a/manager/ui/hawtio/plugins/api-manager/html/api/api_entity.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/api/api_entity.include
@@ -88,7 +88,7 @@
         <!-- Checklist Template -->
         <script type="text/ng-template"
                 id="checklistTemplate.html">
-          <span style="cursor: default; position: absolute; top: 9px; right: 10px; color: #777;"
+          <span style="cursor: pointer; position: absolute; top: 9px; right: 10px; color: #777;"
                 ng-click="closePopover()"
                 class="fa fa-close"></span>
           <uib-accordion close-others="oneAtATime">


### PR DESCRIPTION
Changed cursor on the "Why can't I publish?" popover close button to `pointer` instead of `default`.

JIRA: https://issues.jboss.org/browse/APIMAN-864

cc @EricWittmann 