### PR TITLE
re #998 Fix for `npm install`

### DIFF
--- a/manager/ui/war/README.md
+++ b/manager/ui/war/README.md
@@ -26,3 +26,10 @@ To build and run the app:
 `gulp`
 
 The above script will also monitor for changes, and will rebuild the app accordingly. To see exactly which files are monitored, check the `watch` task in the Gulpfile, located in `/apiman/manager/ui/war/gulpfile.js`.
+
+
+#### Contributing
+
+We gladly accept PRs and always appreciate it when community members want to contribute. We use JIRA to track issues [here](https://issues.jboss.org/projects/APIMAN).
+
+If you'll be adding a new package to `package.json`, please note that we use a shrinkwrap file located at `./npm-shrinkwrap.json`. Add the package name and version to `package.json` using the exact version (i.e. `1.2.3` instead of `~1.2.3` or `^1.2.3`). You'll then need to rewrite the shrinkwrap file with `$ npm shrinkwrap` and commit the changes for **both** files. 

--- a/manager/ui/war/npm-shrinkwrap.json
+++ b/manager/ui/war/npm-shrinkwrap.json
@@ -37,6 +37,11 @@
       "from": "angular-mocks@1.4.7",
       "resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.4.7.tgz"
     },
+    "angular-moment": {
+      "version": "1.0.0-beta.4",
+      "from": "angular-moment@>=1.0.0-beta.4 <2.0.0",
+      "resolved": "http://registry.npmjs.org/angular-moment/-/angular-moment-1.0.0-beta.4.tgz"
+    },
     "angular-resource": {
       "version": "1.3.0",
       "from": "angular-resource@1.3.0",
@@ -73,9 +78,9 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
     },
     "ansi-styles": {
-      "version": "2.1.0",
+      "version": "2.2.0",
       "from": "ansi-styles@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+      "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz"
     },
     "ansicolors": {
       "version": "0.2.1",
@@ -143,9 +148,9 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
     },
     "asn1.js": {
-      "version": "4.4.0",
+      "version": "4.5.0",
       "from": "asn1.js@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.4.0.tgz"
+      "resolved": "http://registry.npmjs.org/asn1.js/-/asn1.js-4.5.0.tgz"
     },
     "assert": {
       "version": "1.3.0",
@@ -223,9 +228,9 @@
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
     },
     "big-integer": {
-      "version": "1.6.11",
+      "version": "1.6.12",
       "from": "big-integer@>=1.6.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.11.tgz"
+      "resolved": "http://registry.npmjs.org/big-integer/-/big-integer-1.6.12.tgz"
     },
     "binary-extensions": {
       "version": "1.4.0",
@@ -270,9 +275,9 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
     },
     "brace-expansion": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "from": "brace-expansion@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz"
+      "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz"
     },
     "braces": {
       "version": "1.8.3",
@@ -481,6 +486,11 @@
       "from": "clone-stats@>=0.0.1 <0.0.2",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
     },
+    "color-convert": {
+      "version": "1.0.0",
+      "from": "color-convert@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+    },
     "colors": {
       "version": "1.0.3",
       "from": "colors@1.0.3",
@@ -626,7 +636,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "from": "core-util-is@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+      "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "create-ecdh": {
       "version": "4.0.0",
@@ -676,9 +686,16 @@
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.6.tgz"
     },
     "dashdash": {
-      "version": "1.12.2",
+      "version": "1.13.0",
       "from": "dashdash@>=1.10.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz"
+      "resolved": "http://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
     },
     "date-now": {
       "version": "0.1.4",
@@ -886,9 +903,9 @@
       "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.0.1.tgz"
     },
     "escape-string-regexp": {
-      "version": "1.0.4",
+      "version": "1.0.5",
       "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
     },
     "esprima-fb": {
       "version": "12001.1.0-dev-harmony-fb",
@@ -1713,9 +1730,9 @@
       }
     },
     "function-bind": {
-      "version": "1.0.2",
+      "version": "1.1.0",
       "from": "function-bind@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.0.2.tgz"
+      "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
     },
     "gaze": {
       "version": "0.5.2",
@@ -2253,6 +2270,11 @@
             }
           }
         },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "from": "json-stable-stringify@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+        },
         "object-assign": {
           "version": "4.0.1",
           "from": "object-assign@>=4.0.0 <5.0.0",
@@ -2274,9 +2296,9 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         },
         "unique-stream": {
-          "version": "2.2.0",
+          "version": "2.2.1",
           "from": "unique-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.0.tgz"
+          "resolved": "http://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz"
         },
         "vinyl-fs": {
           "version": "2.1.1",
@@ -2404,9 +2426,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "dependencies": {
         "sshpk": {
-          "version": "1.7.3",
+          "version": "1.7.4",
           "from": "sshpk@>=1.7.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz"
+          "resolved": "http://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz"
         }
       }
     },
@@ -2447,7 +2469,8 @@
     },
     "inherits": {
       "version": "2.0.1",
-      "from": "inherits@>=2.0.1 <2.1.0"
+      "from": "inherits@>=2.0.1 <2.1.0",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
     },
     "ini": {
       "version": "1.3.4",
@@ -2542,9 +2565,9 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
     },
     "is-my-json-valid": {
-      "version": "2.12.4",
+      "version": "2.13.0",
       "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz"
+      "resolved": "http://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.0.tgz"
     },
     "is-npm": {
       "version": "1.0.0",
@@ -2652,9 +2675,9 @@
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.0.tgz"
     },
     "js-yaml": {
-      "version": "3.5.2",
+      "version": "3.5.3",
       "from": "js-yaml@>=3.1.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.2.tgz",
+      "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-3.5.3.tgz",
       "dependencies": {
         "esprima": {
           "version": "2.7.2",
@@ -2900,9 +2923,9 @@
       }
     },
     "lodash._root": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "from": "lodash._root@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.0.tgz"
+      "resolved": "http://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
     },
     "lodash._shimkeys": {
       "version": "2.4.1",
@@ -2910,14 +2933,14 @@
       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
     },
     "lodash.assign": {
-      "version": "4.0.2",
+      "version": "4.0.3",
       "from": "lodash.assign@*",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.3.tgz",
       "dependencies": {
         "lodash.keys": {
-          "version": "4.0.2",
+          "version": "4.0.3",
           "from": "lodash.keys@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.2.tgz"
+          "resolved": "http://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.3.tgz"
         }
       }
     },
@@ -2944,9 +2967,9 @@
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
     },
     "lodash.isarguments": {
-      "version": "3.0.6",
+      "version": "3.0.7",
       "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.6.tgz"
+      "resolved": "http://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
     },
     "lodash.isarray": {
       "version": "3.0.4",
@@ -3001,9 +3024,9 @@
       }
     },
     "loud-rejection": {
-      "version": "1.2.1",
+      "version": "1.3.0",
       "from": "loud-rejection@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.1.tgz"
+      "resolved": "http://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz"
     },
     "lowercase-keys": {
       "version": "1.0.0",
@@ -3085,14 +3108,14 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
     },
     "mime-db": {
-      "version": "1.21.0",
-      "from": "mime-db@>=1.21.0 <1.22.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+      "version": "1.22.0",
+      "from": "mime-db@>=1.22.0 <1.23.0",
+      "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
     },
     "mime-types": {
-      "version": "2.1.9",
+      "version": "2.1.10",
       "from": "mime-types@>=2.1.7 <2.2.0",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
+      "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
     },
     "minichain": {
       "version": "0.0.1",
@@ -3167,7 +3190,7 @@
     },
     "moment": {
       "version": "2.11.2",
-      "from": "moment@>=2.0.0 <3.0.0",
+      "from": "moment@>=2.11.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
     },
     "morgan": {
@@ -3493,9 +3516,9 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
     },
     "pretty-hrtime": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "from": "pretty-hrtime@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz"
+      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.2.tgz"
     },
     "process": {
       "version": "0.11.2",
@@ -3684,9 +3707,9 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
       "dependencies": {
         "bl": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "from": "bl@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.2.tgz"
+          "resolved": "http://registry.npmjs.org/bl/-/bl-1.0.3.tgz"
         },
         "extend": {
           "version": "3.0.0",
@@ -3748,14 +3771,14 @@
       "resolved": "https://registry.npmjs.org/rework-visit/-/rework-visit-1.0.0.tgz"
     },
     "rimraf": {
-      "version": "2.5.1",
+      "version": "2.5.2",
       "from": "rimraf@>=2.2.8 <3.0.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
       "dependencies": {
         "glob": {
-          "version": "6.0.4",
-          "from": "glob@>=6.0.1 <7.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
+          "version": "7.0.0",
+          "from": "glob@>=7.0.0 <8.0.0",
+          "resolved": "http://registry.npmjs.org/glob/-/glob-7.0.0.tgz"
         }
       }
     },
@@ -4017,9 +4040,9 @@
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
     },
     "strip-ansi": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "from": "strip-ansi@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
     },
     "strip-bom": {
       "version": "2.0.0",
@@ -4290,9 +4313,9 @@
       "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.0.18.tgz"
     },
     "tweetnacl": {
-      "version": "0.13.3",
+      "version": "0.14.0",
       "from": "tweetnacl@>=0.13.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+      "resolved": "http://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.0.tgz"
     },
     "type-detect": {
       "version": "0.1.2",

--- a/manager/ui/war/package.json
+++ b/manager/ui/war/package.json
@@ -26,7 +26,7 @@
     "angular-animate": "1.4.7",
     "angular-clipboard": "1.1.1",
     "angular-mocks": "1.4.7",
-    "angular-moment": "^1.0.0-beta.4",
+    "angular-moment": "1.0.0-beta.4",
     "angular-resource": "1.3.0",
     "angular-route": "1.4.7",
     "angular-sanitize": "1.4.7",


### PR DESCRIPTION
Changes:
- Update `package.json` to include exact version of `angular-moment`
- Update `README.md` to include brief text about `npm-shrinkwrap.json`
- Rewrite `npm-shrinkwrap.json` to include changes

Was able to replicate the issue on both a clean and existing clone, using both the `http` and `https` NPM registries, on and off the VPN, with different versions of Node and NPM.

Tested this fix on both clean and existing clones. See example <a href="https://gist.github.com/kahboom/5b552f07c88667309e4b">here</a>.

JIRA: https://issues.jboss.org/browse/APIMAN-998

cc @EricWittmann 