### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/gateway/engine/es/src/test/java/io/apiman/gateway/engine/es/ESRegistryMarshallingTest.java
+++ b/gateway/engine/es/src/test/java/io/apiman/gateway/engine/es/ESRegistryMarshallingTest.java
@@ -63,7 +63,7 @@ public class ESRegistryMarshallingTest {
                 + "}", ESRegistryMarshalling.marshall(api).string());
 
         // Set to a tree map so we can guarantee ordering.
-        api.setEndpointProperties(new TreeMap<String, String>());
+        api.setEndpointProperties(new TreeMap<>());
         api.getEndpointProperties().put("property-1", "prop-1-value");
         api.getEndpointProperties().put("property-2", "prop-2-value");
         Assert.assertEquals("{"
@@ -195,7 +195,7 @@ public class ESRegistryMarshallingTest {
         ApiContract sc = new ApiContract();
         sc.setApikey("12345");
         sc.setPlan("Gold");
-        sc.setPolicies(new ArrayList<Policy>());
+        sc.setPolicies(new ArrayList<>());
 
         Api api = new Api();
         api.setApiPolicies(null);

--- a/manager/api/es/src/main/java/io/apiman/manager/api/es/EsMarshalling.java
+++ b/manager/api/es/src/main/java/io/apiman/manager/api/es/EsMarshalling.java
@@ -965,7 +965,7 @@ public class EsMarshalling {
         bean.setEndpointContentType(asEnum(source.get("endpointContentType"), EndpointContentType.class));
         bean.setPublicAPI(asBoolean(source.get("publicAPI")));
         bean.setDefinitionType(asEnum(source.get("definitionType"), ApiDefinitionType.class));
-        bean.setGateways(new HashSet<ApiGatewayBean>());
+        bean.setGateways(new HashSet<>());
         List<Map<String, Object>> gateways = (List<Map<String, Object>>) source.get("gateways");
         if (gateways != null) {
             for (Map<String, Object> gatewayMap : gateways) {
@@ -974,7 +974,7 @@ public class EsMarshalling {
                 bean.getGateways().add(gatewayBean);
             }
         }
-        bean.setPlans(new HashSet<ApiPlanBean>());
+        bean.setPlans(new HashSet<>());
         List<Map<String, Object>> plans = (List<Map<String, Object>>) source.get("plans");
         if (plans != null) {
             for (Map<String, Object> planMap : plans) {
@@ -986,7 +986,7 @@ public class EsMarshalling {
         }
         Map<String, Object> endpointProperties = (Map<String, Object>) source.get("endpointProperties");
         if (endpointProperties != null) {
-            bean.setEndpointProperties(new HashMap<String, String>());
+            bean.setEndpointProperties(new HashMap<>());
             for (Entry<String, Object> entry : endpointProperties.entrySet()) {
                 bean.getEndpointProperties().put(entry.getKey(), String.valueOf(entry.getValue()));
             }
@@ -1117,7 +1117,7 @@ public class EsMarshalling {
         @SuppressWarnings("unchecked")
         List<Object> permissions = (List<Object>) source.get("permissions");
         if (permissions != null && !permissions.isEmpty()) {
-            bean.setPermissions(new HashSet<PermissionType>());
+            bean.setPermissions(new HashSet<>());
             for (Object permission : permissions) {
                 bean.getPermissions().add(asEnum(permission, PermissionType.class));
             }
@@ -1263,7 +1263,7 @@ public class EsMarshalling {
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> templates = (List<Map<String, Object>>) source.get("templates");
         if (templates != null && !templates.isEmpty()) {
-            bean.setTemplates(new HashSet<PolicyDefinitionTemplateBean>());
+            bean.setTemplates(new HashSet<>());
             for (Map<String, Object> templateMap : templates) {
                 PolicyDefinitionTemplateBean template = new PolicyDefinitionTemplateBean();
                 template.setLanguage(asString(templateMap.get("language")));

--- a/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/JpaStorage.java
+++ b/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/JpaStorage.java
@@ -678,7 +678,7 @@ public class JpaStorage extends AbstractJpaStorage implements IStorage, IStorage
         SearchResultsBean<ClientSummaryBean> rval = new SearchResultsBean<>();
         rval.setTotalSize(result.getTotalSize());
         List<ClientBean> beans = result.getBeans();
-        rval.setBeans(new ArrayList<ClientSummaryBean>(beans.size()));
+        rval.setBeans(new ArrayList<>(beans.size()));
         for (ClientBean client : beans) {
             ClientSummaryBean summary = new ClientSummaryBean();
             OrganizationBean organization = client.getOrganization();
@@ -704,7 +704,7 @@ public class JpaStorage extends AbstractJpaStorage implements IStorage, IStorage
         SearchResultsBean<ApiSummaryBean> rval = new SearchResultsBean<>();
         rval.setTotalSize(result.getTotalSize());
         List<ApiBean> beans = result.getBeans();
-        rval.setBeans(new ArrayList<ApiSummaryBean>(beans.size()));
+        rval.setBeans(new ArrayList<>(beans.size()));
         for (ApiBean api : beans) {
             ApiSummaryBean summary = new ApiSummaryBean();
             OrganizationBean organization = api.getOrganization();
@@ -731,7 +731,7 @@ public class JpaStorage extends AbstractJpaStorage implements IStorage, IStorage
         SearchResultsBean<PlanSummaryBean> rval = new SearchResultsBean<>();
         rval.setTotalSize(result.getTotalSize());
         List<PlanBean> plans = result.getBeans();
-        rval.setBeans(new ArrayList<PlanSummaryBean>(plans.size()));
+        rval.setBeans(new ArrayList<>(plans.size()));
         for (PlanBean plan : plans) {
             PlanSummaryBean summary = new PlanSummaryBean();
             OrganizationBean organization = plan.getOrganization();

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/CurrentUserResourceImpl.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/CurrentUserResourceImpl.java
@@ -109,7 +109,7 @@ public class CurrentUserResourceImpl implements ICurrentUserResource {
                 }
                 rval.initFromUser(user);
                 rval.setAdmin(securityContext.isAdmin());
-                rval.setPermissions(new HashSet<PermissionBean>());
+                rval.setPermissions(new HashSet<>());
             } else {
                 rval.initFromUser(user);
                 Set<PermissionBean> permissions = query.getPermissions(userId);

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/OrganizationResourceImpl.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/OrganizationResourceImpl.java
@@ -1617,7 +1617,7 @@ public class OrganizationResourceImpl implements IOrganizationResource {
 
         if (gateway != null) {
             if (newVersion.getGateways() == null) {
-                newVersion.setGateways(new HashSet<ApiGatewayBean>());
+                newVersion.setGateways(new HashSet<>());
                 ApiGatewayBean sgb = new ApiGatewayBean();
                 sgb.setGatewayId(gateway.getId());
                 newVersion.getGateways().add(sgb);
@@ -1839,7 +1839,7 @@ public class OrganizationResourceImpl implements IOrganizationResource {
         if (AuditUtils.valueChanged(avb.getPlans(), bean.getPlans())) {
             data.addChange("plans", AuditUtils.asString_ApiPlanBeans(avb.getPlans()), AuditUtils.asString_ApiPlanBeans(bean.getPlans())); //$NON-NLS-1$
             if (avb.getPlans() == null) {
-                avb.setPlans(new HashSet<ApiPlanBean>());
+                avb.setPlans(new HashSet<>());
             }
             avb.getPlans().clear();
             if (bean.getPlans() != null) {
@@ -1849,7 +1849,7 @@ public class OrganizationResourceImpl implements IOrganizationResource {
         if (AuditUtils.valueChanged(avb.getGateways(), bean.getGateways())) {
             data.addChange("gateways", AuditUtils.asString_ApiGatewayBeans(avb.getGateways()), AuditUtils.asString_ApiGatewayBeans(bean.getGateways())); //$NON-NLS-1$
             if (avb.getGateways() == null) {
-                avb.setGateways(new HashSet<ApiGatewayBean>());
+                avb.setGateways(new HashSet<>());
             }
             avb.getGateways().clear();
             avb.getGateways().addAll(bean.getGateways());
@@ -1870,7 +1870,7 @@ public class OrganizationResourceImpl implements IOrganizationResource {
         }
         if (AuditUtils.valueChanged(avb.getEndpointProperties(), bean.getEndpointProperties())) {
             if (avb.getEndpointProperties() == null) {
-                avb.setEndpointProperties(new HashMap<String, String>());
+                avb.setEndpointProperties(new HashMap<>());
             } else {
                 avb.getEndpointProperties().clear();
             }
@@ -1888,7 +1888,7 @@ public class OrganizationResourceImpl implements IOrganizationResource {
                 GatewaySummaryBean gateway = getSingularGateway();
                 if (gateway != null) {
                     if (avb.getGateways() == null) {
-                        avb.setGateways(new HashSet<ApiGatewayBean>());
+                        avb.setGateways(new HashSet<>());
                         ApiGatewayBean sgb = new ApiGatewayBean();
                         sgb.setGatewayId(gateway.getId());
                         avb.getGateways().add(sgb);
@@ -3244,7 +3244,7 @@ public class OrganizationResourceImpl implements IOrganizationResource {
                     member.setEmail(user.getEmail());
                     member.setUserId(userId);
                     member.setUserName(user.getFullName());
-                    member.setRoles(new ArrayList<MemberRoleBean>());
+                    member.setRoles(new ArrayList<>());
                     members.put(userId, member);
                 }
                 MemberRoleBean mrb = new MemberRoleBean();

--- a/manager/api/security/src/main/java/io/apiman/manager/api/security/impl/AbstractSecurityContext.java
+++ b/manager/api/security/src/main/java/io/apiman/manager/api/security/impl/AbstractSecurityContext.java
@@ -101,7 +101,7 @@ public abstract class AbstractSecurityContext implements ISecurityContext {
             return new IndexedPermissions(getQuery().getPermissions(userId));
         } catch (StorageException e) {
             logger.error(Messages.getString("AbstractSecurityContext.ErrorLoadingPermissions") + userId, e); //$NON-NLS-1$
-            return new IndexedPermissions(new HashSet<PermissionBean>());
+            return new IndexedPermissions(new HashSet<>());
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “ The diamond operator ("<>") should be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.