### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/common/config/src/main/java/io/apiman/common/config/options/TLSOptions.java
+++ b/common/config/src/main/java/io/apiman/common/config/options/TLSOptions.java
@@ -273,16 +273,16 @@ public class TLSOptions extends AbstractOptions {
         result = prime * result + (allowAnyHost ? 1231 : 1237);
         result = prime * result + Arrays.hashCode(allowedCiphers);
         result = prime * result + Arrays.hashCode(allowedProtocols);
-        result = prime * result + ((clientKeyStore == null) ? 0 : clientKeyStore.hashCode());
+        result = prime * result + (clientKeyStore == null ? 0 : clientKeyStore.hashCode());
         result = prime * result + (devMode ? 1231 : 1237);
         result = prime * result + Arrays.hashCode(disallowedCiphers);
         result = prime * result + Arrays.hashCode(disallowedProtocols);
         result = prime * result + Arrays.hashCode(keyAliases);
-        result = prime * result + ((keyPassword == null) ? 0 : keyPassword.hashCode());
-        result = prime * result + ((keyStorePassword == null) ? 0 : keyStorePassword.hashCode());
+        result = prime * result + (keyPassword == null ? 0 : keyPassword.hashCode());
+        result = prime * result + (keyStorePassword == null ? 0 : keyStorePassword.hashCode());
         result = prime * result + (trustSelfSigned ? 1231 : 1237);
-        result = prime * result + ((trustStore == null) ? 0 : trustStore.hashCode());
-        result = prime * result + ((trustStorePassword == null) ? 0 : trustStorePassword.hashCode());
+        result = prime * result + (trustStore == null ? 0 : trustStore.hashCode());
+        result = prime * result + (trustStorePassword == null ? 0 : trustStorePassword.hashCode());
         return result;
     }
 

--- a/common/plugin/src/main/java/io/apiman/common/plugin/PluginCoordinates.java
+++ b/common/plugin/src/main/java/io/apiman/common/plugin/PluginCoordinates.java
@@ -152,11 +152,11 @@ public class PluginCoordinates implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((artifactId == null) ? 0 : artifactId.hashCode());
-        result = prime * result + ((classifier == null) ? 0 : classifier.hashCode());
-        result = prime * result + ((groupId == null) ? 0 : groupId.hashCode());
-        result = prime * result + ((type == null) ? 0 : type.hashCode());
-        result = prime * result + ((version == null) ? 0 : version.hashCode());
+        result = prime * result + (artifactId == null ? 0 : artifactId.hashCode());
+        result = prime * result + (classifier == null ? 0 : classifier.hashCode());
+        result = prime * result + (groupId == null ? 0 : groupId.hashCode());
+        result = prime * result + (type == null ? 0 : type.hashCode());
+        result = prime * result + (version == null ? 0 : version.hashCode());
         return result;
     }
 

--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/Api.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/Api.java
@@ -181,9 +181,9 @@ public class Api implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((organizationId == null) ? 0 : organizationId.hashCode());
-        result = prime * result + ((apiId == null) ? 0 : apiId.hashCode());
-        result = prime * result + ((version == null) ? 0 : version.hashCode());
+        result = prime * result + (organizationId == null ? 0 : organizationId.hashCode());
+        result = prime * result + (apiId == null ? 0 : apiId.hashCode());
+        result = prime * result + (version == null ? 0 : version.hashCode());
         return result;
     }
 

--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/ApiContract.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/ApiContract.java
@@ -119,7 +119,7 @@ public class ApiContract implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((apikey == null) ? 0 : apikey.hashCode());
+        result = prime * result + (apikey == null ? 0 : apikey.hashCode());
         return result;
     }
 

--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/Client.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/Client.java
@@ -111,9 +111,9 @@ public class Client implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((organizationId == null) ? 0 : organizationId.hashCode());
-        result = prime * result + ((getClientId() == null) ? 0 : getClientId().hashCode());
-        result = prime * result + ((version == null) ? 0 : version.hashCode());
+        result = prime * result + (organizationId == null ? 0 : organizationId.hashCode());
+        result = prime * result + (getClientId() == null ? 0 : getClientId().hashCode());
+        result = prime * result + (version == null ? 0 : version.hashCode());
         return result;
     }
 

--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/Contract.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/Contract.java
@@ -132,7 +132,7 @@ public class Contract implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((apiKey == null) ? 0 : apiKey.hashCode());
+        result = prime * result + (apiKey == null ? 0 : apiKey.hashCode());
         return result;
     }
 

--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/Policy.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/Policy.java
@@ -70,8 +70,8 @@ public class Policy implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((policyImpl == null) ? 0 : policyImpl.hashCode());
-        result = prime * result + ((policyJsonConfig == null) ? 0 : policyJsonConfig.hashCode());
+        result = prime * result + (policyImpl == null ? 0 : policyImpl.hashCode());
+        result = prime * result + (policyJsonConfig == null ? 0 : policyJsonConfig.hashCode());
         return result;
     }
 

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/DefaultLdapSearchImpl.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/DefaultLdapSearchImpl.java
@@ -54,7 +54,7 @@ public class DefaultLdapSearchImpl implements ILdapSearch {
     private void getResults(String searchDn, String filter, LdapSearchScope scope,
             final IAsyncResultHandler<List<SearchResultEntry>> result) {
         try {
-            SearchScope searchScope = (scope == LdapSearchScope.ONE) ? SearchScope.ONE : SearchScope.SUB;
+            SearchScope searchScope = scope == LdapSearchScope.ONE ? SearchScope.ONE : SearchScope.SUB;
             List<SearchResultEntry> searchResults = connection.search(searchDn, searchScope, filter).getSearchEntries();
             result.handle(AsyncResultImpl.create(searchResults));
         } catch (LDAPException e) {

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/io/ByteBuffer.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/io/ByteBuffer.java
@@ -186,7 +186,7 @@ public class ByteBuffer implements IApimanBuffer {
      */
     @Override
     public byte[] getBytes(int start, int end) {
-        int size = (end - start);
+        int size = end - start;
         byte [] rval = new byte[size];
         System.arraycopy(buffer, start, rval, 0, size);
         return rval;

--- a/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/ESCacheStoreComponent.java
+++ b/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/ESCacheStoreComponent.java
@@ -72,7 +72,7 @@ public class ESCacheStoreComponent extends AbstractESComponent implements ICache
     public <T> void put(String cacheKey, T jsonObject, long timeToLive) throws IOException {
         ESCacheEntry entry = new ESCacheEntry();
         entry.setData(null);
-        entry.setExpiresOn(System.currentTimeMillis() + (timeToLive * 1000));
+        entry.setExpiresOn(System.currentTimeMillis() + timeToLive * 1000);
         entry.setHead(mapper.writeValueAsString(entry));
         Index index = new Index.Builder(entry).refresh(false).index(getIndexName())
                 .type("cacheEntry").id(cacheKey).build(); //$NON-NLS-1$
@@ -89,7 +89,7 @@ public class ESCacheStoreComponent extends AbstractESComponent implements ICache
     public <T> ISignalWriteStream putBinary(final String cacheKey, final T jsonObject, final long timeToLive)
             throws IOException {
         final ESCacheEntry entry = new ESCacheEntry();
-        entry.setExpiresOn(System.currentTimeMillis() + (timeToLive * 1000));
+        entry.setExpiresOn(System.currentTimeMillis() + timeToLive * 1000);
         entry.setHead(mapper.writeValueAsString(jsonObject));
         final IApimanBuffer data = bufferFactory.createBuffer();
         return new ISignalWriteStream() {

--- a/gateway/engine/ispn/src/main/java/io/apiman/gateway/engine/ispn/InfinispanCacheStoreComponent.java
+++ b/gateway/engine/ispn/src/main/java/io/apiman/gateway/engine/ispn/InfinispanCacheStoreComponent.java
@@ -70,7 +70,7 @@ public class InfinispanCacheStoreComponent extends AbstractInfinispanComponent i
                 entry = new InfinispanCacheEntry();
             }
             entry.setHead(jsonObject);
-            entry.setExpiresOn(System.currentTimeMillis() + (timeToLive * 1000));
+            entry.setExpiresOn(System.currentTimeMillis() + timeToLive * 1000);
             getCache().put(cacheKey, entry);
         }
     }
@@ -107,7 +107,7 @@ public class InfinispanCacheStoreComponent extends AbstractInfinispanComponent i
                             entry = new InfinispanCacheEntry();
                         }
                         entry.setHead(jsonObject);
-                        entry.setExpiresOn(System.currentTimeMillis() + (timeToLive * 1000));
+                        entry.setExpiresOn(System.currentTimeMillis() + timeToLive * 1000);
                         entry.setData(dataBuffer.getBytes());
                         getCache().put(cacheKey, entry);
                     }

--- a/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/BasicAuthLDAPTest.java
+++ b/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/BasicAuthLDAPTest.java
@@ -318,7 +318,7 @@ public class BasicAuthLDAPTest extends AbstractLdapTestUnit {
     }
 
     public static void injectLdifFiles(String... ldifFiles) throws Exception {
-        if ((ldifFiles != null) && (ldifFiles.length > 0)) {
+        if (ldifFiles != null && ldifFiles.length > 0) {
             for (String ldifFile : ldifFiles) {
                 InputStream is = null;
                 try {

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpApiConnection.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpApiConnection.java
@@ -242,7 +242,7 @@ public class HttpApiConnection implements IApiConnection, IApiConnectionResponse
      * @return the port configured in the URL, or empty string if no port specified
      */
     private String determinePort(URL url) {
-        return (url.getPort() == -1) ? "" : ":" + url.getPort(); //$NON-NLS-1$ //$NON-NLS-2$
+        return url.getPort() == -1 ? "" : ":" + url.getPort(); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     /**

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/ok/HttpURLConnectionImpl.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/ok/HttpURLConnectionImpl.java
@@ -367,7 +367,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
 
   private String defaultUserAgent() {
     String agent = System.getProperty("http.agent");
-    return agent != null ? agent : ("Java" + System.getProperty("java.version"));
+    return agent != null ? agent : "Java" + System.getProperty("java.version");
   }
 
   /**

--- a/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/components/jdbc/suitetests/QueryTest.java
+++ b/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/components/jdbc/suitetests/QueryTest.java
@@ -113,7 +113,7 @@ public class QueryTest {
                                 context.assertEquals(3.14159, queryResult.getDouble(5));
                                 context.assertEquals(true, queryResult.getBoolean(6));
                                 context.assertEquals(new DateTime("1976-06-29T00:00:00.000"), queryResult.getDateTime(7));
-                                context.assertEquals(((byte) 31), queryResult.getBytes(8)[3]);
+                                context.assertEquals((byte) 31, queryResult.getBytes(8)[3]);
 
                                 async.complete();
                             }),

--- a/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/components/ldap/LdapTestParent.java
+++ b/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/components/ldap/LdapTestParent.java
@@ -113,7 +113,7 @@ public class LdapTestParent extends AbstractLdapTestUnit {
     }
 
     public static void injectLdifFiles(String... ldifFiles) throws Exception {
-        if ((ldifFiles != null) && (ldifFiles.length > 0)) {
+        if (ldifFiles != null && ldifFiles.length > 0) {
             for (String ldifFile : ldifFiles) {
                 InputStream is = null;
                 try {

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/actions/ActionBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/actions/ActionBean.java
@@ -100,10 +100,10 @@ public class ActionBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((entityId == null) ? 0 : entityId.hashCode());
-        result = prime * result + ((entityVersion == null) ? 0 : entityVersion.hashCode());
-        result = prime * result + ((organizationId == null) ? 0 : organizationId.hashCode());
-        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        result = prime * result + (entityId == null ? 0 : entityId.hashCode());
+        result = prime * result + (entityVersion == null ? 0 : entityVersion.hashCode());
+        result = prime * result + (organizationId == null ? 0 : organizationId.hashCode());
+        result = prime * result + (type == null ? 0 : type.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apis/ApiGatewayBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apis/ApiGatewayBean.java
@@ -59,7 +59,7 @@ public class ApiGatewayBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((gatewayId == null) ? 0 : gatewayId.hashCode());
+        result = prime * result + (gatewayId == null ? 0 : gatewayId.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apis/ApiPlanBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apis/ApiPlanBean.java
@@ -84,8 +84,8 @@ public class ApiPlanBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((planId == null) ? 0 : planId.hashCode());
-        result = prime * result + ((version == null) ? 0 : version.hashCode());
+        result = prime * result + (planId == null ? 0 : planId.hashCode());
+        result = prime * result + (version == null ? 0 : version.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apis/ApiVersionBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apis/ApiVersionBean.java
@@ -375,7 +375,7 @@ public class ApiVersionBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/clients/ClientVersionBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/clients/ClientVersionBean.java
@@ -228,7 +228,7 @@ public class ClientVersionBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/contracts/NewContractBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/contracts/NewContractBean.java
@@ -120,11 +120,11 @@ public class NewContractBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((planId == null) ? 0 : planId.hashCode());
-        result = prime * result + ((apiId == null) ? 0 : apiId.hashCode());
-        result = prime * result + ((apiOrgId == null) ? 0 : apiOrgId.hashCode());
-        result = prime * result + ((apiVersion == null) ? 0 : apiVersion.hashCode());
-        result = prime * result + ((apiKey == null) ? 0 : apiKey.hashCode());
+        result = prime * result + (planId == null ? 0 : planId.hashCode());
+        result = prime * result + (apiId == null ? 0 : apiId.hashCode());
+        result = prime * result + (apiOrgId == null ? 0 : apiOrgId.hashCode());
+        result = prime * result + (apiVersion == null ? 0 : apiVersion.hashCode());
+        result = prime * result + (apiKey == null ? 0 : apiKey.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/GrantRolesBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/GrantRolesBean.java
@@ -80,8 +80,8 @@ public class GrantRolesBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((getRoleIds() == null) ? 0 : getRoleIds().hashCode());
-        result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+        result = prime * result + (getRoleIds() == null ? 0 : getRoleIds().hashCode());
+        result = prime * result + (userId == null ? 0 : userId.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/PermissionBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/PermissionBean.java
@@ -73,8 +73,8 @@ public class PermissionBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        result = prime * result + ((organizationId == null) ? 0 : organizationId.hashCode());
+        result = prime * result + (name == null ? 0 : name.hashCode());
+        result = prime * result + (organizationId == null ? 0 : organizationId.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/RoleBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/RoleBean.java
@@ -112,7 +112,7 @@ public class RoleBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/RoleMembershipBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/RoleMembershipBean.java
@@ -143,7 +143,7 @@ public class RoleMembershipBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((getId() == null) ? 0 : getId().hashCode());
+        result = prime * result + (getId() == null ? 0 : getId().hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/UserBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/UserBean.java
@@ -118,7 +118,7 @@ public class UserBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((username == null) ? 0 : username.hashCode());
+        result = prime * result + (username == null ? 0 : username.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/UserPermissionsBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/UserPermissionsBean.java
@@ -71,8 +71,8 @@ public class UserPermissionsBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((permissions == null) ? 0 : permissions.hashCode());
-        result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+        result = prime * result + (permissions == null ? 0 : permissions.hashCode());
+        result = prime * result + (userId == null ? 0 : userId.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/orgs/OrganizationBasedCompositeId.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/orgs/OrganizationBasedCompositeId.java
@@ -80,8 +80,8 @@ public class OrganizationBasedCompositeId implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
-        result = prime * result + ((organization == null) ? 0 : organization.getId().hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
+        result = prime * result + (organization == null ? 0 : organization.getId().hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/orgs/OrganizationBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/orgs/OrganizationBean.java
@@ -165,7 +165,7 @@ public class OrganizationBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/plans/PlanVersionBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/plans/PlanVersionBean.java
@@ -209,7 +209,7 @@ public class PlanVersionBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/policies/PolicyBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/policies/PolicyBean.java
@@ -308,7 +308,7 @@ public class PolicyBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/policies/PolicyDefinitionBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/policies/PolicyDefinitionBean.java
@@ -230,7 +230,7 @@ public class PolicyDefinitionBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/search/OrderByBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/search/OrderByBean.java
@@ -71,7 +71,7 @@ public class OrderByBean implements Serializable {
         final int prime = 31;
         int result = 1;
         result = prime * result + (ascending ? 1231 : 1237);
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + (name == null ? 0 : name.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/search/SearchCriteriaBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/search/SearchCriteriaBean.java
@@ -130,9 +130,9 @@ public class SearchCriteriaBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((filters == null) ? 0 : filters.hashCode());
-        result = prime * result + ((orderBy == null) ? 0 : orderBy.hashCode());
-        result = prime * result + ((paging == null) ? 0 : paging.hashCode());
+        result = prime * result + (filters == null ? 0 : filters.hashCode());
+        result = prime * result + (orderBy == null ? 0 : orderBy.hashCode());
+        result = prime * result + (paging == null ? 0 : paging.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/search/SearchCriteriaFilterBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/search/SearchCriteriaFilterBean.java
@@ -86,9 +86,9 @@ public class SearchCriteriaFilterBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        result = prime * result + ((operator == null) ? 0 : operator.hashCode());
-        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        result = prime * result + (name == null ? 0 : name.hashCode());
+        result = prime * result + (operator == null ? 0 : operator.hashCode());
+        result = prime * result + (value == null ? 0 : value.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/summary/ApiPlanSummaryBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/summary/ApiPlanSummaryBean.java
@@ -87,7 +87,7 @@ public class ApiPlanSummaryBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((planId == null) ? 0 : planId.hashCode());
+        result = prime * result + (planId == null ? 0 : planId.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/summary/ApiSummaryBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/summary/ApiSummaryBean.java
@@ -136,8 +136,8 @@ public class ApiSummaryBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
-        result = prime * result + ((organizationId == null) ? 0 : organizationId.hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
+        result = prime * result + (organizationId == null ? 0 : organizationId.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/summary/ClientSummaryBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/summary/ClientSummaryBean.java
@@ -141,8 +141,8 @@ public class ClientSummaryBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
-        result = prime * result + ((organizationId == null) ? 0 : organizationId.hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
+        result = prime * result + (organizationId == null ? 0 : organizationId.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/summary/ContractSummaryBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/summary/ContractSummaryBean.java
@@ -297,7 +297,7 @@ public class ContractSummaryBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((contractId == null) ? 0 : contractId.hashCode());
+        result = prime * result + (contractId == null ? 0 : contractId.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/summary/OrganizationSummaryBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/summary/OrganizationSummaryBean.java
@@ -131,7 +131,7 @@ public class OrganizationSummaryBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/summary/PlanSummaryBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/summary/PlanSummaryBean.java
@@ -126,8 +126,8 @@ public class PlanSummaryBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
-        result = prime * result + ((organizationId == null) ? 0 : organizationId.hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
+        result = prime * result + (organizationId == null ? 0 : organizationId.hashCode());
         return result;
     }
 

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/summary/PolicyDefinitionSummaryBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/summary/PolicyDefinitionSummaryBean.java
@@ -145,7 +145,7 @@ public class PolicyDefinitionSummaryBean implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
         return result;
     }
 

--- a/manager/api/export-import/src/main/java/io/apiman/manager/api/exportimport/manager/StorageImportDispatcher.java
+++ b/manager/api/export-import/src/main/java/io/apiman/manager/api/exportimport/manager/StorageImportDispatcher.java
@@ -746,9 +746,9 @@ public class StorageImportDispatcher implements IImportReaderDispatcher {
         public int hashCode() {
             final int prime = 31;
             int result = 1;
-            result = prime * result + ((id == null) ? 0 : id.hashCode());
-            result = prime * result + ((organizationId == null) ? 0 : organizationId.hashCode());
-            result = prime * result + ((version == null) ? 0 : version.hashCode());
+            result = prime * result + (id == null ? 0 : id.hashCode());
+            result = prime * result + (organizationId == null ? 0 : organizationId.hashCode());
+            result = prime * result + (version == null ? 0 : version.hashCode());
             return result;
         }
 

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/OrganizationResourceImpl.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/OrganizationResourceImpl.java
@@ -799,7 +799,7 @@ public class OrganizationResourceImpl implements IOrganizationResource {
         contract.setPlan(pvb);
         contract.setCreatedBy(securityContext.getCurrentUser());
         contract.setCreatedOn(new Date());
-        contract.setApikey((bean.getApiKey() == null) ? apiKeyGenerator.generate() : bean.getApiKey());
+        contract.setApikey(bean.getApiKey() == null ? apiKeyGenerator.generate() : bean.getApiKey());
 
         // Move the client to the "Ready" state if necessary.
         if (cvb.getStatus() == ClientStatus.Created && clientValidator.isReady(cvb, true)) {
@@ -977,7 +977,7 @@ public class OrganizationResourceImpl implements IOrganizationResource {
         boolean hasPermission = securityContext.hasPermission(PermissionType.clientView, organizationId);
         if ("true".equals(download)) { //$NON-NLS-1$
             try {
-                String path = String.format("%s/%s/%s/%s", organizationId, clientId, version, (hasPermission ? '+' : '-' )); //$NON-NLS-1$
+                String path = String.format("%s/%s/%s/%s", organizationId, clientId, version, hasPermission ? '+' : '-'); //$NON-NLS-1$
                 DownloadBean dbean = downloadManager.createDownload(DownloadType.apiRegistryJson, path);
                 return Response.ok(dbean, MediaType.APPLICATION_JSON).build();
             } catch (StorageException e) {
@@ -1009,7 +1009,7 @@ public class OrganizationResourceImpl implements IOrganizationResource {
         boolean hasPermission = securityContext.hasPermission(PermissionType.clientView, organizationId);
         if ("true".equals(download)) { //$NON-NLS-1$
             try {
-                String path = String.format("%s/%s/%s/%s", organizationId, clientId, version, (hasPermission ? '+' : '-' )); //$NON-NLS-1$
+                String path = String.format("%s/%s/%s/%s", organizationId, clientId, version, hasPermission ? '+' : '-'); //$NON-NLS-1$
                 DownloadBean dbean = downloadManager.createDownload(DownloadType.apiRegistryXml, path);
                 return Response.ok(dbean, MediaType.APPLICATION_JSON).build();
             } catch (StorageException e) {

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/audit/AuditUtils.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/audit/AuditUtils.java
@@ -62,7 +62,7 @@ public class AuditUtils {
      * @return true if value changed, else false
      */
     public static boolean valueChanged(String before, String after) {
-        if ((before == null && after == null) || after == null) {
+        if (before == null && after == null || after == null) {
             return false;
         }
 
@@ -80,7 +80,7 @@ public class AuditUtils {
      * @return true if value changed, else false
      */
     public static boolean valueChanged(Boolean before, Boolean after) {
-        if ((before == null && after == null) || after == null) {
+        if (before == null && after == null || after == null) {
             return false;
         }
 
@@ -99,7 +99,7 @@ public class AuditUtils {
      * @return true if value changed, else false
      */
     public static boolean valueChanged(Set<?> before, Set<?> after) {
-        if ((before == null && after == null) || after == null) {
+        if (before == null && after == null || after == null) {
             return false;
         }
         if (before == null) {
@@ -129,7 +129,7 @@ public class AuditUtils {
      * @return true if value changed, else false
      */
     public static boolean valueChanged(Map<String, String> before, Map<String, String> after) {
-        if ((before == null && after == null) || after == null) {
+        if (before == null && after == null || after == null) {
             return false;
         }
         if (before == null) {

--- a/manager/api/war/src/main/java/io/apiman/manager/api/war/WarCdiFactory.java
+++ b/manager/api/war/src/main/java/io/apiman/manager/api/war/WarCdiFactory.java
@@ -143,7 +143,7 @@ public class WarCdiFactory {
             return jpaStorage;
         } else if ("es".equals(config.getStorageType())) { //$NON-NLS-1$
             return initES(config, esStorage);
-        } else if (storage != null && (storage instanceof IStorageQuery)) {
+        } else if (storage != null && storage instanceof IStorageQuery) {
             return (IStorageQuery) storage;
         } else {
             try {

--- a/manager/ui/war/src/main/java/io/apiman/manager/ui/server/kc/KeyCloakBearerTokenGenerator.java
+++ b/manager/ui/war/src/main/java/io/apiman/manager/ui/server/kc/KeyCloakBearerTokenGenerator.java
@@ -79,9 +79,9 @@ public class KeyCloakBearerTokenGenerator implements ITokenGenerator {
                 Class<?> tc = Class.forName("org.keycloak.util.Time"); //$NON-NLS-1$
                 Method method = tc.getMethod("currentTime"); //$NON-NLS-1$
                 Object object = method.invoke(null);
-                return ((Integer) object);
+                return (Integer) object;
             } catch (Throwable e1) {
-                return ((int) (System.currentTimeMillis() / 1000));
+                return (int) (System.currentTimeMillis() / 1000);
             }
         }
     }

--- a/test/common/src/main/java/io/apiman/test/common/util/TestVariableResolverFactory.java
+++ b/test/common/src/main/java/io/apiman/test/common/util/TestVariableResolverFactory.java
@@ -113,7 +113,7 @@ public class TestVariableResolverFactory extends BaseVariableResolverFactory {
     @Override
     public VariableResolver getVariableResolver(String name) {
         VariableResolver vr = variableResolvers.get(name);
-        return vr != null ? vr : (nextFactory == null ? null : nextFactory.getVariableResolver(name));
+        return vr != null ? vr : nextFactory == null ? null : nextFactory.getVariableResolver(name);
     }
 
     /**

--- a/tools/ldap/src/main/java/io/apiman/tools/ldap/ApimanLdapServer.java
+++ b/tools/ldap/src/main/java/io/apiman/tools/ldap/ApimanLdapServer.java
@@ -135,7 +135,7 @@ public class ApimanLdapServer extends AbstractLdapTestUnit {
     }
 
     public static void injectLdifFiles(String... ldifFiles) throws Exception {
-        if ((ldifFiles != null) && (ldifFiles.length > 0)) {
+        if (ldifFiles != null && ldifFiles.length > 0) {
             for (String ldifFile : ldifFiles) {
                 InputStream is = null;
                 try {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.