### PR TITLE
APIMAN-953: make apiman able to process GET parameters with multiple …

### DIFF
--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/ApiRequest.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/ApiRequest.java
@@ -17,6 +17,7 @@ package io.apiman.gateway.engine.beans;
 
 import java.io.Serializable;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -34,8 +35,9 @@ public class ApiRequest implements IApiObject, Serializable {
     private String type;
     private String url;
     private String destination;
-    private Map<String, String> queryParams = new LinkedHashMap<>();
     private Map<String, String> headers = new HeaderHashMap();
+    private Map<String, List<String>> queryParameters = new LinkedHashMap<String, List<String>>();
+    private final QueryParamsWrapper queryParametersWrapper;
     private String remoteAddr;
     private Object rawRequest;
     private boolean transportSecurity = false;
@@ -52,6 +54,7 @@ public class ApiRequest implements IApiObject, Serializable {
      * Constructor.
      */
     public ApiRequest() {
+        this.queryParametersWrapper = new QueryParamsWrapper(this);
     }
 
     /**
@@ -199,15 +202,33 @@ public class ApiRequest implements IApiObject, Serializable {
     /**
      * @return the queryParams
      */
+    @Deprecated
     public Map<String, String> getQueryParams() {
-        return queryParams;
+        return queryParametersWrapper;
     }
 
     /**
-     * @param queryParams the queryParams to set
+     * @param queryParams
+     *            the queryParams to set
      */
+    @Deprecated
     public void setQueryParams(Map<String, String> queryParams) {
-        this.queryParams = queryParams;
+        throw new UnsupportedOperationException(
+                "Since APIMAN-953, you must use the method getQueryParameters() and setQueryParameters()");
+    }
+
+    /**
+     * @return the queryParameters
+     */
+    public Map<String, List<String>> getQueryParameters() {
+        return queryParameters;
+    }
+
+    /**
+     * @param queryParameters the queryParameters to set
+     */
+    public void setQueryParameters(Map<String, List<String>> queryParameters) {
+        this.queryParameters = queryParameters;
     }
 
     /**

--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/QueryParamsWrapper.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/QueryParamsWrapper.java
@@ -1,0 +1,88 @@
+package io.apiman.gateway.engine.beans;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class QueryParamsWrapper implements Map<String, String> {
+
+    private ApiRequest apiRequest;
+    
+    public QueryParamsWrapper(ApiRequest apiRequest) {
+        this.apiRequest = apiRequest;
+    }
+    
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException("Since APIMAN-953, ApiRequest.getQueryParams() is read-only. Please use getQueryParameters().");
+    }
+
+    @Override
+    public boolean containsKey(Object arg0) {
+        return apiRequest.getQueryParameters().containsKey(arg0);
+    }
+
+    @Override
+    public boolean containsValue(Object arg0) {
+        //too difficult to implement. Nobody uses this anyway.
+        throw new UnsupportedOperationException("Since APIMAN-953, ApiRequest.getQueryParams() is deprecated. This class is just wrapping the new ApiRequest.getQueryParameters(). This method has not been implemented. Please use getQueryParameters().");
+    }
+
+    @Override
+    public Set<java.util.Map.Entry<String, String>> entrySet() {
+        Set<java.util.Map.Entry<String, String>> set = new HashSet<>();
+        for (java.util.Map.Entry<String, List<String>> entry : apiRequest.getQueryParameters().entrySet()) {
+            set.add(new AbstractMap.SimpleEntry<String, String>(entry.getKey(), entry.getValue().get(entry.getValue().size() - 1)));
+        }
+        return set;
+    }
+
+    @Override
+    public String get(Object arg0) {
+        List<String> list = apiRequest.getQueryParameters().get(arg0);
+        if (list == null) {
+            return null;
+        }
+        return list.get(list.size() - 1);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return apiRequest.getQueryParameters().isEmpty();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return apiRequest.getQueryParameters().keySet();
+    }
+
+    @Override
+    public String put(String arg0, String arg1) {
+        throw new UnsupportedOperationException("Since APIMAN-953, ApiRequest.getQueryParams() is read-only. Please use getQueryParameters().");
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends String> arg0) {
+        throw new UnsupportedOperationException("Since APIMAN-953, ApiRequest.getQueryParams() is read-only. Please use getQueryParameters().");
+    }
+
+    @Override
+    public String remove(Object arg0) {
+        throw new UnsupportedOperationException("Since APIMAN-953, ApiRequest.getQueryParams() is read-only. Please use getQueryParameters().");
+    }
+
+    @Override
+    public int size() {
+        return apiRequest.getQueryParameters().size();
+    }
+
+    @Override
+    public Collection<String> values() {
+        // difficult to implement. Nobody uses this anyway.
+        throw new UnsupportedOperationException("Since APIMAN-953, ApiRequest.getQueryParams() is deprecated. This class is just wrapping the new ApiRequest.getQueryParameters(). This method has not been implemented. Please use getQueryParameters().");
+    }
+
+}

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/ApiRequestExecutorImpl.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/ApiRequestExecutorImpl.java
@@ -332,7 +332,7 @@ public class ApiRequestExecutorImpl implements IApiRequestExecutor {
 
     private void stripApiKey() {
         request.getHeaders().remove("X-API-Key"); //$NON-NLS-1$
-        request.getQueryParams().remove("apikey"); //$NON-NLS-1$
+        request.getQueryParameters().remove("apikey"); //$NON-NLS-1$
     }
 
     /**

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpApiConnection.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpApiConnection.java
@@ -132,14 +132,16 @@ public class HttpApiConnection implements IApiConnection, IApiConnectionResponse
             if (request.getDestination() != null) {
                 endpoint += request.getDestination();
             }
-            if (request.getQueryParams() != null && !request.getQueryParams().isEmpty()) {
+            if (request.getQueryParameters() != null && !request.getQueryParameters().isEmpty()) {
                 String delim = "?"; //$NON-NLS-1$
-                for (Entry<String, String> entry : request.getQueryParams().entrySet()) {
-                    endpoint += delim + entry.getKey();
-                    if (entry.getValue() != null) {
-                        endpoint += "=" + URLEncoder.encode(entry.getValue(), "UTF-8"); //$NON-NLS-1$ //$NON-NLS-2$
+                for (Entry<String, List<String>> entry : request.getQueryParameters().entrySet()) {
+                    for (String value : entry.getValue()) {
+                        endpoint += delim + URLEncoder.encode(entry.getKey(), "UTF-8"); //$NON-NLS-1$  
+                        if (value != null) {
+                            endpoint += "=" + URLEncoder.encode(value, "UTF-8"); //$NON-NLS-1$ //$NON-NLS-2$
+                        }
+                        delim = "&"; //$NON-NLS-1$
                     }
-                    delim = "&"; //$NON-NLS-1$
                 }
             }
             URL url = new URL(endpoint);

--- a/gateway/platforms/servlet/src/test/java/io/apiman/gateway/platforms/servlet/GatewayServletTest.java
+++ b/gateway/platforms/servlet/src/test/java/io/apiman/gateway/platforms/servlet/GatewayServletTest.java
@@ -17,6 +17,7 @@ package io.apiman.gateway.platforms.servlet;
 
 import io.apiman.common.util.ApimanPathUtils.ApiRequestPathInfo;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -117,36 +118,54 @@ public class GatewayServletTest {
     }
 
     /**
-     * Test method for {@link io.apiman.gateway.platforms.servlet.GatewayServlet#parseApiRequestQueryParams(String)}
+     * Test method for {@link io.apiman.gateway.platforms.servlet.GatewayServlet#parseApiRequestQueryParameters(String)}
      */
     @Test
     public void testParseApiRequestQueryParams() {
-        Map<String, String> paramMap = GatewayServlet.parseApiRequestQueryParams(null);
+        Map<String, List<String>> paramMap = GatewayServlet.parseApiRequestQueryParameters(null);
         Assert.assertNotNull(paramMap);
 
-        paramMap = GatewayServlet.parseApiRequestQueryParams("param1");
-        Assert.assertNull(paramMap.get("param1"));
+        paramMap = GatewayServlet.parseApiRequestQueryParameters("param1");
+        Assert.assertEquals(1, paramMap.get("param1").size());
+        Assert.assertNull(paramMap.get("param1").get(0));
 
-        paramMap = GatewayServlet.parseApiRequestQueryParams("param1=value1");
-        Assert.assertEquals("value1", paramMap.get("param1"));
+        paramMap = GatewayServlet.parseApiRequestQueryParameters("param1=value1");
+        Assert.assertEquals(1, paramMap.get("param1").size());
+        Assert.assertEquals("value1", paramMap.get("param1").get(0));
+        
+        paramMap = GatewayServlet.parseApiRequestQueryParameters("param1=value1&param1=value2");
+        Assert.assertEquals(2, paramMap.get("param1").size());
+        Assert.assertEquals("value1", paramMap.get("param1").get(0));
+        Assert.assertEquals("value2", paramMap.get("param1").get(1));
 
-        paramMap = GatewayServlet.parseApiRequestQueryParams("param1=value1&param2");
-        Assert.assertEquals("value1", paramMap.get("param1"));
-        Assert.assertNull(paramMap.get("param2"));
+        paramMap = GatewayServlet.parseApiRequestQueryParameters("param1=value1&param2");
+        Assert.assertEquals(1, paramMap.get("param1").size());
+        Assert.assertEquals("value1", paramMap.get("param1").get(0));
+        Assert.assertEquals(1, paramMap.get("param2").size());
+        Assert.assertNull(paramMap.get("param2").get(0));
+        
+        paramMap = GatewayServlet.parseApiRequestQueryParameters("param2=");
+        Assert.assertEquals(1, paramMap.get("param2").size());
+        Assert.assertEquals("", paramMap.get("param2").get(0));
+        
+        paramMap = GatewayServlet.parseApiRequestQueryParameters("param2&param2=&param2=value1&param2&param2=");
+        Assert.assertEquals(5, paramMap.get("param2").size());
+        Assert.assertNull(paramMap.get("param2").get(0));
+        Assert.assertEquals("", paramMap.get("param2").get(1));
+        Assert.assertEquals("value1", paramMap.get("param2").get(2));
+        Assert.assertNull(paramMap.get("param2").get(3));
+        Assert.assertEquals("", paramMap.get("param2").get(4));
 
-        paramMap = GatewayServlet.parseApiRequestQueryParams("param1=value1&param2=value2");
-        Assert.assertEquals("value1", paramMap.get("param1"));
-        Assert.assertEquals("value2", paramMap.get("param2"));
-
-        paramMap = GatewayServlet.parseApiRequestQueryParams("param1=value1&param2=value2&param3=value3");
-        Assert.assertEquals("value1", paramMap.get("param1"));
-        Assert.assertEquals("value2", paramMap.get("param2"));
-        Assert.assertEquals("value3", paramMap.get("param3"));
-
-        paramMap = GatewayServlet.parseApiRequestQueryParams("param1=hello%20world&param2=hello+world&param3=hello world");
-        Assert.assertEquals("hello world", paramMap.get("param1"));
-        Assert.assertEquals("hello world", paramMap.get("param2"));
-        Assert.assertEquals("hello world", paramMap.get("param3"));
+        paramMap = GatewayServlet.parseApiRequestQueryParameters("param1=value1&param2=value2");
+        Assert.assertEquals(1, paramMap.get("param1").size());
+        Assert.assertEquals("value1", paramMap.get("param1").get(0));
+        Assert.assertEquals(1, paramMap.get("param2").size());
+        Assert.assertEquals("value2", paramMap.get("param2").get(0));
+        
+        paramMap = GatewayServlet.parseApiRequestQueryParameters("param%201=hello%20world&param+2=hello+world&param+3=%3D%2B%26%3F");
+        Assert.assertEquals("hello world", paramMap.get("param 1").get(0));
+        Assert.assertEquals("hello world", paramMap.get("param 2").get(0));
+        Assert.assertEquals("=+&?", paramMap.get("param 3").get(0));
     }
 
 }

--- a/gateway/platforms/vertx3/vertx3/src/main/generated/io/apiman/gateway/platforms/vertx3/io/VertxApiRequestConverter.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/generated/io/apiman/gateway/platforms/vertx3/io/VertxApiRequestConverter.java
@@ -41,13 +41,12 @@ public class VertxApiRequestConverter {
       });
       obj.setHeaders(map);
     }
-    if (json.getValue("queryParams") instanceof JsonObject) {
-      java.util.Map<String, java.lang.String> map = new java.util.LinkedHashMap<>();
-      json.getJsonObject("queryParams").forEach(entry -> {
-        if (entry.getValue() instanceof String)
-          map.put(entry.getKey(), (String)entry.getValue());
+    if (json.getValue("queryParameters") instanceof JsonObject) {
+      java.util.Map<String, java.util.List<java.lang.String>> map = new java.util.LinkedHashMap<>();
+      json.getJsonObject("queryParameters").forEach(entry -> {
+        //TODO          if (entry.getValue() instanceof String)          map.put(entry.getKey(), (String)entry.getValue());
       });
-      obj.setQueryParams(map);
+      obj.setQueryParameters(map);
     }
     if (json.getValue("rawRequest") instanceof Object) {
       obj.setRawRequest(json.getValue("rawRequest"));
@@ -84,9 +83,9 @@ public class VertxApiRequestConverter {
       obj.getHeaders().forEach((key,value) -> map.put(key, value));
       json.put("headers", map);
     }
-    if (obj.getQueryParams() != null) {
+    if (obj.getQueryParameters() != null) {
       JsonObject map = new JsonObject();
-      obj.getQueryParams().forEach((key,value) -> map.put(key, value));
+      obj.getQueryParameters().forEach((key,value) -> map.put(key, value));
       json.put("queryParams", map);
     }
     if (obj.getRawRequest() != null) {

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/HttpConnector.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/HttpConnector.java
@@ -52,6 +52,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -161,7 +162,7 @@ class HttpConnector implements IApiConnectionResponse, IApiConnection {
     }
 
     private void doConnection() {
-        String endpoint = apiPath + destination + queryParams(apiRequest.getQueryParams());
+        String endpoint = apiPath + destination + queryParams(apiRequest.getQueryParameters());
         logger.debug(String.format("Connecting to %s | port: %d verb: %s path: %s", apiHost, apiPort,
                 HttpMethod.valueOf(apiRequest.getType()), endpoint));
 
@@ -285,22 +286,25 @@ class HttpConnector implements IApiConnectionResponse, IApiConnection {
         }
     }
 
-    private String queryParams(Map<String, String> queryParams) {
-        if (queryParams == null || queryParams.size() == 0)
+    private String queryParams(Map<String, List<String>> queryParameters) {
+        if (queryParameters == null || queryParameters.size() == 0)
             return "";
 
-        StringBuilder sb = new StringBuilder(queryParams.size() * 2 * 10);
+        StringBuilder sb = new StringBuilder(queryParameters.size() * 2 * 10);
         String joiner = "?";
 
         try {
-            for (Entry<String, String> entry : queryParams.entrySet()) {
-                sb.append(joiner);
-                sb.append(entry.getKey());
-                if (entry.getValue() != null) {
-                    sb.append("=");
-                    sb.append(URLEncoder.encode(entry.getValue(), "UTF-8"));
+            for (Entry<String, List<String>> entry : queryParameters.entrySet()) {
+                for (String value : entry.getValue()) {
+                    sb.append(joiner);
+                    sb.append(URLEncoder.encode(entry.getKey(), "UTF-8"));
+                    if (value != null) {
+                        sb.append("=");
+                        sb.append(URLEncoder.encode(value, "UTF-8"));
+                    }
+                    joiner = "&";
                 }
-                joiner = "&";
+                
             }
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/http/HttpApiFactory.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/http/HttpApiFactory.java
@@ -24,8 +24,10 @@ import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -65,7 +67,7 @@ public class HttpApiFactory {
         apimanRequest.setType(req.method().toString());
         apimanRequest.setTransportSecure(isTransportSecure);
         multimapToMap(apimanRequest.getHeaders(), req.headers(), IGNORESET);
-        multimapToMap(apimanRequest.getQueryParams(), req.params(), Collections.<String>emptySet());
+        multimapToListMap(apimanRequest.getQueryParameters(), req.params());
         mungePath(req, apimanRequest);
         return apimanRequest;
     }
@@ -106,7 +108,20 @@ public class HttpApiFactory {
             }
         }
     }
+    
+    private static void multimapToListMap(Map<String, List<String>> destination, MultiMap source) {
+        for (Map.Entry<String, String> entry : source) {
+            String key = entry.getKey();
+            String val = entry.getValue();
 
+            if (!destination.containsKey(key)) {
+                destination.put(key, new ArrayList<>());
+            }
+            
+            destination.get(key).add(val);
+        }
+    }
+    
     private static String parseApiKey(HttpServerRequest req) {
         String headerKey = req.headers().get("X-API-Key");
         if (headerKey == null || headerKey.trim().length() == 0) {

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/io/VertxApiRequest.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/io/VertxApiRequest.java
@@ -44,7 +44,7 @@ public class VertxApiRequest extends ApiRequest {
         setUrl(copy.getUrl());
         setDestination(copy.getDestination());
         setHeaders(copy.getHeaders());
-        setQueryParams(copy.getQueryParams());
+        setQueryParameters(copy.getQueryParameters());
         setRawRequest(copy.getRawRequest());
         setRemoteAddr(copy.getRemoteAddr());
         setApiId(copy.getApiId());
@@ -81,7 +81,7 @@ public class VertxApiRequest extends ApiRequest {
                 + ", getContract()=" + getContract() + ", getServiceOrgId()=" + getApiOrgId()
                 + ", getServiceId()=" + getApiId() + ", getServiceVersion()=" + getApiVersion()
                 + ", getQueryParams()="
-                + (getQueryParams() != null ? toString(getQueryParams().entrySet(), maxLen) : null)
+                + (getQueryParameters() != null ? toString(getQueryParameters().entrySet(), maxLen) : null)
                 + ", isTransportSecure()=" + isTransportSecure() + ", getClass()=" + getClass()
                 + ", hashCode()=" + hashCode() + "]";
     }


### PR DESCRIPTION
…values

APIMAN-953: make apiman able to process GET parameters with multiple
values.
Backwards-compatible for *reading* get parameters the old way
(returns the last value, just as with the older implementation), but
trying to delete/add/alter the old map throws an
UnsupportedOperationException.
Also fixes a problem with processing
parameter encoding. Added tests for that.