### PR TITLE
Upgrade frontend plugin to 0.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <version.war.plugin>2.5</version.war.plugin>
     <version.exec.plugin>1.3.2</version.exec.plugin>
     <version.docker.plugin>0.11.2</version.docker.plugin>
-    <version.frontend-maven.plugin>0.0.23</version.frontend-maven.plugin>
+    <version.frontend-maven.plugin>0.0.27</version.frontend-maven.plugin>
 
     <!-- Dependency Versions -->
     <version.com.fasterxml.classmate>0.8.0</version.com.fasterxml.classmate>


### PR DESCRIPTION
Upgrade to latest version as internal builds need the ability to set `npmRegistryURL` which is only available in >= 0.27.