### PR TITLE
Nice toString for CaseInsensitiveStringMultiMap

### DIFF
--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/util/CaseInsensitiveStringMultiMap.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/util/CaseInsensitiveStringMultiMap.java
@@ -212,4 +212,17 @@ public class CaseInsensitiveStringMultiMap implements IStringMultiMap {
         elemMap.clear();
         return this;
     }
+
+    @Override
+    public String toString() {
+        String elems = keySet().stream()
+                .map(key -> getAllEntries(key))
+                .map(pairs -> pairs.get(0).getKey() + " => [" + joinValues(pairs) + "]")
+                .collect(Collectors.joining(", "));
+        return "{" + elems + "}";
+    }
+
+    private String joinValues(List<Entry<String, String>> pairs) {
+        return pairs.stream().map(Entry::getValue).collect(Collectors.joining(", "));
+    }
 }


### PR DESCRIPTION
Looks like this:

```
new CaseInsensitiveMultiMap().add("a", "x").add("b", "y").add("c", "foo")
                             .add("c",` "BAR").add("C", "baz");

#toString
{a => [x], b => [y], c => [foo, BAR, baz]}
```