### PR TITLE
re #824 Accept secretKey in new implementation of IDataEncrypter

### DIFF
--- a/common/util/src/main/java/io/apiman/common/util/AesEncrypter.java
+++ b/common/util/src/main/java/io/apiman/common/util/AesEncrypter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2016 JBoss Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,17 +30,11 @@ import org.apache.commons.codec.binary.Base64;
  * A simple AES encrypter.
  *
  * @author eric.wittmann@redhat.com
+ * @author Rachel Yordán <ryordan@redhat.com>
  */
 public class AesEncrypter {
 
     private static final String secretKey = "f2f0aa80-84bd8a6"; //$NON-NLS-1$
-
-    private static SecretKeySpec skeySpec;
-
-    static {
-        byte[] ivraw = secretKey.getBytes();
-        skeySpec = new SecretKeySpec(ivraw, "AES"); //$NON-NLS-1$
-    }
 
     private AesEncrypter() {
     }
@@ -51,12 +45,26 @@ public class AesEncrypter {
      * @return the string
      */
     public static String encrypt(String plainText) {
+        return encrypt(secretKey, plainText);
+    }
+    
+    
+    /**
+     * Encrypt.
+     * @param plainText the plain text
+     * @param secretKey the secret key
+     * @return the string
+     */
+    public static String encrypt(String secretKey, String plainText) {
         if (plainText == null) {
             return null;
         }
         byte[] encrypted;
         Cipher cipher;
         try {
+            byte[] ivraw = secretKey.getBytes();
+            SecretKeySpec skeySpec = new SecretKeySpec(ivraw, "AES"); //$NON-NLS-1$
+            
             cipher = Cipher.getInstance("AES"); //$NON-NLS-1$
             cipher.init(Cipher.ENCRYPT_MODE, skeySpec);
         } catch (NoSuchAlgorithmException e) {
@@ -75,6 +83,7 @@ public class AesEncrypter {
         }
         return "$CRYPT::" + new String(Base64.encodeBase64(encrypted)); //$NON-NLS-1$
     }
+    
 
     /**
      * Decrypt.
@@ -82,6 +91,17 @@ public class AesEncrypter {
      * @return the string
      */
     public static final String decrypt(String encryptedText) {
+        return decrypt(secretKey, encryptedText);
+    }
+    
+    
+    /**
+     * Decrypt.
+     * @param encryptedText the encrypted text
+     * @param secretKey the secret key
+     * @return the string
+     */
+    public static final String decrypt(String secretKey, String encryptedText) {
         if (encryptedText == null) {
             return null;
         }
@@ -89,6 +109,9 @@ public class AesEncrypter {
             byte[] decoded = Base64.decodeBase64(encryptedText.substring(8));
             Cipher cipher;
             try {
+                byte[] ivraw = secretKey.getBytes();
+                SecretKeySpec skeySpec = new SecretKeySpec(ivraw, "AES"); //$NON-NLS-1$
+                
                 cipher = Cipher.getInstance("AES"); //$NON-NLS-1$
                 cipher.init(Cipher.DECRYPT_MODE, skeySpec);
             } catch (NoSuchAlgorithmException e) {
@@ -110,6 +133,7 @@ public class AesEncrypter {
             return encryptedText;
         }
     }
+    
 
     /**
      * Main entry point for the encrypter.  Allows encryption and decryption of text

--- a/common/util/src/main/java/io/apiman/common/util/crypt/AesDataEncrypter.java
+++ b/common/util/src/main/java/io/apiman/common/util/crypt/AesDataEncrypter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.common.util.crypt;
+
+import io.apiman.common.util.AesEncrypter;
+
+import java.util.Map;
+
+/**
+ * A default data encrypter for the gateway.
+ *
+ * @author eric.wittmann@redhat.com
+ * @author Rachel Yordán <ryordan@redhat.com>
+ */
+public class AesDataEncrypter implements IDataEncrypter {
+    
+    private String secretKey;
+
+    /**
+     * Constructor.
+     */
+    public AesDataEncrypter(Map<String, String> config) {
+        secretKey = config.get("secretKey");
+        
+        if (secretKey == null) {
+            throw new RuntimeException("Missing configuration property: apiman-manager.config.secretKey");
+        }
+    }
+    
+    /* (non-Javadoc)
+     * @see io.apiman.common.util.crypt.IDataEncrypter#encrypt(java.lang.String)
+     */
+    @Override
+    public String encrypt(String plainText) {
+        return AesEncrypter.encrypt(secretKey, plainText);
+    }
+
+    /* (non-Javadoc)
+     * @see io.apiman.common.util.crypt.IDataEncrypter#decrypt(java.lang.String)
+     */
+    @Override
+    public String decrypt(String encryptedText) {
+        return AesEncrypter.decrypt(secretKey, encryptedText);
+    }
+}

--- a/distro/wildfly9/src/main/resources/overlay/standalone/configuration/apiman.properties
+++ b/distro/wildfly9/src/main/resources/overlay/standalone/configuration/apiman.properties
@@ -6,6 +6,10 @@ apiman-manager.plugins.registries=http://rawgit.com/apiman/apiman-plugin-registr
 # Apiman Manager logging. standard, json or a FQDN implementing IApimanLogger
 apiman-manager.config.logger=standard
 
+# Apiman Manager secret key for data encryption
+#apiman.encrypter.type=io.apiman.common.util.crypt.AesDataEncrypter
+#apiman.encrypter.type.secretKey=
+
 # ---------------------------------------------------------------------
 # The following are settings for using elasticsearch for various
 # apiman components.

--- a/gateway/engine/core/src/test/java/io/apiman/gateway/engine/impl/AesDataEncrypterTest.java
+++ b/gateway/engine/core/src/test/java/io/apiman/gateway/engine/impl/AesDataEncrypterTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.apiman.common.util.crypt.AesDataEncrypter;
+import io.apiman.common.util.crypt.IDataEncrypter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ *
+ * @author Rachel Yordán <ryordan@redhat.com>
+ */
+@SuppressWarnings({ "nls" })
+public class AesDataEncrypterTest {
+    
+    @Test
+    public void dataEncrypterWithKey() {
+        Map<String, String> config = new HashMap();
+        config.put("secretKey", "a2a0aa80-84Zd2a6");
+        IDataEncrypter dataEncrypter = new AesDataEncrypter(config);
+        
+        String result = dataEncrypter.encrypt("Hello, world.");
+        assertNotNull(result);
+        assertEquals("$CRYPT::XtwdsXC3Tv6vlQXQQPrxdg==", result);
+        
+        result = dataEncrypter.decrypt(result);
+        assertEquals("Hello, world.", result);
+    }
+    
+    @Test
+    public void dataEncrypterWithDifferentKey() {
+        Map<String, String> config = new HashMap();
+        config.put("secretKey", "H2a9a780-m4Zd2a0");
+        IDataEncrypter dataEncrypter = new AesDataEncrypter(config);
+        
+        String result = dataEncrypter.encrypt("Hello, world.");
+        assertNotNull(result);
+        
+        assertEquals("$CRYPT::dLklbimUARc6EfsrxpSG2Q==", result);
+        
+        result = dataEncrypter.decrypt(result);
+        assertEquals("Hello, world.", result);
+    }
+    
+    
+    @Test(expected = RuntimeException.class)
+    public void dataEncrypterWithoutKey() {
+        Map<String, String> config = new HashMap();
+        IDataEncrypter dataEncrypter = new AesDataEncrypter(config);
+        
+        dataEncrypter.encrypt("Hello, world.");
+    }
+    
+}


### PR DESCRIPTION
Changes (btw please tell me if I'm saying any of this incorrectly lol):
- Add implementation of `IDataEncrypter` interface, called `AesDataEncrypter`. Accepts a `config` Map, where it retrieves the `secretKey` from.
- Add new `encrypt` and `decrypt` methods to the `AesEncrypter` class that accept a `secretKey` string parameter.
- Add unit tests.
- Adding another bullet point to distract from the fact that it feels like I did so much more, but really only wrote a few lines of code.

Test screenshot because I have one, so why not:

<img width="1053" alt="screen shot 2016-03-16 at 10 42 57 am" src="https://cloud.githubusercontent.com/assets/3844502/13816221/e878522a-eb63-11e5-95bd-a8f53954af7e.png">


JIRA: https://issues.jboss.org/browse/APIMAN-824

cc @EricWittmann @msavy 