### PR TITLE
re #977 Update swagger & swagger-ui

### DIFF
--- a/manager/ui/war/npm-shrinkwrap.json
+++ b/manager/ui/war/npm-shrinkwrap.json
@@ -4129,9 +4129,9 @@
       "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-2.1.5.tgz"
     },
     "swagger-ui": {
-      "version": "2.1.2",
-      "from": "swagger-ui@2.1.2",
-      "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-2.1.2.tgz"
+      "version": "2.1.4",
+      "from": "swagger-ui@2.1.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-2.1.4.tgz"
     },
     "swagger-ui-browserify": {
       "version": "2.1.3",

--- a/manager/ui/war/package.json
+++ b/manager/ui/war/package.json
@@ -59,7 +59,7 @@
     "sshpk": "1.4.6",
     "sugar": "1.4.1",
     "swagger-client": "2.1.5",
-    "swagger-ui": "2.1.2",
+    "swagger-ui": "2.1.4",
     "swagger-ui-browserify": "2.1.3",
     "through2": "0.6.3",
     "typescript": "1.6.2",

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <version.org.picketbox>4.1.1.Final</version.org.picketbox>
     <version.org.slf4j>1.7.7</version.org.slf4j>
     <version.io.netty>4.0.33.Final</version.io.netty>
-    <version.io.swagger>1.5.3</version.io.swagger>
+    <version.io.swagger>1.5.7</version.io.swagger>
     <version.xmlunit>1.6</version.xmlunit>
     <version.io.vertx>3.1.0</version.io.vertx>
   </properties>


### PR DESCRIPTION
Changes:
- Updated Swagger Java implementation version to 1.5.7 in pom.xml.
- Updated swagger-ui version to 2.1.4 in package.json.

JIRA: https://issues.jboss.org/browse/APIMAN-977

cc @EricWittmann 