### PR TITLE
Override hashcode whenever overriding equals() and "equals(Object obj)" should test argument type

### DIFF
--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/config/AuthorizationRule.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/config/AuthorizationRule.java
@@ -79,9 +79,20 @@ public class AuthorizationRule {
      */
     @Override
     public boolean equals(Object obj) {
+        if (obj == null)
+            return false;
+        if (this.getClass() != obj.getClass())
+            return false;
         AuthorizationRule rule2 = (AuthorizationRule) obj;
         return this.getVerb().equals(rule2.getVerb()) && this.getPathPattern().equals(rule2.getPathPattern())
                 && this.getRole().equals(rule2.getRole());
     }
 
+    @Override
+    public int hashCode() {
+        int result = this.verb != null ? this.verb.hashCode() : 0;
+        result = 31 * result + (this.pathPattern != null ? this.pathPattern.hashCode() : 0);
+        result = 31 * result + (this.role != null ? this.role.hashCode() : 0);
+        return result;
+    }
 }

--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/config/IgnoredResource.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/config/IgnoredResource.java
@@ -72,8 +72,18 @@ public class IgnoredResource {
      */
     @Override
     public boolean equals(Object obj) {
+        if (obj == null)
+            return false;
+        if (this.getClass() != obj.getClass())
+            return false;
         IgnoredResource rule2 = (IgnoredResource) obj;
         return this.getVerb().equals(rule2.getVerb()) && this.getPathPattern().equals(rule2.getPathPattern());
     }
 
+    @Override
+    public int hashCode() {
+        int result = this.verb != null ? this.verb.hashCode() : 0;
+        result = 31 * result + (this.pathPattern != null ? this.pathPattern.hashCode() : 0);
+        return result;
+    }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of FindBugs rule HE_EQUALS_USE_HASHCODE - “ Class defines equals() and uses Object.hashCode() ”. You can find more information about the issue here: http://findbugs.sourceforge.net/bugDescriptions.html#HE_EQUALS_USE_HASHCODE
And
Sonar rule squid:S2097 - “ "equals(Object obj)" should test argument type ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2097
Please let me know if you have any questions.
Ayman Abdelghany.