### PR TITLE
Profile out further modules

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -14,6 +14,19 @@
     <module>api</module>
     <module>engine</module>
     <module>platforms</module>
-    <module>test</module>
   </modules>
+
+  <profiles>
+    <profile>
+      <id>distros</id>
+      <activation>
+        <property>
+          <name>!skipDistros</name>
+        </property>
+      </activation>
+      <modules>
+        <module>test</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -11,6 +11,18 @@
   <modules>
     <module>common</module>
     <module>policies</module>
-    <module>suite</module>
   </modules>
+  <profiles>
+    <profile>
+      <id>distros</id>
+      <activation>
+        <property>
+          <name>!skipDistros</name>
+        </property>
+      </activation>
+      <modules>
+        <module>suite</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
This is a continuation of SHA 53c1310ab81337e8658f37ac7bed180ea9661d0a.

Building as a non-snapshot version reveals that these modules are dependent on the distros.