### PR TITLE
Ignore Resources Policy: enhance to allow shading by VERB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ gwt-unitCache
 *.iml
 .idea
 npm-debug.log
+.metadata

--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/IgnoredResourcesPolicy.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/IgnoredResourcesPolicy.java
@@ -15,23 +15,25 @@
  */
 package io.apiman.gateway.engine.policies;
 
+import io.apiman.gateway.engine.policies.config.IgnoredResource;
 import io.apiman.gateway.engine.beans.PolicyFailure;
 import io.apiman.gateway.engine.beans.PolicyFailureType;
 import io.apiman.gateway.engine.beans.ApiRequest;
 import io.apiman.gateway.engine.components.IPolicyFailureFactoryComponent;
+import io.apiman.gateway.engine.policies.PolicyFailureCodes;
 import io.apiman.gateway.engine.policies.config.IgnoredResourcesConfig;
 import io.apiman.gateway.engine.policies.i18n.Messages;
 import io.apiman.gateway.engine.policy.IPolicyChain;
 import io.apiman.gateway.engine.policy.IPolicyContext;
 
 /**
- * A simple policy that causes a failure if the paths of the inbound
- * request matching the configured set of regular expressions.
+ * A simple policy that causes a failure if the paths of the inbound request
+ * matching the configured set of regular expressions.
  *
  * @author rubenrm1@gmail.com
  */
 public class IgnoredResourcesPolicy extends AbstractMappedPolicy<IgnoredResourcesConfig> {
-    
+
     /**
      * Constructor.
      */
@@ -45,36 +47,51 @@ public class IgnoredResourcesPolicy extends AbstractMappedPolicy<IgnoredResource
     protected Class<IgnoredResourcesConfig> getConfigurationClass() {
         return IgnoredResourcesConfig.class;
     }
-    
+
     /**
-     * @see io.apiman.gateway.engine.policies.AbstractMappedPolicy#doApply(io.apiman.gateway.engine.beans.ApiRequest, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     * @see io.apiman.gateway.engine.policies.AbstractMappedPolicy#doApply(io.apiman.gateway.engine.beans.ApiRequest,
+     *      io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object,
+     *      io.apiman.gateway.engine.policy.IPolicyChain)
      */
     @Override
     protected void doApply(ApiRequest request, IPolicyContext context, IgnoredResourcesConfig config,
             IPolicyChain<ApiRequest> chain) {
-        if (!satisfiesAnyPath(config, request.getDestination())) {
+        if (!satisfiesAnyPath(config, request.getDestination(), request.getType())) {
             super.doApply(request, context, config, chain);
         } else {
-            IPolicyFailureFactoryComponent ffactory = context.getComponent(IPolicyFailureFactoryComponent.class);
-            String msg = Messages.i18n.format("IgnoredResourcesPolicy.PathsToIgnore", request.getDestination()); //$NON-NLS-1$
-            PolicyFailure failure = ffactory.createFailure(PolicyFailureType.NotFound, PolicyFailureCodes.PATHS_TO_IGNORE, msg);
+            IPolicyFailureFactoryComponent ffactory = context
+                    .getComponent(IPolicyFailureFactoryComponent.class);
+            String msg = Messages.i18n.format("IgnoredResourcesPolicy.PathsToIgnore", //$NON-NLS-1$
+                    request.getDestination());
+            PolicyFailure failure = ffactory.createFailure(PolicyFailureType.NotFound,
+                    PolicyFailureCodes.PATHS_TO_IGNORE, msg);
             chain.doFailure(failure);
         }
     }
-    
+
     /**
-     * Evaluates whether the destination provided matches any of the configured pathsToIgnore
+     * Evaluates whether the destination provided matches any of the configured
+     * pathsToIgnore
      * 
-     * @param config The {@link IgnoredResourcesConfig} containing the pathsToIgnore
-     * @param destination The destination to evaluate
+     * @param config
+     *            The {@link IgnoredResourcesConfig} containing the
+     *            pathsToIgnore
+     * @param destination
+     *            The destination to evaluate
+     * @param verb
+     *            HTTP verb or '*' for all verbs
      * @return true if any path matches the destination. false otherwise
      */
-    private boolean satisfiesAnyPath(IgnoredResourcesConfig config, String destination) {
+    private boolean satisfiesAnyPath(IgnoredResourcesConfig config, String destination, String verb) {
         if (destination == null || destination.trim().length() == 0) {
             destination = "/"; //$NON-NLS-1$
         }
-        for (String pathToIgnore : config.getPathsToIgnore()) {
-            if (destination.matches(pathToIgnore)) {
+        for (IgnoredResource resource : config.getRules()) {
+            String resourceVerb = resource.getVerb();
+            boolean verbMatches = verb == null || IgnoredResource.VERB_MATCH_ALL.equals(resourceVerb)
+                    || verb.equalsIgnoreCase(resourceVerb); // $NON-NLS-1$
+            boolean destinationMatches = destination.matches(resource.getPathPattern());
+            if (verbMatches && destinationMatches) {
                 return true;
             }
         }

--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/config/IgnoredResource.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/config/IgnoredResource.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.policies.config;
+
+/**
+ * A single ignored resource rule consisting of a verb (GET,POST etc.) and path
+ * pattern
+ *
+ * @author wtr@redhat.com
+ */
+public class IgnoredResource {
+
+    private String verb;
+    private String pathPattern;
+
+    /**
+     * Used to match all possible http verbs.
+     */
+    public final static String VERB_MATCH_ALL = "*";
+
+    /**
+     * Constructor.
+     */
+    public IgnoredResource() {
+    }
+
+    /**
+     * @return the verb
+     */
+    public String getVerb() {
+        return verb;
+    }
+
+    /**
+     * @param verb
+     *            the verb to set
+     */
+    public void setVerb(String verb) {
+        this.verb = verb;
+    }
+
+    /**
+     * @return the pathPattern
+     */
+    public String getPathPattern() {
+        return pathPattern;
+    }
+
+    /**
+     * @param pathPattern
+     *            the pathPattern to set
+     */
+    public void setPathPattern(String pathPattern) {
+        this.pathPattern = pathPattern;
+    }
+
+    /**
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object obj) {
+        IgnoredResource rule2 = (IgnoredResource) obj;
+        return this.getVerb().equals(rule2.getVerb()) && this.getPathPattern().equals(rule2.getPathPattern());
+    }
+
+}

--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/config/IgnoredResourcesConfig.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/config/IgnoredResourcesConfig.java
@@ -15,7 +15,6 @@
  */
 package io.apiman.gateway.engine.policies.config;
 
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,7 +25,7 @@ import java.util.List;
  */
 public class IgnoredResourcesConfig {
 
-    private List<String> pathsToIgnore = new ArrayList<>();
+    private List<IgnoredResource> rules = new ArrayList<>();
 
     /**
      * Constructor.
@@ -37,15 +36,16 @@ public class IgnoredResourcesConfig {
     /**
      * @return the pathsToIgnore
      */
-    public List<String> getPathsToIgnore() {
-        return pathsToIgnore;
+    public List<IgnoredResource> getRules() {
+        return rules;
     }
 
     /**
-     * @param pathsToIgnore the pathsToIgnore to set
+     * @param pathsToIgnore
+     *            the pathsToIgnore to set
      */
-    public void setPathsToIgnore(List<String> pathsToIgnore) {
-        this.pathsToIgnore = pathsToIgnore;
+    public void setRules(List<IgnoredResource> pathsToIgnore) {
+        this.rules = pathsToIgnore;
     }
 
 }

--- a/gateway/test/src/test/resources/test-plan-data/policies/ignored-resources-xml/002-register-client.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/ignored-resources-xml/002-register-client.resttest
@@ -14,7 +14,7 @@ Content-Type: application/json
       "policies" : [
         {
           "policyImpl" : "class:io.apiman.gateway.engine.policies.IgnoredResourcesPolicy",
-          "policyJsonConfig" : "{ \"pathsToIgnore\" : [\"/invoices/.+/items/.+\", \"/items/.+\"] }"
+          "policyJsonConfig" : "{\"rules\":[{\"verb\":\"*\",\"pathPattern\":\"/invoices/.+/items/.+\"},{\"verb\":\"*\",\"pathPattern\":\"/items/.+\"}]}"
         }
       ]
     }

--- a/gateway/test/src/test/resources/test-plan-data/policies/ignored-resources/002-register-client.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/ignored-resources/002-register-client.resttest
@@ -14,7 +14,7 @@ Content-Type: application/json
       "policies" : [
         {
           "policyImpl" : "class:io.apiman.gateway.engine.policies.IgnoredResourcesPolicy",
-          "policyJsonConfig" : "{ \"pathsToIgnore\" : [\"/invoices/.+/items/.+\", \"/items/.+\"] }"
+          "policyJsonConfig" : "{\"rules\":[{\"verb\":\"*\",\"pathPattern\":\"/invoices/.+/items/.+\"},{\"verb\":\"*\",\"pathPattern\":\"/items/.+\"}]}"
         }
       ]
     }

--- a/manager/ui/hawtio/plugins/api-manager/html/directives/requestMethod.html
+++ b/manager/ui/hawtio/plugins/api-manager/html/directives/requestMethod.html
@@ -1,0 +1,11 @@
+<select id="requestMethod" ng-model="verb" apiman-select-picker data-width="110" data-live-search="false" ng-disabled="isEntityDisabled()">
+	 <option value="*" selected="selected">*</option>
+	   <option value="GET">GET</option>
+	   <option value="POST">POST</option>
+	   <option value="PUT">PUT</option>
+	   <option value="DELETE">DELETE</option>
+	   <option value="OPTIONS">OPTIONS</option>
+	   <option value="HEAD">HEAD</option>
+	   <option value="TRACE">TRACE</option>
+	   <option value="CONNECT">CONNECT</option>
+</select>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/authorization.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/authorization.include
@@ -7,41 +7,29 @@
       width: 100%;
       margin-bottom: 10px;
     }
-    .authorization-form .panel {
-    }
-    .authorization-form .panel span {
-      padding-left: 3px;
-      padding-right: 3px;
-      margin-top: 4px;
-    }
     .authorization-form .panel button {
-      margin-top: 15px;
-    }
-    .authorization-form .panel input.apiman-form-control[type="text"] {
-      display: inline;
-      width: 120px;
-      margin-top: 4px;
-    }
-    #form-page .authorization-form dl dd .inline-form-select {
-      display: inline-table;
-      width: auto;
-      margin-top: 4px;
+      float:right;
     }
   </style>
   <div class="help" apiman-i18n-key="authorization-message">Manage the list of fine-grained authorization rules in the box below.  If you want a single required role to protect your entire API, simply add one item with a path of ".*" and a verb of "*".</div>
-  
   <div class="panel panel-default">
     <div class="panel-heading">
       <h3 class="panel-title" apiman-i18n-key="add-authorization-rule">Add Authorization Rule</h3>
     </div>
     <div class="panel-body">
-      <span apiman-i18n-key="authorization.to-access">To access resource</span>
-      <input id="path" ng-model="path" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="authorization.enter-path" placeholder="(/path/to/.*)" ng-disabled="isEntityDisabled()"></input>
-      <span apiman-i18n-key="authorization.using-verb">using verb/action</span>
-      <input id="verb" ng-model="verb" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="authorization.enter-verb" placeholder="(verb)" ng-disabled="isEntityDisabled()"></input>
-      <span apiman-i18n-key="authorization.must-have-role">the user must have role</span>
-      <input id="role" ng-model="role" class="apiman-form-control form-control" style="" type="text" apiman-i18n-key="authorization.enter-role" placeholder="(required role)" ng-disabled="isEntityDisabled()"></input>
-      <span apiman-i18n-key="authorization.period">.</span>
+      <div style="display:inline-block;margin-right:10px;margin-bottom:4px;">
+     	<label for="path" apiman-i18n-key="authorization.to-access">Ignored URI</label>
+     	<input id="path" name="path" ng-model="path" class="apiman-form-control form-control" style="margin-top:5px;margin-bottom:5px;" type="text" apiman-i18n-key="authorization.enter-path" placeholder="(/path/to/.*)" ng-disabled="isEntityDisabled()"></input>
+      </div>
+      <div style="display: inline-block;margin-right:10px;margin-bottom:4px;">
+     	<label style="display: block;" apiman-i18n-key="authorization.must-have-role">User Role</label>
+      	<input id="role" ng-model="role" class="apiman-form-control form-control" style="width:150px;" type="text" apiman-i18n-key="authorization.enter-role" placeholder="(required role)" ng-disabled="isEntityDisabled()"></input>
+      </div>
+      <div style="display: inline-block;margin-right:10px;margin-bottom:4px;">
+    	<label apiman-i18n-key="authorization.using-verb" style="display: block;">HTTP method</label>
+     	<http-verbs-select></http-verbs-select>
+      </div>
+      <div></div>
       <div>
         <button id="add-rule" ng-disabled="currentItemInvalid()" ng-click="add(path, verb, role)" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px" ng-disabled="isEntityDisabled()">Add</button>
       </div>

--- a/manager/ui/hawtio/plugins/api-manager/html/policyForms/ignored-resources.include
+++ b/manager/ui/hawtio/plugins/api-manager/html/policyForms/ignored-resources.include
@@ -1,14 +1,56 @@
-<div class="form policy-config ip-list" data-field="form" ng-controller="Apiman.IgnoredResourcesFormController">
-  <div apiman-i18n-key="ignored-resources-message">Manage the list of regular expressions to be ignored in the box below.</div>
-  <div style="width: 100%; float: left; margin-bottom: 5px; margin-top: 5px">
-    <select id="paths" ng-model="selectedPath" data-field="pathsToIgnore" multiple class="apiman-form-control form-control" style="height: 150px; width: 200px; float: left;" ng-options="item for item in config.pathsToIgnore | orderBy: 'toString()'" ng-disabled="isEntityDisabled()">
-    </select>
-    <div style="margin-left: 5px; float: left">
-      <button id="clear" ng-click="clear()" ng-disabled="!config.pathsToIgnore || isEntityDisabled()" data-field="clear" apiman-i18n-key="clear" class="btn btn-default" style="min-width: 75px">Clear</button>
-      <div class="clear:both"></div>
-      <button id="remove" ng-click="remove(selectedPath)" ng-disabled="!selectedPath || isEntityDisabled()" data-field="remove" apiman-i18n-key="remove" class="btn btn-default" style="min-width: 75px; margin-top: 5px;">Remove</button>
-    </div>
+<div class="form policy-config ignored-resources" data-field="form" ng-controller="Apiman.IgnoredResourcesFormController">
+  <div style="margin-bottom:10px;" apiman-i18n-key="ignored-resources-message">Manage the list of API routes that will be ignored.</div>
+   
+ <div class="panel panel-default">
+   <div class="panel-heading">
+     <h3 class="panel-title" apiman-i18n-key="add-ignored-resources-rule">Ignore Resources Rule</h3>
+   </div>
+   <div class="panel-body">
+   	 <div style="display: inline-block;margin-right:10px">
+     	<label for="path" style="display: inline;" apiman-i18n-key="ignored-resources.to-access">Ignored URI</label>
+     	<input id="path" name="path" ng-model="pathPattern" class="apiman-form-control form-control" style="margin-top:5px;margin-bottom:5px;" type="text" apiman-i18n-key="ignored-resources.enter-path" placeholder="(/path/to/.*)" ng-disabled="isEntityDisabled()"></input>
+     </div>
+     <div style="display: inline-block;">
+    	<label apiman-i18n-key="ignored-resources.using-verb" style="display: block;margin-right:10px;">HTTP method</label>
+     	<http-verbs-select></http-verbs-select>
+     </div>
+     <div style="margin:10px"></div>
+     <div style="float:right;margin-top:10px">
+       <button id="add-rule" ng-disabled="currentItemInvalid()" ng-click="add(pathPattern, verb)" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px" ng-disabled="isEntityDisabled()">Add</button>
+     </div>
+   </div>
+ </div>
+  
+  <div>
+    <dl>
+      <dt apiman-i18n-key="configured-ignored-resources-rules">Ignored Resources</dt>
+    </dl>
   </div>
-  <input id="path" ng-model="path" data-field="pathToIgnore" class="apiman-form-control form-control" style="width: 200px; float: left; margin-right: 5px" type="text" apiman-i18n-key="ignored-resources.enter-path" placeholder="Enter a Path to ignore..." ng-disabled="isEntityDisabled()"></input>
-  <button id="add" ng-disabled="!path || isEntityDisabled()" ng-click="add(path)" data-field="add" apiman-i18n-key="add" class="btn btn-default" style="min-width: 75px">Add</button>
+  
+  <table class="table table-striped table-bordered">
+    <thead>
+      <tr>
+        <th width="30%" apiman-i18n-key="verb">Method</th>
+        <th width="70%" apiman-i18n-key="path">Path</th>
+        <th width="1%"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr ng-repeat="item in config.rules | orderBy: 'pathPattern'">
+        <td>{{ item.pathPattern }}</td>
+        <td>{{ item.verb }}</td>
+        <td>
+          <button ng-click="remove(item)" class="btn btn-default" ng-disabled="isEntityDisabled()"><i class="fa fa-times fa-fw"></i></button>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="4" ng-show="!config.rules.length">
+          <div class="apiman-no-content">
+            <p class="apiman-no-entities-description" apiman-i18n-key="ignored-resources.no-rules-table">No resources excluded.</p>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  
 </div>

--- a/manager/ui/hawtio/plugins/api-manager/ts/directives.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/directives.ts
@@ -65,7 +65,6 @@ module Apiman {
                             $(element)['selectpicker']('refresh');
                         });
                     }
-
                     $timeout(function() {
                         $(element)['selectpicker']();
                         $(element)['selectpicker']('refresh');
@@ -97,10 +96,6 @@ module Apiman {
                             $(element)['selectpicker']('destroy');
                         });
                     });
-
-                    $timeout(function() {
-                        $(element)['selectpicker']('refresh');
-                    }, 200);
                 }
             };
         }]);
@@ -652,4 +647,20 @@ module Apiman {
             }
         }
     });
+    
+   _module.directive('httpVerbsSelect',
+        ['Logger', function(Logger) {
+            return {
+                templateUrl: 'plugins/api-manager/html/directives/requestMethod.html',
+                replace: true,
+                restrict: 'E',
+                link: function(scope, elem, attrs) {
+                 	// init model
+                 	scope.resetVerbsSelector = function(){
+                 		scope.verb="*";
+                 	}
+                 	scope.resetVerbsSelector();
+                }
+            };
+        }]);
 }

--- a/manager/ui/hawtio/plugins/api-manager/ts/policies.ts
+++ b/manager/ui/hawtio/plugins/api-manager/ts/policies.ts
@@ -338,40 +338,37 @@ module Apiman {
         ['$scope', 'Logger', 'EntityStatusSvc',
         ($scope, Logger, EntityStatusSvc) => {
             var validate = function(config) {
-                var valid = true;
-
+              	var valid = config.rules && config.rules.length > 0;
                 $scope.setValid(valid);
             };
-
+			$scope.currentItemInvalid=function(){ return !$scope.pathPattern || !$scope.verb || !isRegexpValid($scope.path); };
             $scope.$watch('config', validate, true);
             
-            $scope.add = function(path) {
-                if (!$scope.config.pathsToIgnore) {
-                    $scope.config.pathsToIgnore = [];
+            $scope.add = function(path, verb) {
+                if (!$scope.config.rules) {
+                    $scope.config.rules = [];
                 }
-
-                $scope.remove(path);
-                $scope.config.pathsToIgnore.push(path);
-                $scope.selectedPath =  [ path ];
-                $scope.path = undefined;
+                var rule = {
+                    'verb' : verb,
+                    'pathPattern' : path
+                };
+                $scope.config.rules.push(rule);
+                
+                $scope.pathPattern = undefined;
+                $scope.resetVerbsSelector();
                 $('#path').focus();
             };
             
-            $scope.remove = function(paths) {
-                angular.forEach(paths, function(path) {
-                    var idx = -1;
-
-                    angular.forEach($scope.config.pathsToIgnore, function(item, index) {
-                        if (item == path) {
-                            idx = index;
-                        }
-                    });
-
-                    if (idx != -1) {
-                        $scope.config.pathsToIgnore.splice(idx, 1);
+            $scope.remove = function(selectedRule) {
+ 				var idx = -1;
+                angular.forEach($scope.config.rules, function (item, index) {
+                    if (item == selectedRule) {
+                        idx = index;
                     }
                 });
-
+                if (idx != -1) {
+                    $scope.config.rules.splice(idx, 1);
+                }
                 $scope.selectedPath = undefined;
             };
             
@@ -604,8 +601,8 @@ module Apiman {
 
                 $scope.config.rules.push(rule);
                 $scope.path = undefined;
-                $scope.verb = undefined;
                 $scope.role = undefined;
+                $scope.resetVerbsSelector();
 
                 $('#path').focus();
             };


### PR DESCRIPTION
## What was done
- Added verb (http method) support for Ignore resources policy rule.
- Adjusted tests to cover new cases. 
- Reshaped UI to support new functionalities. 

## Gui changes

`IgnoredAligators`
http://gfycat.com/ThatBowedAlligatorgar

`AuthBorer`
http://gfycat.com/AliveKindlyBorer

## Technical comments

1. Policies gui components
I think we may improve a little bit the way we style policies. 
Currently we use nested style (which is slightly invalid) or direct style on elements. 
I think that we can have separate style templates for this (with gulp support). 
It might look better to clean all rules at the same time so I'm not pushing that here.

2. Separate ts files per policy.
It may be better to have separate ts files per policy (this may speed up gulp building)
Do we have any reasons to keep it in one file?