### PR TITLE
re #996 Delete APIs in UI

### DIFF
--- a/manager/ui/war/plugins/api-manager/html/api/api_entity.include
+++ b/manager/ui/war/plugins/api-manager/html/api/api_entity.include
@@ -17,11 +17,36 @@
                   </ul>
                 </div>
                 <a apiman-permission="apiEdit" href="{{ pluginName }}/orgs/{{ org.id }}/apis/{{ api.id}}/{{ version.version }}/new-version" class="btn btn-primary apiman-entity-action" apiman-i18n-key="new-version">New Version</a>
+
+                <!-- Dropdown Cog -->
+                <ul class="api-menu pull-right"
+                    style="list-style-type: none; padding-left: 10px; padding-top: 6px;">
+                  <li class="dropdown">
+                    <a href="#"
+                       style="text-decoration: none;"
+                       class="dropdown-toggle dropdown-cog"
+                       data-toggle="dropdown">
+                      <span class="fa fa-cog"></span>
+                      <b class="caret"></b>
+                    </a>
+                    <ul class="dropdown-menu">
+                      <li>
+                        <a class="api-delete"
+                           href="#"
+                           ng-click="callDelete()"
+                           apiman-i18n-key="delete">Delete API</a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
               </div>
+
+
             </div>
             <hr />
           </div>
         </div>
+
         <div class="row apiman-entity-metadata">
           <div class="col-md-7" style="margin-bottom: 8px">
             <!-- Api Summary -->
@@ -54,6 +79,7 @@
                 <a apiman-i18n-key="ttdo-new-api-version" data-field="ttd_toNewApiVersion" href="{{ pluginName }}/orgs/{{ org.id }}/apis/{{ api.id}}/{{ version.version }}/new-version">Create a new version of this API (New Version)</a>
               </div>
             </div>
+
             <!-- The Publish Action -->
             <div class="apiman-divider-40"></div>
             <div class="">
@@ -128,6 +154,47 @@
           <div class="optional"
                style="margin: -5px 0 10px 15px;">
             * optional
+          </div>
+        </script>
+
+        <!-- Delete API Modal Template -->
+        <script type="text/ng-template"
+                id="deleteModal.html">
+          <div class="modal-header">
+            <button class="close"
+                    type="button"
+                    ng-click="no()">
+              <span class="pficon pficon-close"></span>
+            </button>
+            <h3 class="modal-title">
+              <span apiman-i18n-key="delete-api-modal-title">Are you SURE you want to delete this API?</span>
+            </h3>
+          </div>
+          <div class="modal-body">
+            <p class="bg-warning"
+               style="padding: 15px 25px; margin: -18px -25px 10px -25px;"
+               apiman-i18n-key="api-delete-modal-confirmation-warning">
+              Unexpected bad things will happen if you don't read this!
+            </p>
+            <p class="explanation"
+               apiman-i18n-key="api-delete-modal-confirmation-description">
+              This action <b>CANNOT</b> be undone. This will permanently delete the API, including all of its versions and their contracts.
+            </p>
+            <p class="explanation"
+               apiman-i18n-key="api-delete-modal-confirmation-instructions">
+              Please type in the name of the API to confirm.
+            </p>
+            <input type="text"
+                   class="apiman-form-control form-control"
+                   ng-keyup="typed()"
+                   ng-model="confirmApiName">
+          </div>
+          <div class="modal-footer">
+            <button class="btn btn-danger"
+                    type="button"
+                    apiman-i18n-key="api-delete-modal-confirmation-button"
+                    ng-disabled="!okayToDelete"
+                    ng-click="yes()">I understand the consequences, delete this API</button>
           </div>
         </script>
       </div>

--- a/manager/ui/war/plugins/api-manager/html/client/client-apis.html
+++ b/manager/ui/war/plugins/api-manager/html/client/client-apis.html
@@ -67,7 +67,7 @@
                                 <div class="modal-header">
                                   <button class="close"
                                           type="button"
-                                          ng-click="cancel()">
+                                          ng-click="ok()">
                                     <span class="pficon pficon-close"></span>
                                   </button>
                                   <h3 class="modal-title"

--- a/manager/ui/war/plugins/api-manager/ts/rpc.ts
+++ b/manager/ui/war/plugins/api-manager/ts/rpc.ts
@@ -122,6 +122,28 @@ module ApimanRPC {
             }
         }]);
 
+    export var ApiSvcs = _module.factory('ApiSvcs', [
+        '$resource',
+        '$http',
+        'Configuration', function($resource,
+                                  $http,
+                                  Configuration) {
+            return {
+                deleteApi: function(data) {
+                    var endpoint = Configuration.api.endpoint + '/organizations/' + data.orgId + '/apis/' + data.apiId;
+
+                    return $http({
+                        method: 'DELETE',
+                        url: endpoint,
+                        data: {
+                            organizationId: data.orgId,
+                            apiId: data.apiId
+                        }
+                    });
+                }
+            }
+        }]);
+
     export var ApiDefinitionSvcs = _module.factory('ApiDefinitionSvcs', ['$resource', '$http', 'Configuration',
         function($resource, $http, Configuration) {
             return {


### PR DESCRIPTION
Changes:
- Add modal template and button to delete API (let me know if you don't like the cog dropdown option. I personally like it but we can go the traditional button route, I just didn't want to clutter the UI or "encourage" the user to delete).
- Add request to API to delete API
- Add comparison check for user input vs name of API after forcing both as lowercase, for user convenience
- Quick fix for How to Invoke API modal close button not working (JIRA: https://issues.jboss.org/browse/APIMAN-1001)
- Minor styling (mostly inline for now, will be improved later)

Also, in the future we need to implement a check that determines whether to show/hide the delete button at all in the UI. For now, the user will know because they will get an error when they try to delete an "undeletable" API.

Screenshots:

<img width="626" alt="screen shot 2016-03-02 at 11 52 34 am" src="https://cloud.githubusercontent.com/assets/3844502/13468141/57b7e3c6-e06f-11e5-85cb-6ae23ddb4a30.png">

<img width="1192" alt="screen shot 2016-03-02 at 12 02 46 pm" src="https://cloud.githubusercontent.com/assets/3844502/13468145/5d9cf916-e06f-11e5-8f98-514867093cd7.png">

<img width="1211" alt="screen shot 2016-03-02 at 12 02 55 pm" src="https://cloud.githubusercontent.com/assets/3844502/13468151/6200f46c-e06f-11e5-9229-d8e3abfb7170.png">


JIRA: https://issues.jboss.org/browse/APIMAN-996

cc @EricWittmann @msavy 