### PR TITLE
re #974 Navbar Header

### DIFF
--- a/manager/ui/war/apiman/README.md
+++ b/manager/ui/war/apiman/README.md
@@ -1,0 +1,12 @@
+#### Configuration
+
+Set configuration settings for the apiman Manager UI. To get started, duplicate the `config.js-SAMPLE` file, removing 
+the `-SAMPLE` text from the name.
+
+```
+var APIMAN_CONFIG_DATA = {
+  "ui" : {
+    "header": Which header to use. Possible values are: "apiman", "amg"
+  }
+};
+```

--- a/manager/ui/war/plugins/api-manager/css/apiman.css
+++ b/manager/ui/war/plugins/api-manager/css/apiman.css
@@ -134,6 +134,10 @@ textarea.apiman-form-data {
   animation-iteration-count: infinite;
 }
 
+.amg.navbar-pf {
+  border-top: none;
+}
+
 #apiman-header {
   background-color: rgb(36, 52, 70);
   border-bottom: 1px solid black;

--- a/manager/ui/war/plugins/api-manager/html/headers/README.md
+++ b/manager/ui/war/plugins/api-manager/html/headers/README.md
@@ -1,0 +1,7 @@
+#### Navigation Headers
+
+The navigation header is configured in `/apiman/manager/ui/war/apiman/config.js` in the `ui.header` property. Possible 
+values include:
+
+- `apiman`: Community header.
+- `amg`: Enterprise header.

--- a/manager/ui/war/plugins/api-manager/html/headers/amg.include
+++ b/manager/ui/war/plugins/api-manager/html/headers/amg.include
@@ -1,0 +1,66 @@
+<div id="apiman-progress-indicator"
+     ng-class="pageState"></div>
+
+<nav class="amg navbar navbar-default navbar-pf"
+     role="navigation"
+     ng-controller="Apiman.NavbarController">
+  <div class="navbar-header">
+    <button type="button"
+            class="navbar-toggle"
+            data-toggle="collapse"
+            data-target=".navbar-collapse-1">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+    <a class="navbar-brand"
+       href="{{ pluginName }}/"
+       title="apiman">
+      <img src="//rawgit.com/patternfly/patternfly/master/dist/img/brand.svg"
+           alt="apiman Open Source API Management" />
+    </a>
+  </div>
+  <div class="collapse navbar-collapse navbar-collapse-1">
+    <ul class="nav navbar-nav navbar-utility">
+      <li class="dropdown">
+        <a href="#"
+           class="dropdown-toggle"
+           data-toggle="dropdown">
+          <span class="pficon pficon-user"></span>
+          {{ username }}&nbsp;<b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li>
+            <a id="navbar-home"
+               href="{{ pluginName }}/"
+               apiman-i18n-key="home">Home</a>
+          </li>
+          <li>
+            <a id="navbar-my-stuff"
+               href="{{ pluginName }}/users/{{ username }}/orgs"
+               apiman-i18n-key="my-stuff">My Stuff</a>
+          </li>
+          <li>
+            <a id="navbar-profile"
+               href="{{ pluginName }}/profile"
+               apiman-i18n-key="profile">Profile</a>
+          </li>
+          <li class="divider"></li>
+          <li>
+            <a id="navbar-about"
+               href="{{ pluginName }}/about"
+               apiman-i18n-key="about-apiman">About apiman</a>
+          </li>
+          <li class="divider"></li>
+          <li>
+            <a id="navbar-logout"
+               href="{{ logoutUrl }}"
+               target="_self"
+               apiman-i18n-key="logout">Logout</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</nav>

--- a/manager/ui/war/src/main/sdk/json-schema.html
+++ b/manager/ui/war/src/main/sdk/json-schema.html
@@ -7,9 +7,9 @@
 
     <link rel="icon" type="image/png" href="../webapp/css/images/favicon.png"></link>
 
-    <link rel="stylesheet" href="../../../libs/bootstrap/dist/css/bootstrap.css" />
-    <link rel="stylesheet" href="../../../libs/bootstrap-select/bootstrap-select.css" />
-    <link rel="stylesheet" href="../../../libs/patternfly/dist/css/patternfly.css" />
+    <link rel="stylesheet" href="../../../node_modules/patternfly/components/bootstrap/dist/css/bootstrap.css" />
+    <link rel="stylesheet" href="../../../node_modules/patternfly/components/bootstrap-select/dist/css/bootstrap-select.css" />
+    <link rel="stylesheet" href="../../../node_modules/patternfly/dist/css/patternfly.css" />
     <link href="../../../plugins/api-manager/css/apiman.css?iter=4" rel="stylesheet"></link>
     <link href="../../../plugins/api-manager/css/apiman-responsive.css?iter=1" rel="stylesheet"></link>
     <style type="text/css" media="screen">
@@ -33,12 +33,12 @@
         }
     </style>
 
-    <script type="text/javascript" src="../../../libs/jquery/dist/jquery.js"></script>
+    <script type="text/javascript" src="../../../node_modules/patternfly/components/jquery/dist/jquery.js"></script>
     <script type="text/javascript" src="http://d1n0x3qji82z53.cloudfront.net/src-min-noconflict/ace.js" charset="utf-8"></script>
-    <script type="text/javascript" src="../../../libs/bootstrap/dist/js/bootstrap.js"></script>
-    <script type="text/javascript" src="../../../libs/bootstrap-select/bootstrap-select.js"></script>
-    <script type="text/javascript" src="../../../libs/json-editor/dist/jsoneditor.js"></script>
-    <script type="text/javascript" src="../../../libs/patternfly/dist/js/patternfly.js"></script>
+    <script type="text/javascript" src="../../../node_modules/patternfly/components/bootstrap/dist/js/bootstrap.js"></script>
+    <script type="text/javascript" src="../../../node_modules/patternfly/components/bootstrap-select/dist/js/bootstrap-select.js"></script>
+    <script type="text/javascript" src="../../../node_modules/json-editor/dist/jsoneditor.js"></script>
+    <script type="text/javascript" src="../../../node_modules/patternfly/dist/js/patternfly.js"></script>
     <script>
       var editor;
       var aceEditor;


### PR DESCRIPTION
Changes:
- Added the `amg` navigation header using the existing top loading bar; added some minor styling.
- Added a `README.md` for the headers and configuration directories, although this might be overkill. I thought we should document the possible values and how they are used somewhere.
- This also includes the change to get the JSON Schema testing page thing working again (updated paths for scripts).

JIRA: https://issues.jboss.org/browse/APIMAN-974

<img width="1440" alt="screen shot 2016-02-12 at 11 35 58 am" src="https://cloud.githubusercontent.com/assets/3844502/13013290/d8d53b72-d17c-11e5-95ba-22e668451926.png">


cc @EricWittmann 