### PR TITLE
Normalises HTTP Basic scheme name to match that of RFC1945

### DIFF
--- a/common/servlet/src/main/java/io/apiman/common/servlet/AuthenticationFilter.java
+++ b/common/servlet/src/main/java/io/apiman/common/servlet/AuthenticationFilter.java
@@ -339,7 +339,7 @@ public class AuthenticationFilter implements Filter {
      * @throws IOException when an error cannot be sent
      */
     private void sendAuthResponse(HttpServletResponse response) throws IOException {
-        response.setHeader("WWW-Authenticate", String.format("BASIC realm=\"%1$s\"", realm)); //$NON-NLS-1$ //$NON-NLS-2$
+        response.setHeader("WWW-Authenticate", String.format("Basic realm=\"%1$s\"", realm)); //$NON-NLS-1$ //$NON-NLS-2$
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
     }
 

--- a/common/util/src/main/java/io/apiman/common/util/Basic.java
+++ b/common/util/src/main/java/io/apiman/common/util/Basic.java
@@ -26,7 +26,7 @@ public class Basic {
     public static String encode(String username, String password) {
         String up = username + ':' + password;
         StringBuilder builder = new StringBuilder();
-        builder.append("BASIC ");
+        builder.append("Basic ");
         builder.append(Base64.encodeBase64String(up.getBytes()));
         return builder.toString();
     }

--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/BasicAuthenticationPolicy.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/BasicAuthenticationPolicy.java
@@ -184,7 +184,7 @@ public class BasicAuthenticationPolicy extends AbstractMappedPolicy<BasicAuthent
         if (realm == null || realm.trim().isEmpty()) {
             realm = "Apiman"; //$NON-NLS-1$
         }
-        failure.getHeaders().put("WWW-Authenticate", String.format("BASIC realm=\"%1$s\"", realm)); //$NON-NLS-1$ //$NON-NLS-2$
+        failure.getHeaders().put("WWW-Authenticate", String.format("Basic realm=\"%1$s\"", realm)); //$NON-NLS-1$ //$NON-NLS-2$
         chain.doFailure(failure);
     }
 

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpApiConnection.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpApiConnection.java
@@ -161,7 +161,7 @@ public class HttpApiConnection implements IApiConnection, IApiConnectionResponse
 
                     String up = options.getUsername() + ':' + options.getPassword();
                     StringBuilder builder = new StringBuilder();
-                    builder.append("BASIC "); //$NON-NLS-1$
+                    builder.append("Basic "); //$NON-NLS-1$
                     builder.append(Base64.encodeBase64String(up.getBytes()));
                     connection.setRequestProperty("Authorization", builder.toString()); //$NON-NLS-1$
                     suppressedHeaders.add("Authorization"); //$NON-NLS-1$

--- a/gateway/test/src/test/resources/test-plan-data/policies/basic-auth-static/004-failure.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/basic-auth-static/004-failure.resttest
@@ -6,7 +6,7 @@ X-API-Key: 12345
 Content-Type: application/json
 X-Policy-Failure-Type: Authentication
 X-Policy-Failure-Code: 10003
-WWW-Authenticate: BASIC realm="Test"
+WWW-Authenticate: Basic realm="Test"
 
 {
     "type" : "Authentication",

--- a/gateway/test/src/test/resources/test-plan-data/policies/basic-auth-static/005-failure.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/basic-auth-static/005-failure.resttest
@@ -6,7 +6,7 @@ X-API-Key: 12345
 Content-Type: application/json
 X-Policy-Failure-Type: Authentication
 X-Policy-Failure-Code: 10004
-WWW-Authenticate: BASIC realm="Test"
+WWW-Authenticate: Basic realm="Test"
 
 {
     "type" : "Authentication",

--- a/test/policies/src/main/java/io/apiman/test/policies/PolicyTestRequest.java
+++ b/test/policies/src/main/java/io/apiman/test/policies/PolicyTestRequest.java
@@ -62,7 +62,7 @@ public class PolicyTestRequest {
     }
 
     public PolicyTestRequest basicAuth(String username, String password) {
-        return header("Authorization", "BASIC " + Base64.encodeBase64String( (username + ':' + password).getBytes() )); //$NON-NLS-1$ //$NON-NLS-2$
+        return header("Authorization", "Basic " + Base64.encodeBase64String( (username + ':' + password).getBytes() )); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     public PolicyTestRequest body(String body) {


### PR DESCRIPTION
This PR normalises the HTTP Basic scheme name to match that of RFC1945.

See: http://tools.ietf.org/html/rfc1945#section-11.1

This fixes an issue with strict back-end services rejecting 'BASIC' (the current value) instead of 'Basic'.