### PR TITLE
Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/ApiRequestExecutorImpl.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/ApiRequestExecutorImpl.java
@@ -466,7 +466,7 @@ public class ApiRequestExecutorImpl implements IApiRequestExecutor {
                     if (totalCounter.size() == numPolicies) {
                         // Did we get any errors?  If yes, report the first one. If no, then send back
                         // the fully resolved list of policies.
-                        if (errorCounter.size() > 0) {
+                        if (!errorCounter.isEmpty()) {
                             int errorIdx = errorCounter.iterator().next();
                             Throwable error = errors.get(errorIdx);
                             // TODO add some logging here to indicate which policy error'd out

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/HttpConnector.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/HttpConnector.java
@@ -287,7 +287,7 @@ class HttpConnector implements IApiConnectionResponse, IApiConnection {
     }
 
     private String queryParams(QueryMap queryParams) {
-        if (queryParams == null || queryParams.size() == 0)
+        if (queryParams == null || queryParams.isEmpty())
             return "";
 
         StringBuilder sb = new StringBuilder(queryParams.size() * 2 * 10);

--- a/manager/api/es/src/main/java/io/apiman/manager/api/es/EsStorage.java
+++ b/manager/api/es/src/main/java/io/apiman/manager/api/es/EsStorage.java
@@ -1271,7 +1271,7 @@ public class EsStorage implements IStorage, IStorageQuery {
             ApiEntryBean bean = EsMarshalling.unmarshallApiEntry(hit.source);
             ApiVersionBean svb = getApiVersion(bean.getApiOrgId(), bean.getApiId(), bean.getApiVersion());
             Set<ApiGatewayBean> gateways = svb.getGateways();
-            if (gateways != null && gateways.size() > 0) {
+            if (gateways != null && !gateways.isEmpty()) {
                 ApiGatewayBean sgb = gateways.iterator().next();
                 bean.setGatewayId(sgb.getGatewayId());
             }
@@ -1754,7 +1754,7 @@ public class EsStorage implements IStorage, IStorageQuery {
             SearchSourceBuilder builder = new SearchSourceBuilder().query(qb).size(500);
             List<Hit<Map<String,Object>,Void>> hits = listEntities("roleMembership", builder); //$NON-NLS-1$
             Set<PermissionBean> rval = new HashSet<>(hits.size());
-            if (hits.size() > 0) {
+            if (!hits.isEmpty()) {
                 for (Hit<Map<String,Object>,Void> hit : hits) {
                     Map<String, Object> source = hit.source;
                     String roleId = String.valueOf(source.get("roleId")); //$NON-NLS-1$
@@ -2401,7 +2401,7 @@ public class EsStorage implements IStorage, IStorageQuery {
                 }
                 this.nextHitIdx = 0;
             }
-            return hits.size() > 0;
+            return !hits.isEmpty();
         }
 
         /**

--- a/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/JpaStorage.java
+++ b/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/JpaStorage.java
@@ -584,7 +584,7 @@ public class JpaStorage extends AbstractJpaStorage implements IStorage, IStorage
             query.setParameter(1, groupId);
             query.setParameter(2, artifactId);
             List<Object[]> rows = query.getResultList();
-            if (rows.size() > 0) {
+            if (!rows.isEmpty()) {
                 Object[] row = rows.get(0);
                 PluginBean plugin = new PluginBean();
                 plugin.setId(((Number) row[0]).longValue());
@@ -1423,7 +1423,7 @@ public class JpaStorage extends AbstractJpaStorage implements IStorage, IStorage
                 entry.setApiKey(contractBean.getApikey());
 
                 Set<ApiGatewayBean> gateways = svb.getGateways();
-                if (gateways != null && gateways.size() > 0) {
+                if (gateways != null && !gateways.isEmpty()) {
                     ApiGatewayBean sgb = gateways.iterator().next();
                     entry.setGatewayId(sgb.getGatewayId());
                 }

--- a/manager/test/api/src/main/java/io/apiman/manager/test/junit/ManagerRestTester.java
+++ b/manager/test/api/src/main/java/io/apiman/manager/test/junit/ManagerRestTester.java
@@ -271,7 +271,7 @@ public class ManagerRestTester extends ParentRunner<TestInfo> {
                     String[] expectedPayloads = ((PublishPayloadTestInfo) testInfo).expectedPayloads;
                     int index = 0;
                     for (String expectedPayload : expectedPayloads) {
-                        if (MockGatewayServlet.getPayloads().size() == 0) {
+                        if (MockGatewayServlet.getPayloads().isEmpty()) {
                             Assert.fail("Expected a payload but did not find one.");
                         }
                         String actualPayload = MockGatewayServlet.getPayloads().get(index);

--- a/manager/test/api/src/test/java/io/apiman/manager/test/es/ESMetricsAccessorTest.java
+++ b/manager/test/api/src/test/java/io/apiman/manager/test/es/ESMetricsAccessorTest.java
@@ -135,7 +135,7 @@ public class ESMetricsAccessorTest {
         UsageHistogramBean usage = metrics.getUsage("JBossOverlord", "s-ramp-api", "1.0", HistogramIntervalType.day,
                 parseDate("2015-01-01"), new DateTime().withZone(DateTimeZone.UTC));
         List<UsageDataPoint> data = usage.getData();
-        Assert.assertTrue(data.size() > 0);
+        Assert.assertTrue(!data.isEmpty());
         Assert.assertTrue(data.size() > 1);
         Assert.assertEquals("2015-06-19T00:00:00.000Z", usage.getData().get(169).getLabel());
         Assert.assertEquals(46L, usage.getData().get(169).getCount());
@@ -353,7 +353,7 @@ public class ESMetricsAccessorTest {
         ResponseStatsHistogramBean stats = metrics.getResponseStats("JBossOverlord", "s-ramp-api", "1.0", HistogramIntervalType.day,
                 parseDate("2015-06-01"), new DateTime().withZone(DateTimeZone.UTC));
         List<ResponseStatsDataPoint> data = stats.getData();
-        Assert.assertTrue(data.size() > 0);
+        Assert.assertTrue(!data.isEmpty());
         Assert.assertTrue(data.size() > 1);
         Assert.assertEquals("2015-06-19T00:00:00.000Z", stats.getData().get(18).getLabel());
         Assert.assertEquals(46L, stats.getData().get(18).getTotal());
@@ -364,7 +364,7 @@ public class ESMetricsAccessorTest {
         stats = metrics.getResponseStats("Test", "echo", "1.0", HistogramIntervalType.day,
                 parseDate("2015-06-01"), new DateTime().withZone(DateTimeZone.UTC));
         data = stats.getData();
-        Assert.assertTrue(data.size() > 0);
+        Assert.assertTrue(!data.isEmpty());
         Assert.assertTrue(data.size() > 1);
         Assert.assertEquals("2015-06-16T00:00:00.000Z", stats.getData().get(15).getLabel());
         Assert.assertEquals(214L, stats.getData().get(15).getTotal());
@@ -449,7 +449,7 @@ public class ESMetricsAccessorTest {
         ResponseStatsPerPlanBean stats = metrics.getResponseStatsPerPlan("JBossOverlord", "s-ramp-api", "1.0",
                 parseDate("2015-06-01"), new DateTime().withZone(DateTimeZone.UTC));
         Map<String, ResponseStatsDataPoint> data = stats.getData();
-        Assert.assertTrue(data.size() > 0);
+        Assert.assertTrue(!data.isEmpty());
         ResponseStatsDataPoint point = data.get("Gold");
         Assert.assertNotNull(point);
         Assert.assertEquals(12L, point.getTotal());
@@ -470,7 +470,7 @@ public class ESMetricsAccessorTest {
         stats = metrics.getResponseStatsPerPlan("Test", "echo", "1.0",
                 parseDate("2015-06-01"), new DateTime().withZone(DateTimeZone.UTC));
         data = stats.getData();
-        Assert.assertTrue(data.size() > 0);
+        Assert.assertTrue(!data.isEmpty());
         point = data.get("Gold");
         Assert.assertNotNull(point);
         Assert.assertEquals(67L, point.getTotal());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
Ayman Abdelghany.