### PR TITLE
Configurable redirect follow behaviour for gateway

### DIFF
--- a/common/config/src/main/java/io/apiman/common/config/options/HttpConnectorOptions.java
+++ b/common/config/src/main/java/io/apiman/common/config/options/HttpConnectorOptions.java
@@ -28,10 +28,12 @@ public class HttpConnectorOptions extends AbstractOptions {
     private static final int DEFAULT_READ_TIMEOUT = 30;
     private static final int DEFAULT_WRITE_TIMEOUT = 30;
     private static final int DEFAULT_CONNECT_TIMEOUT = 10;
-    
+    private static final boolean DEFAULT_FOLLOW_REDIRECTS = true;
+
     private int readTimeout;
     private int writeTimeout;
     private int connectTimeout;
+    private boolean followRedirects;
 
     /**
      * Constructor.
@@ -49,6 +51,7 @@ public class HttpConnectorOptions extends AbstractOptions {
         String read = options.get("http.timeouts.read"); //$NON-NLS-1$
         String write = options.get("http.timeouts.write"); //$NON-NLS-1$
         String connect = options.get("http.timeouts.connect"); //$NON-NLS-1$
+        String redirects = options.get("http.followRedirects"); //$NON-NLS-1$
         if (read != null) {
             setReadTimeout(Integer.parseInt(read));
         } else {
@@ -63,6 +66,11 @@ public class HttpConnectorOptions extends AbstractOptions {
             setConnectTimeout(Integer.parseInt(connect));
         } else {
             setConnectTimeout(DEFAULT_CONNECT_TIMEOUT);
+        }
+        if (redirects != null) {
+            setFollowRedirects(Boolean.parseBoolean(redirects));
+        } else {
+            setFollowRedirects(DEFAULT_FOLLOW_REDIRECTS);
         }
     }
 
@@ -108,4 +116,17 @@ public class HttpConnectorOptions extends AbstractOptions {
         this.connectTimeout = connectTimeout;
     }
 
+    /**
+     * @return the followRedirects
+     */
+    public boolean isFollowRedirects() {
+        return followRedirects;
+    }
+
+    /**
+     * @param followRedirects the followRedirects to set
+     */
+    public void setFollowRedirects(boolean followRedirects) {
+        this.followRedirects = followRedirects;
+    }
 }

--- a/distro/wildfly8/src/main/resources/overlay/standalone/configuration/apiman.properties
+++ b/distro/wildfly8/src/main/resources/overlay/standalone/configuration/apiman.properties
@@ -70,6 +70,7 @@ apiman-gateway.components.IBufferFactoryComponent=io.apiman.gateway.engine.impl.
 apiman-gateway.connector-factory.http.timeouts.read=30
 apiman-gateway.connector-factory.http.timeouts.write=30
 apiman-gateway.connector-factory.http.timeouts.connect=10
+apiman-gateway.connector-factory.http.followRedirects=true
 
 # ---------------------------------------------------------------------
 # Elasticsearch Metrics Settings

--- a/distro/wildfly9/src/main/resources/overlay/standalone/configuration/apiman.properties
+++ b/distro/wildfly9/src/main/resources/overlay/standalone/configuration/apiman.properties
@@ -70,6 +70,7 @@ apiman-gateway.components.IBufferFactoryComponent=io.apiman.gateway.engine.impl.
 apiman-gateway.connector-factory.http.timeouts.read=30
 apiman-gateway.connector-factory.http.timeouts.write=30
 apiman-gateway.connector-factory.http.timeouts.connect=10
+apiman-gateway.connector-factory.http.followRedirects=true
 
 # ---------------------------------------------------------------------
 # Elasticsearch Metrics Settings

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpConnectorFactory.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpConnectorFactory.java
@@ -84,6 +84,8 @@ public class HttpConnectorFactory implements IConnectorFactory {
         client.setReadTimeout(connectorOptions.getReadTimeout(), TimeUnit.SECONDS);
         client.setWriteTimeout(connectorOptions.getWriteTimeout(), TimeUnit.SECONDS);
         client.setConnectTimeout(connectorOptions.getConnectTimeout(), TimeUnit.SECONDS);
+        client.setFollowRedirects(connectorOptions.isFollowRedirects());
+        client.setFollowSslRedirects(connectorOptions.isFollowRedirects());
         client.setProxySelector(ProxySelector.getDefault());
         client.setCookieHandler(CookieHandler.getDefault());
         client.setCertificatePinner(CertificatePinner.DEFAULT);

--- a/gateway/platforms/war/micro/src/main/java/io/apiman/gateway/platforms/war/micro/GatewayMicroService.java
+++ b/gateway/platforms/war/micro/src/main/java/io/apiman/gateway/platforms/war/micro/GatewayMicroService.java
@@ -205,6 +205,7 @@ public class GatewayMicroService {
         setConfigProperty(WarEngineConfig.APIMAN_GATEWAY_CONNECTOR_FACTORY_CLASS + ".http.timeouts.read", "25");
         setConfigProperty(WarEngineConfig.APIMAN_GATEWAY_CONNECTOR_FACTORY_CLASS + ".http.timeouts.write", "25");
         setConfigProperty(WarEngineConfig.APIMAN_GATEWAY_CONNECTOR_FACTORY_CLASS + ".http.timeouts.connect", "10");
+        setConfigProperty(WarEngineConfig.APIMAN_GATEWAY_CONNECTOR_FACTORY_CLASS + ".http.followRedirects", "true");
     }
 
     /**

--- a/gateway/platforms/war/standalone/common/src/main/resources/apiman.properties
+++ b/gateway/platforms/war/standalone/common/src/main/resources/apiman.properties
@@ -29,6 +29,14 @@ apiman-gateway.components.IBufferFactoryComponent=io.apiman.gateway.engine.impl.
 apiman-gateway.plugin-registry.pluginsDir=./apiman/plugins
 
 # ---------------------------------------------------------------------
+# Connector factory options
+# ---------------------------------------------------------------------
+apiman-gateway.connector-factory.http.timeouts.read=30
+apiman-gateway.connector-factory.http.timeouts.write=30
+apiman-gateway.connector-factory.http.timeouts.connect=10
+apiman-gateway.connector-factory.http.followRedirects=true
+
+# ---------------------------------------------------------------------
 # Elasticsearch Metrics Settings
 # ---------------------------------------------------------------------
 


### PR DESCRIPTION
# Summary

Adds the ability to control whether the gateway automatically follows redirects (301, 302 etc.) from the back-end service.

# Rationale

Prior to this change, the redirect behaviour of the gateway was the OkHttp default of 'follow redirects'. This can lead to some unexpected behaviour when back-end services return a redirect status code intended for the *client*, not the gateway.

The default setting (and the behaviour today) results in the gateway attempting to load the URL to which the client should be redirected, rather than passing through the 301/302 to the client. This change makes that behaviour configurable.

# Implementation

* A new property has been added to `HttpConnectorOptions`.
* The `HttpConnectorFactory` applies the redirect property to the OkHttpClient.
* The default value for redirects has been set to ensure backwards compatibility for anybody relying on this behaviour today.

The new property looks like this:

```
# ---------------------------------------------------------------------
# Connector factory options
# ---------------------------------------------------------------------

# Whether to automatically follow redirects (301, 302 etc.) from the
# back-end service.
apiman-gateway.connector-factory.http.followRedirects=true
```

## Considerations

There may be an argument for changing the default redirect-follow behaviour to 'false', to help avoid violating the principle of least surprise, but I leave this up to you @EricWittmann, @msavy.