### PR TITLE
Solve issue with "No IRegistry class configured" reported by Apiman Gateway bundle

### DIFF
--- a/common/util/pom.xml
+++ b/common/util/pom.xml
@@ -20,13 +20,6 @@
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
     </dependency>
-
-    <!-- For OSGI -->
-<!--    <dependency>
-      <groupId>io.apiman</groupId>
-      <artifactId>apiman-gateway-engine-core</artifactId>
-      <scope>provided</scope>
-    </dependency>-->
   </dependencies>
   
   <build>

--- a/common/util/pom.xml
+++ b/common/util/pom.xml
@@ -43,6 +43,11 @@
             org.apache.commons.codec.binary;version="[1.4,2)",
             org.apache.commons.lang.text;version="[2.6,3)"
             </Import-Package>
+            <DynamicImport-Package>
+              io.apiman.gateway.engine.es,
+              io.apiman.gateway.engine.policy,
+              io.apiman.gateway.engine.impl
+            </DynamicImport-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/common/util/pom.xml
+++ b/common/util/pom.xml
@@ -20,6 +20,13 @@
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
     </dependency>
+
+    <!-- For OSGI -->
+<!--    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-gateway-engine-core</artifactId>
+      <scope>provided</scope>
+    </dependency>-->
   </dependencies>
   
   <build>
@@ -28,6 +35,16 @@
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>
+            javax.crypto,
+            javax.crypto.spec,
+            org.apache.commons.codec.binary;version="[1.4,2)",
+            org.apache.commons.lang.text;version="[2.6,3)"
+            </Import-Package>
+          </instructions>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/distro/karaf/bundles/gateway/gateway-osgi-servlet/pom.xml
+++ b/distro/karaf/bundles/gateway/gateway-osgi-servlet/pom.xml
@@ -109,6 +109,7 @@
                         <Import-Package>!
                             !io.apiman.gateway.osgi.servlet,
                             !io.apiman.gateway.platforms.war*,
+                            io.apiman.gateway.engine.es,
                             *
                         </Import-Package>
                         <Embed-Dependency>

--- a/distro/karaf/bundles/gateway/gateway-osgi/pom.xml
+++ b/distro/karaf/bundles/gateway/gateway-osgi/pom.xml
@@ -41,17 +41,18 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>apiman-gateway-engine-ispn</artifactId>
         </dependency>
-        <dependency>
+<!--        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>apiman-gateway-engine-es</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>apiman-gateway-engine-influxdb</artifactId>
+            <artifactId>apiman-gateway-engine-policies</artifactId>
         </dependency>
+        -->
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>apiman-gateway-engine-policies</artifactId>
+            <artifactId>apiman-gateway-engine-influxdb</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/distro/karaf/bundles/gateway/gateway-osgi/pom.xml
+++ b/distro/karaf/bundles/gateway/gateway-osgi/pom.xml
@@ -184,11 +184,11 @@
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
         </dependency>
-        <dependency>
+<!--        <dependency>
             <groupId>com.codahale.metrics</groupId>
             <artifactId>metrics-healthchecks</artifactId>
             <version>3.0.0</version>
-        </dependency>
+        </dependency>-->
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core</artifactId>

--- a/distro/karaf/features/src/main/resources/repository/features.xml
+++ b/distro/karaf/features/src/main/resources/repository/features.xml
@@ -86,6 +86,7 @@
         <bundle>mvn:io.apiman/apiman-gateway-engine-beans/${project.version}</bundle>
         <bundle>mvn:io.apiman/apiman-gateway-engine-core/${project.version}</bundle>
         <bundle>mvn:io.apiman/apiman-gateway-engine-es/${project.version}</bundle>
+        <bundle>mvn:io.apiman/apiman-gateway-engine-policies/${project.version}</bundle>
         <bundle>mvn:io.apiman/gateway-osgi-servlet/${project.version}</bundle>
     </feature>
 

--- a/distro/karaf/features/src/main/resources/repository/features.xml
+++ b/distro/karaf/features/src/main/resources/repository/features.xml
@@ -36,6 +36,8 @@
         <bundle>mvn:org.apache.commons/commons-lang3/3.3.2</bundle>
         <bundle>mvn:org.apache.httpcomponents/httpcore-osgi/4.4.4</bundle>
         <bundle>mvn:org.apache.httpcomponents/httpclient-osgi/4.4.1</bundle>
+        <!-- TODO. Check if a bundle exists -->
+        <bundle>wrap:mvn:org.apache.httpcomponents/httpcore-nio/4.3.2</bundle>
         <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.stax-api-1.0/2.5.0</bundle>
         <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jsr311-api-1.1.1/2.5.0</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-beanutils/1.8.3_1</bundle>

--- a/distro/karaf/features/src/main/resources/repository/features.xml
+++ b/distro/karaf/features/src/main/resources/repository/features.xml
@@ -23,6 +23,19 @@
     </feature>
 
     <feature name="apiman-gateway" version="${project.version}">
+        <!-- TODO
+        <bundle>wrap:mvn:org.apache.jackrabbit/jackrabbit-webdav/1.5.2</bundle>
+        <bundle>wrap:mvn:org.apache.commons/commons-vfs2/2.0</bundle>
+        <bundle>wrap:mvn:org.infinispan/infinispan-core/5.2.11.Final</bundle>
+        <bundle>wrap:mvn:org.infinispan/infinispan-common/5.2.11.Final</bundle>
+        <bundle>mvn:com.google.guava/guava/18.0</bundle>
+        <bundle>wrap:mvn:io.searchbox/jest-common/2.0.0</bundle>
+        <bundle>wrap:mvn:io.searchbox/jest/2.0.0</bundle>
+        <bundle>mvn:com.google.code.gson/gson/2.3.1</bundle>
+        -->
+        <bundle>mvn:org.apache.commons/commons-lang3/3.3.2</bundle>
+        <bundle>mvn:org.apache.httpcomponents/httpcore-osgi/4.4.4</bundle>
+        <bundle>mvn:org.apache.httpcomponents/httpclient-osgi/4.4.1</bundle>
         <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.stax-api-1.0/2.5.0</bundle>
         <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jsr311-api-1.1.1/2.5.0</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-beanutils/1.8.3_1</bundle>
@@ -32,13 +45,18 @@
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dom4j/1.6.1_4</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.ant/1.7.0_5</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.regexp/1.3_3</bundle>
-        <bundle>mvn:org.apache.commons/commons-lang3/3.3.2</bundle>
+        <!-- TODO Check with SMX project when it will be releases -->
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jest/0.1.6_1-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.elasticsearch/1.7.2_1</bundle>
         <bundle>mvn:commons-lang/commons-lang/2.6</bundle>
         <bundle>mvn:commons-codec/commons-codec/1.10</bundle>
         <bundle>mvn:commons-io/commons-io/2.4</bundle>
         <bundle>mvn:commons-digester/commons-digester/2.1</bundle>
         <bundle>mvn:commons-jxpath/commons-jxpath/1.3</bundle>
         <bundle>mvn:org.bouncycastle/bcprov-jdk15on/1.52</bundle>
+        <bundle>mvn:org.codehaus.jackson/jackson-core-asl/1.9.9</bundle>
+        <bundle>mvn:org.codehaus.jackson/jackson-mapper-asl/1.9.9</bundle>
+        <bundle>mvn:org.codehaus.jackson/jackson-jaxrs/1.9.9</bundle>
         <bundle>mvn:org.codehaus.woodstox/stax2-api/3.1.4</bundle>
         <bundle>mvn:com.fasterxml.jackson.core/jackson-core/2.4.5</bundle>
         <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/2.4.5</bundle>
@@ -52,34 +70,23 @@
         <bundle>wrap:mvn:org.reflections/reflections/0.9.9</bundle>
         <bundle>wrap:mvn:org.jdom/jdom/1.1.3</bundle>
         <bundle>mvn:com.google.code.findbugs/annotations/2.0.1</bundle>
-        <bundle>mvn:io.swagger/swagger-annotations/1.5.4</bundle>
-        <bundle>mvn:org.codehaus.jackson/jackson-core-asl/1.9.9</bundle>
-        <bundle>mvn:org.codehaus.jackson/jackson-mapper-asl/1.9.9</bundle>
-        <bundle>mvn:org.codehaus.jackson/jackson-jaxrs/1.9.9</bundle>
-        <bundle>wrap:mvn:com.squareup.okio/okio/1.4.0</bundle>
         <bundle>mvn:com.google.code.gson/gson/2.5</bundle>
-        <bundle>mvn:io.apiman/apiman-common-plugin/1.2.2-SNAPSHOT</bundle>
-        <bundle>mvn:io.apiman/apiman-common-util/1.2.2-SNAPSHOT</bundle>
-<!--        <bundle>wrap:mvn:org.apache.jackrabbit/jackrabbit-webdav/1.5.2</bundle>
-        <bundle>wrap:mvn:org.apache.commons/commons-vfs2/2.0</bundle>-->
-        <bundle>mvn:com.google.code.gson/gson/2.3.1</bundle>
+        <bundle>mvn:io.swagger/swagger-annotations/1.5.4</bundle>
+        <bundle>wrap:mvn:com.squareup.okio/okio/1.4.0</bundle>
         <bundle>wrap:mvn:org.scannotation/scannotation/1.0.3</bundle>
+        <!-- Required by jackson-datatype-joda -->
         <bundle>mvn:joda-time/joda-time/2.5</bundle>
-<!--        <bundle>wrap:mvn:org.infinispan/infinispan-core/5.2.11.Final</bundle>-->
-<!--        <bundle>wrap:mvn:org.infinispan/infinispan-common/5.2.11.Final</bundle>-->
+        <bundle>mvn:joda-time/joda-time/1.6.2</bundle>
+        <bundle>wrap:mvn:org.picketbox/jboss-security-spi/4.1.1.Final</bundle>
         <feature>pax-cdi-1.1-weld</feature>
         <feature>hibernate</feature>
         <feature>war</feature>
         <feature>apiman-common</feature>
-        <feature>apiman-lib</feature>
-        <bundle>mvn:io.apiman/apiman-gateway-engine-beans/1.2.2-SNAPSHOT</bundle>
-        <bundle>mvn:io.apiman/apiman-gateway-engine-core/1.2.2-SNAPSHOT</bundle>
-        <bundle>mvn:io.apiman/apiman-gateway-engine-es/1.2.2-SNAPSHOT</bundle>
-        <bundle>mvn:io.apiman/gateway-osgi-servlet/1.2.2-SNAPSHOT</bundle>
-        <bundle>wrap:mvn:io.searchbox/jest-common/0.1.6</bundle>
-        <bundle>mvn:org.apache.httpcomponents/httpclient-osgi/4.2.5</bundle>
-        <bundle>wrap:mvn:io.searchbox/jest-common/0.1.6</bundle>
-        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.elasticsearch/1.7.2_1</bundle>
+        <!-- <feature>apiman-lib</feature>-->
+        <bundle>mvn:io.apiman/apiman-gateway-engine-beans/${project.version}</bundle>
+        <bundle>mvn:io.apiman/apiman-gateway-engine-core/${project.version}</bundle>
+        <bundle>mvn:io.apiman/apiman-gateway-engine-es/${project.version}</bundle>
+        <bundle>mvn:io.apiman/gateway-osgi-servlet/${project.version}</bundle>
     </feature>
 
     <feature name="apiman-lib" version="${project.version}">
@@ -92,7 +99,6 @@
         <!--<bundle>mvn:org.ops4j.pax.logging/pax-logging-log4j2/1.8.4</bundle>-->
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-configuration/1.9_2</bundle>
         <bundle>mvn:joda-time/joda-time/1.6.2</bundle>
-        <bundle>wrap:mvn:org.picketbox/jboss-security-spi/4.1.1.Final</bundle>
         <bundle>wrap:mvn:org.scannotation/scannotation/1.0.3</bundle>
         <bundle>mvn:org.apache.commons/commons-lang3/3.3.2</bundle>
         <bundle>mvn:org.apache.httpcomponents/httpcore-osgi/4.2.5</bundle>
@@ -169,7 +175,7 @@
         <bundle>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.4.5</bundle>
         <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/2.4.5</bundle>
         <bundle>mvn:com.fasterxml.jackson.datatype/jackson-datatype-joda/2.4.5</bundle>
-        <!-- A SMX Bundle is also deployed for reflection - TODO -->
+        <!-- TODO: A SMX Bundle is also deployed for reflection -->
         <bundle>wrap:mvn:org.reflections/reflections/0.9.10</bundle>
         <bundle>mvn:com.google.guava/guava/18.0</bundle>
         <bundle>mvn:com.google.code.findbugs/annotations/2.0.1</bundle>
@@ -186,11 +192,6 @@
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.elasticsearch/1.7.2_1</bundle>
         <bundle>wrap:mvn:org.scannotation/scannotation/1.0.3</bundle>
     </feature>
-
-<!--    <feature name="apiman-gateway" version="${project.version}">
-        <bundle>mvn:io.apiman/apiman-gateway-engine-beans/${project.version}</bundle>
-        <bundle>mvn:io.apiman/apiman-gateway-api-rest/${project.version}</bundle>
-    </feature>-->
 
     <feature name="apiman-common" version="${project.version}">
         <bundle>mvn:io.apiman/apiman-common-auth/${project.version}</bundle>

--- a/distro/karaf/features/src/main/resources/repository/features.xml
+++ b/distro/karaf/features/src/main/resources/repository/features.xml
@@ -37,7 +37,7 @@
         <bundle>mvn:org.apache.httpcomponents/httpcore-osgi/4.4.4</bundle>
         <bundle>mvn:org.apache.httpcomponents/httpclient-osgi/4.4.1</bundle>
         <!-- TODO. Check if a bundle exists -->
-        <bundle>wrap:mvn:org.apache.httpcomponents/httpcore-nio/4.3.2</bundle>
+        <bundle>wrap:mvn:org.apache.httpcomponents/httpasyncclient-osgi/4.1.1</bundle>
         <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.stax-api-1.0/2.5.0</bundle>
         <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jsr311-api-1.1.1/2.5.0</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-beanutils/1.8.3_1</bundle>

--- a/distro/karaf/test/pom.xml
+++ b/distro/karaf/test/pom.xml
@@ -22,14 +22,10 @@
             <artifactId>pax-exam-container-karaf</artifactId>
             <version>4.6.0</version>
         </dependency>
-it
 
-
-
-        <!-- Pax Exam version you would like to use. At least 2.2.x is required. -->
+        <!-- Pax Exam -->
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
-
             <artifactId>pax-exam-junit4</artifactId>
             <version>4.7.0</version>
             <scope>test</scope>

--- a/gateway/engine/core/pom.xml
+++ b/gateway/engine/core/pom.xml
@@ -86,7 +86,16 @@
               *
             </Import-Package>
             <Export-Package>
-              io.apiman.gateway.engine*
+              io.apiman.gateway.engine,
+              io.apiman.gateway.engine.async,
+              io.apiman.gateway.engine.auth,
+              io.apiman.gateway.engine.components,
+              io.apiman.gateway.engine.i18n,
+              io.apiman.gateway.engine.impl,
+              io.apiman.gateway.engine.io,
+              io.apiman.gateway.engine.metrics,
+              io.apiman.gateway.engine.policy,
+              io.apiman.gateway.engine.rates
             </Export-Package>
           </instructions>
         </configuration>

--- a/gateway/engine/core/pom.xml
+++ b/gateway/engine/core/pom.xml
@@ -80,16 +80,17 @@
         <configuration>
           <instructions>
             <Import-Package>
-              !io.apiman.gateway.engine*,
-              com.unboundid.*;resolution:="optional",
-              com.zaxxer.hikari*;resolution:="optional",
+              com.unboundid.ldap.sdk;resolution:="optional",
+              com.unboundid.util;resolution:="optional",
+              com.unboundid.util.ssl;resolution:="optional",
+              com.zaxxer.hikari;resolution:="optional",
               *
             </Import-Package>
             <Export-Package>
               io.apiman.gateway.engine,
               io.apiman.gateway.engine.async,
               io.apiman.gateway.engine.auth,
-              io.apiman.gateway.engine.components,
+              io.apiman.gateway.engine.components.*,
               io.apiman.gateway.engine.i18n,
               io.apiman.gateway.engine.impl,
               io.apiman.gateway.engine.io,


### PR DESCRIPTION
- Add dynamic Import Package to apiman-common-util in order to load the classes required to create the PluginRegistry, ....
- Update the features file to deploy the jest bundle committed to SMX project
- Recalculate some of the packages to be exported
- Deploy apiman-gateway-engine-es and apiman-gateway-engine-policies as bundle