### PR TITLE
Configurable connection options (timeouts, redirects) for service connector in 1.1.x

### DIFF
--- a/common/config/src/main/java/io/apiman/common/config/options/AbstractOptions.java
+++ b/common/config/src/main/java/io/apiman/common/config/options/AbstractOptions.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
 
 /**
  * Base class for all options.
@@ -73,6 +74,15 @@ public abstract class AbstractOptions {
             return defaultValue;
         } else {
             return BooleanUtils.toBoolean(value);
+        }
+    }
+
+    protected static int parseInt(Map<String, String> optionsMap, String key, int defaultValue) {
+        String value = optionsMap.get(key);
+        if (value == null) {
+            return defaultValue;
+        } else {
+            return NumberUtils.toInt(value, defaultValue);
         }
     }
 }

--- a/common/config/src/main/java/io/apiman/common/config/options/ConnectionOptions.java
+++ b/common/config/src/main/java/io/apiman/common/config/options/ConnectionOptions.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.common.config.options;
+
+import java.util.Map;
+
+/**
+ * Options parser for connection settings.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+public class ConnectionOptions extends AbstractOptions {
+    public static final String PREFIX = "connection."; //$NON-NLS-1$
+    public static final String FOLLOW_REDIRECTS = PREFIX + "followRedirects"; //$NON-NLS-1$
+    public static final String READ_TIMEOUT = PREFIX + "readTimeout"; //$NON-NLS-1$
+    public static final String CONNECT_TIMEOUT = PREFIX + "connectTimeout"; //$NON-NLS-1$
+
+    /**
+     * Whether to automatically follow redirects.
+     */
+    private boolean followRedirects;
+
+    /**
+     * The read timeout in millis.
+     */
+    private int readTimeout;
+
+    /**
+     * The connect timeout in millis.
+     */
+    private int connectTimeout;
+
+    /**
+     * Constructor. Parses options immediately.
+     * @param options the options
+     */
+    public ConnectionOptions(Map<String, String> options) {
+        super(options);
+    }
+
+    /**
+     * @see AbstractOptions#parse(Map)
+     */
+    @Override
+    protected void parse(Map<String, String> options) {
+        setFollowRedirects(parseBool(options, FOLLOW_REDIRECTS, true));
+        setReadTimeout(parseInt(options, READ_TIMEOUT, 15000));
+        setConnectTimeout(parseInt(options, CONNECT_TIMEOUT, 10000));
+    }
+
+    /**
+     * @return the followRedirects
+     */
+    public boolean isFollowRedirects() {
+        return followRedirects;
+    }
+
+    /**
+     * @param followRedirects the followRedirects to set
+     */
+    public void setFollowRedirects(boolean followRedirects) {
+        this.followRedirects = followRedirects;
+    }
+
+    /**
+     * @return the readTimeout
+     */
+    public int getReadTimeout() {
+        return readTimeout;
+    }
+
+    /**
+     * @param readTimeout the readTimeout to set
+     */
+    public void setReadTimeout(int readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+
+    /**
+     * @return the connectTimeout
+     */
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    /**
+     * @param connectTimeout the connectTimeout to set
+     */
+    public void setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+}

--- a/distro/wildfly8/src/main/resources/overlay/standalone/configuration/apiman.properties
+++ b/distro/wildfly8/src/main/resources/overlay/standalone/configuration/apiman.properties
@@ -69,6 +69,18 @@ apiman-gateway.metrics.client.username=${apiman.es.username}
 apiman-gateway.metrics.client.password=${apiman.es.password}
 
 # ---------------------------------------------------------------------
+# Connection settings for the gateway connector(s).
+# ---------------------------------------------------------------------
+
+# Whether to automatically follow redirects (301, 302 etc.) from the
+# back-end service.
+#apiman-gateway.connector-factory.connection.followRedirects=false
+
+# Configure the timeout values for connections to the back-end service.
+#apiman-gateway.connector-factory.connection.readTimeout=15000
+#apiman-gateway.connector-factory.connection.connectTimeout=10000
+
+# ---------------------------------------------------------------------
 # SSL/TLS settings for the gateway connector(s).
 # ---------------------------------------------------------------------
 

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpConnectorFactory.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpConnectorFactory.java
@@ -15,6 +15,7 @@
  */
 package io.apiman.gateway.platforms.servlet.connectors;
 
+import io.apiman.common.config.options.ConnectionOptions;
 import io.apiman.common.config.options.TLSOptions;
 import io.apiman.gateway.engine.IConnectorFactory;
 import io.apiman.gateway.engine.IServiceConnection;
@@ -42,6 +43,7 @@ public class HttpConnectorFactory implements IConnectorFactory {
     // 2WAY auth (i.e. mutual auth)
     private SSLSessionStrategy mutualAuthSslStrategy;
     private TLSOptions tlsOptions;
+    private ConnectionOptions connectionOptions;
 
     /**
      * Constructor.
@@ -49,6 +51,7 @@ public class HttpConnectorFactory implements IConnectorFactory {
      */
     public HttpConnectorFactory(Map<String, String> config) {
         this.tlsOptions = new TLSOptions(config);
+        this.connectionOptions = new ConnectionOptions(config);
     }
 
     /* (non-Javadoc)
@@ -66,7 +69,7 @@ public class HttpConnectorFactory implements IConnectorFactory {
                     IAsyncResultHandler<IServiceConnectionResponse> handler) throws ConnectorException {
 
                 HttpServiceConnection connection = new HttpServiceConnection(request, service, requiredAuthType,
-                        getSslStrategy(requiredAuthType), handler);
+                        getSslStrategy(requiredAuthType), connectionOptions, handler);
                 return connection;
             }
         };

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpServiceConnection.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpServiceConnection.java
@@ -95,6 +95,11 @@ public class HttpServiceConnection implements IServiceConnection, IServiceConnec
         okClient.setProtocols(Util.immutableList(Protocol.HTTP_1_1));
         okClient.setConnectionSpecs(DEFAULT_CONNECTION_SPECS);
         okClient.setSocketFactory(SocketFactory.getDefault());
+
+        // don't automatically follow redirects
+        okClient.setFollowRedirects(false);
+        okClient.setFollowSslRedirects(false);
+
         Internal.instance.setNetwork(okClient, Network.DEFAULT);
     }
 

--- a/gateway/platforms/war/standalone/common/src/main/resources/apiman.properties
+++ b/gateway/platforms/war/standalone/common/src/main/resources/apiman.properties
@@ -43,6 +43,18 @@ apiman-gateway.metrics.client.password=${apiman.es.password}
 apiman-gateway.metrics.client.index=apiman_metrics
 
 # ---------------------------------------------------------------------
+# Connection settings for the gateway connector(s).
+# ---------------------------------------------------------------------
+
+# Whether to automatically follow redirects (301, 302 etc.) from the
+# back-end service.
+#apiman-gateway.connector-factory.connection.followRedirects=false
+
+# Configure the timeout values for connections to the back-end service.
+#apiman-gateway.connector-factory.connection.readTimeout=15000
+#apiman-gateway.connector-factory.connection.connectTimeout=10000
+
+# ---------------------------------------------------------------------
 # SSL/TLS settings for the gateway connector(s).
 # ---------------------------------------------------------------------
 


### PR DESCRIPTION
# Summary

* Adds the ability to control whether the gateway automatically follows redirects (301, 302 etc.) from the back-end service.
* Adds the ability to set the read timeout and connect timeout values for the service connection.

# Rationale

Prior to this change, the redirect behaviour of the gateway was the OkHttp default of 'follow redirects'. This can lead to some unexpected behaviour when back-end services return a redirect status code intended for the *client*, not the gateway.

The default setting (and the behaviour today) results in the gateway attempting to load the URL to which the client should be redirected, rather than passing through the 301/302 to the client. This change makes that behaviour configurable.

# Implementation

* A new `ConnectionOptions` class has been added that is fed by the engine configuration.
* The `HttpServiceConnection` is passed the connection options and applies them to the OkHttp client.
* The default values for timeouts and redirects have been set to ensure backwards compatibility for anybody relying on this behaviour today.

The new properties look like this:

```
# ---------------------------------------------------------------------
# Connection settings for the gateway connector(s).
# ---------------------------------------------------------------------

# Whether to automatically follow redirects (301, 302 etc.) from the
# back-end service.
apiman-gateway.connector-factory.connection.followRedirects=true

# Configure the timeout values for connections to the back-end service.
apiman-gateway.connector-factory.connection.readTimeout=15000
apiman-gateway.connector-factory.connection.connectTimeout=10000
```

## Considerations

There may be an argument for changing the default redirect-follow behaviour to 'false', to help avoid violating the principle of least surprise, but I leave this up to you @EricWittmann, @msavy.