### PR TITLE
Adding private constructor to util classes (containing static methods only)

### DIFF
--- a/common/auth/src/main/java/io/apiman/common/auth/AuthTokenUtil.java
+++ b/common/auth/src/main/java/io/apiman/common/auth/AuthTokenUtil.java
@@ -59,7 +59,10 @@ public class AuthTokenUtil {
             };
         }
     }
-    
+
+    private AuthTokenUtil() {
+    }
+
     /**
      * Produce a token suitable for transmission.  This will generate the auth token,
      * then serialize it to a JSON string, then Base64 encode the JSON.

--- a/common/config/src/main/java/io/apiman/common/config/ConfigFactory.java
+++ b/common/config/src/main/java/io/apiman/common/config/ConfigFactory.java
@@ -31,6 +31,9 @@ public class ConfigFactory {
         ConfigurationInterpolator.registerGlobalLookup("vault", new VaultLookup()); //$NON-NLS-1$
     }
 
+    private ConfigFactory() {
+    }
+
     public static final CompositeConfiguration createConfig() {
         CompositeConfiguration compositeConfiguration = new CompositeConfiguration();
         compositeConfiguration.addConfiguration(new SystemPropertiesConfiguration());

--- a/common/plugin/src/main/java/io/apiman/common/plugin/PluginUtils.java
+++ b/common/plugin/src/main/java/io/apiman/common/plugin/PluginUtils.java
@@ -42,6 +42,9 @@ public class PluginUtils {
         }
     }
 
+    private PluginUtils() {
+    }
+
     /**
      * @return a set of default maven repositories to search for plugins
      */

--- a/common/util/src/main/java/io/apiman/common/util/AesEncrypter.java
+++ b/common/util/src/main/java/io/apiman/common/util/AesEncrypter.java
@@ -42,6 +42,9 @@ public class AesEncrypter {
         skeySpec = new SecretKeySpec(ivraw, "AES"); //$NON-NLS-1$
     }
 
+    private AesEncrypter() {
+    }
+
     /**
      * Encrypt.
      * @param plainText the plain text

--- a/common/util/src/main/java/io/apiman/common/util/ApimanPathUtils.java
+++ b/common/util/src/main/java/io/apiman/common/util/ApimanPathUtils.java
@@ -20,6 +20,9 @@ public class ApimanPathUtils {
     public static final String X_API_VERSION_HEADER = "X-API-Version"; //$NON-NLS-1$
     public static final String ACCEPT_HEADER = "Accept"; //$NON-NLS-1$
 
+    private ApimanPathUtils() {
+    }
+
     /**
      * Parses the HTTP request and returns an object containing all of the API
      * information (Org, Id, Version).

--- a/common/util/src/main/java/io/apiman/common/util/Basic.java
+++ b/common/util/src/main/java/io/apiman/common/util/Basic.java
@@ -20,6 +20,9 @@ import org.apache.commons.codec.binary.Base64;
 @SuppressWarnings("nls")
 public class Basic {
 
+    private Basic() {
+    }
+
     public static String encode(String username, String password) {
         String up = username + ':' + password;
         StringBuilder builder = new StringBuilder();

--- a/common/util/src/main/java/io/apiman/common/util/ReflectionUtils.java
+++ b/common/util/src/main/java/io/apiman/common/util/ReflectionUtils.java
@@ -24,6 +24,9 @@ import java.lang.reflect.Method;
  */
 public class ReflectionUtils {
 
+    private ReflectionUtils() {
+    }
+
     /**
      * Call a method if it exists. Use very sparingly and generally prefer interfaces.
      * @param object The object

--- a/common/util/src/main/java/io/apiman/common/util/ServiceRegistryUtil.java
+++ b/common/util/src/main/java/io/apiman/common/util/ServiceRegistryUtil.java
@@ -31,6 +31,9 @@ public class ServiceRegistryUtil {
 
     private static Map<Class<?>, Set<?>> servicesCache = new HashMap<>();
 
+    private ServiceRegistryUtil() {
+    }
+
     /**
      * Gets a single service by its interface.
      * @param serviceInterface the service interface

--- a/common/util/src/main/java/io/apiman/common/util/SimpleStringUtils.java
+++ b/common/util/src/main/java/io/apiman/common/util/SimpleStringUtils.java
@@ -26,6 +26,9 @@ package io.apiman.common.util;
  */
 public class SimpleStringUtils {
 
+    private SimpleStringUtils() {
+    }
+
     /**
      * Trim string of whitespace.
      * 

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/components/ldap/result/DefaultExceptionFactory.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/components/ldap/result/DefaultExceptionFactory.java
@@ -26,6 +26,9 @@ import com.unboundid.ldap.sdk.ResultCode;
  */
 public class DefaultExceptionFactory {
 
+    private DefaultExceptionFactory() {
+    }
+
     /**
      * Convert LDAP Exceptions
      *

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/components/ldap/result/DefaultLdapResultCodeFactory.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/components/ldap/result/DefaultLdapResultCodeFactory.java
@@ -23,6 +23,9 @@ import com.unboundid.ldap.sdk.ResultCode;
  */
 public class DefaultLdapResultCodeFactory {
 
+    private DefaultLdapResultCodeFactory() {
+    }
+
     public static LdapResultCode convertResultCode(ResultCode resultCode) {
         switch (resultCode.intValue()) {
         case ResultCode.SUCCESS_INT_VALUE:

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/LDAPConnectionFactory.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/LDAPConnectionFactory.java
@@ -34,6 +34,9 @@ public class LDAPConnectionFactory {
     private static final int MAX_CONNECTIONS_PER_POOL = 20;
     private static final int MAX_POOLS = 20;
 
+    private LDAPConnectionFactory() {
+    }
+
     protected static Map<LdapConfigBean, LDAPConnectionPool> connectionPoolCache =
             new LRUMap<LdapConfigBean, LDAPConnectionPool>(MAX_POOLS) {
         private static final long serialVersionUID = 1L;

--- a/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/ESUtils.java
+++ b/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/ESUtils.java
@@ -22,6 +22,9 @@ package io.apiman.gateway.engine.es;
  */
 public class ESUtils {
 
+    private ESUtils() {
+    }
+
     /**
      * Gets the root cause of an exception.
      * @param e the root cause

--- a/gateway/test/src/main/java/io/apiman/gateway/test/server/GatewayTestUtils.java
+++ b/gateway/test/src/main/java/io/apiman/gateway/test/server/GatewayTestUtils.java
@@ -23,6 +23,9 @@ package io.apiman.gateway.test.server;
 @SuppressWarnings("nls")
 public class GatewayTestUtils {
 
+    private GatewayTestUtils() {
+    }
+
     public static GatewayTestType getTestType() {
         return GatewayTestType.valueOf(System.getProperty("apiman.test.type", GatewayTestType.memory.name()));
     }

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/BeanUtils.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/BeanUtils.java
@@ -23,6 +23,9 @@ package io.apiman.manager.api.beans;
  */
 public class BeanUtils {
 
+    private BeanUtils() {
+    }
+
     /**
      * Creates a bean id from the given bean name.  This essentially removes any
      * non "word" characters from the name.

--- a/manager/api/core/src/main/java/io/apiman/manager/api/core/util/PolicyTemplateUtil.java
+++ b/manager/api/core/src/main/java/io/apiman/manager/api/core/util/PolicyTemplateUtil.java
@@ -44,6 +44,9 @@ public class PolicyTemplateUtil {
     // Cache a MVEL 2.0 compiled template - the key is PolicyDefId::language
     private static final Map<String, CompiledTemplate> templateCache = new HashMap<>();
 
+    private PolicyTemplateUtil() {
+    }
+
     /**
      * Clears out the template cache.
      */

--- a/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/JpaUtil.java
+++ b/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/JpaUtil.java
@@ -30,6 +30,9 @@ public final class JpaUtil {
 
     private static Logger logger = LoggerFactory.getLogger(JpaUtil.class);
 
+    private JpaUtil() {
+    }
+
     /**
      * Returns true if the given exception is a unique constraint violation.  This
      * is useful to detect whether someone is trying to persist an entity that

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/audit/AuditUtils.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/audit/AuditUtils.java
@@ -55,6 +55,9 @@ public class AuditUtils {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
+    private AuditUtils() {
+    }
+
     /**
      * Returns true only if the value changed.
      * @param before the value before change

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/util/ExceptionFactory.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/util/ExceptionFactory.java
@@ -62,6 +62,9 @@ import io.apiman.manager.api.rest.impl.i18n.Messages;
  */
 public final class ExceptionFactory {
 
+    private ExceptionFactory() {
+    }
+
     /**
      * Creates an exception from a username.
      * @param username the username

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/util/FieldValidator.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/util/FieldValidator.java
@@ -27,6 +27,9 @@ import org.apache.commons.lang.StringUtils;
  */
 public class FieldValidator {
 
+    private FieldValidator() {
+    }
+
     /**
      * Validates an entity name.
      * @param name

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/util/SearchCriteriaUtil.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/util/SearchCriteriaUtil.java
@@ -42,6 +42,9 @@ public final class SearchCriteriaUtil {
         validOperators.add(SearchCriteriaFilterOperator.like);
     }
 
+    private SearchCriteriaUtil() {
+    }
+
     /**
      * Validates that the search criteria bean is complete and makes sense.
      * @param criteria the search criteria

--- a/manager/test/api/src/main/java/io/apiman/manager/test/util/ManagerTestUtils.java
+++ b/manager/test/api/src/main/java/io/apiman/manager/test/util/ManagerTestUtils.java
@@ -21,7 +21,10 @@ package io.apiman.manager.test.util;
  * @author eric.wittmann@redhat.com
  */
 public class ManagerTestUtils {
-    
+
+    private ManagerTestUtils() {
+    }
+
     public static enum TestType {
         jpa, es;
     }

--- a/test/common/src/main/java/io/apiman/test/common/util/TestUtil.java
+++ b/test/common/src/main/java/io/apiman/test/common/util/TestUtil.java
@@ -38,6 +38,9 @@ import org.apache.commons.io.IOUtils;
 @SuppressWarnings({"nls", "javadoc"})
 public class TestUtil {
 
+    private TestUtil() {
+    }
+
     /**
      * Loads a test plan from a classpath resource.
      * @param resourcePath


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “ Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.