### PR TITLE
Apiman Gateway Api can be deployed on Karaf

### DIFF
--- a/common/util/pom.xml
+++ b/common/util/pom.xml
@@ -39,7 +39,8 @@
             <DynamicImport-Package>
               io.apiman.gateway.engine.es,
               io.apiman.gateway.engine.policy,
-              io.apiman.gateway.engine.impl
+              io.apiman.gateway.engine.impl,
+              io.apiman.gateway.platforms.servlet.connectors
             </DynamicImport-Package>
           </instructions>
         </configuration>

--- a/distro/karaf/bundles/gateway/gateway-osgi-api/pom.xml
+++ b/distro/karaf/bundles/gateway/gateway-osgi-api/pom.xml
@@ -14,20 +14,6 @@
 
     <dependencies>
         <!-- Project Libs -->
-        <!--
-<dependency>
-    <groupId>${project.groupId}</groupId>
-    <artifactId>apiman-gateway-platforms-war</artifactId>
-</dependency>
-
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>apiman-gateway-engine-beans</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>apiman-gateway-engine-core</artifactId>
-        </dependency>-->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>apiman-gateway-api-rest</artifactId>
@@ -35,10 +21,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>apiman-gateway-api-rest-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>apiman-common-servlet</artifactId>
         </dependency>
 
         <!-- REST Easy -->

--- a/distro/karaf/bundles/gateway/gateway-osgi/pom.xml
+++ b/distro/karaf/bundles/gateway/gateway-osgi/pom.xml
@@ -11,7 +11,6 @@
 
     <artifactId>gateway-osgi</artifactId>
     <name>Apiman :: OSGI :: Gateway Module</name>
-    <!--    <packaging>war</packaging>-->
     <packaging>bundle</packaging>
 
     <properties>
@@ -21,35 +20,14 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>apiman-common-config</artifactId>
-        </dependency>
-        <!--
-                <dependency>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>apiman-gateway-engine-beans</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>apiman-gateway-engine-core</artifactId>
-                </dependency>-->
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>gateway-osgi-servlet</artifactId>
             <version>1.2.2-SNAPSHOT</version>
         </dependency>
+        <!-- TODO - Deploy ispn and influxdb as bundles -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>apiman-gateway-engine-ispn</artifactId>
         </dependency>
-<!--        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>apiman-gateway-engine-es</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>apiman-gateway-engine-policies</artifactId>
-        </dependency>
-        -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>apiman-gateway-engine-influxdb</artifactId>
@@ -66,14 +44,6 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>apiman-gateway-api-rest-impl</artifactId>
         </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>apiman-common-servlet</artifactId>
-        </dependency>
-<!--        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>apiman-gateway-platforms-war</artifactId>
-        </dependency>-->
 
         <!-- Third Party Dependencies -->
         <dependency>

--- a/distro/karaf/features/src/main/resources/repository/features.xml
+++ b/distro/karaf/features/src/main/resources/repository/features.xml
@@ -74,6 +74,7 @@
         <bundle>mvn:com.google.code.findbugs/annotations/2.0.1</bundle>
         <bundle>mvn:com.google.code.gson/gson/2.5</bundle>
         <bundle>mvn:io.swagger/swagger-annotations/1.5.4</bundle>
+        <bundle>wrap:mvn:com.squareup.okhttp/okhttp/2.4.0</bundle>
         <bundle>wrap:mvn:com.squareup.okio/okio/1.4.0</bundle>
         <bundle>wrap:mvn:org.scannotation/scannotation/1.0.3</bundle>
         <!-- Required by jackson-datatype-joda -->
@@ -89,6 +90,7 @@
         <bundle>mvn:io.apiman/apiman-gateway-engine-core/${project.version}</bundle>
         <bundle>mvn:io.apiman/apiman-gateway-engine-es/${project.version}</bundle>
         <bundle>mvn:io.apiman/apiman-gateway-engine-policies/${project.version}</bundle>
+        <bundle>mvn:io.apiman/apiman-gateway-platforms-servlet/${project.version}</bundle>
         <bundle>mvn:io.apiman/gateway-osgi-servlet/${project.version}</bundle>
     </feature>
 


### PR DESCRIPTION
Apiman Gateway Api can be deployed on Karaf  after doing these modifications

- Add missing package to Apiman Common Util
- Deploy okHTTP client as wrapped bundle
- Remove comments from gateway bundles
- Remove some embedded dependencies