### PR TITLE
re #968 Swap method and path on table

### DIFF
--- a/manager/ui/war/plugins/api-manager/html/policyForms/ignored-resources.include
+++ b/manager/ui/war/plugins/api-manager/html/policyForms/ignored-resources.include
@@ -37,8 +37,8 @@
   <table class="table table-striped table-bordered">
     <thead>
       <tr>
-        <th width="30%" apiman-i18n-key="verb">Method</th>
-        <th width="70%" apiman-i18n-key="path">Path</th>
+        <th width="30%" apiman-i18n-key="path">Path</th>
+        <th width="70%" apiman-i18n-key="method">Method</th>
         <th width="1%"></th>
       </tr>
     </thead>

--- a/manager/ui/war/src/main/sdk/json-schema.html
+++ b/manager/ui/war/src/main/sdk/json-schema.html
@@ -5,7 +5,7 @@
     <title>apiman - JSON Schema Policy Configuration SDK</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
 
-    <link rel="icon" type="image/png" href="../webapp/css/images/favicon.png"></link>
+    <link rel="icon" type="image/x-icon" href="../../../favicon.ico"></link>
 
     <link rel="stylesheet" href="../../../node_modules/patternfly/components/bootstrap/dist/css/bootstrap.css" />
     <link rel="stylesheet" href="../../../node_modules/patternfly/components/bootstrap-select/dist/css/bootstrap-select.css" />


### PR DESCRIPTION
Swapped the "method" and "path" labels on the table header of the Ignored Resources Policy Configuration page.

JIRA: https://issues.jboss.org/browse/APIMAN-968

<img width="905" alt="screen shot 2016-02-15 at 2 39 05 pm" src="https://cloud.githubusercontent.com/assets/3844502/13058589/2feabb18-d3f2-11e5-93d8-e28bea00c59e.png">


cc @EricWittmann 