### PR TITLE
Casting math operands before assignment

### DIFF
--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/InMemoryCacheStoreComponent.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/InMemoryCacheStoreComponent.java
@@ -46,7 +46,7 @@ public class InMemoryCacheStoreComponent implements ICacheStoreComponent {
     private Map<String, Object> objectCache = new LinkedHashMap<>();
     private Map<String, IApimanBuffer> dataCache = new HashMap<>();
     private long cacheSize = 0;
-    private long maxCacheSize = 10 * 1024 * 1024; // 10 MB
+    private long maxCacheSize = 10 * 1024 * 1024L; // 10 MB
 
     private IBufferFactoryComponent bufferFactory;
 

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/OrganizationResourceImpl.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/OrganizationResourceImpl.java
@@ -197,11 +197,11 @@ public class OrganizationResourceImpl implements IOrganizationResource {
         "EEE, dd MMM yyyy"
     };
 
-    private static final long ONE_MINUTE_MILLIS = 1 * 60 * 1000;
-    private static final long ONE_HOUR_MILLIS = 1 * 60 * 60 * 1000;
-    private static final long ONE_DAY_MILLIS = 1 * 24 * 60 * 60 * 1000;
-    private static final long ONE_WEEK_MILLIS = 7 * 24 * 60 * 60 * 1000;
-    private static final long ONE_MONTH_MILLIS = 30 * 24 * 60 * 60 * 1000;
+    private static final long ONE_MINUTE_MILLIS = 1 * 60 * 1000L;
+    private static final long ONE_HOUR_MILLIS = 1 * 60 * 60 * 1000L;
+    private static final long ONE_DAY_MILLIS = 1 * 24 * 60 * 60 * 1000L;
+    private static final long ONE_WEEK_MILLIS = 7 * 24 * 60 * 60 * 1000L;
+    private static final long ONE_MONTH_MILLIS = 30 * 24 * 60 * 60 * 1000L;
 
     @Inject IStorage storage;
     @Inject IStorageQuery query;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2184 - “ Math operands should be cast before assignment”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2184
Please let me know if you have any questions.
Ayman Abdelghany.