### PR TITLE
re #1025 Fix for dropdown not working

### DIFF
--- a/manager/ui/war/plugins/api-manager/html/catalog/api-catalog.html
+++ b/manager/ui/war/plugins/api-manager/html/catalog/api-catalog.html
@@ -51,7 +51,7 @@
               <ui-select multiple
               			 id="apiman-tags-filter"
                          tagging
-                         tagging-label="false"
+                         tagging-label="(press enter)"
                          ng-model="selected.tags"
                          theme="bootstrap"
                          sortable="true"


### PR DESCRIPTION
Re-added the tagging label to `(press enter)`, since setting it to `false` was causing issues. Will create a GH issue in the ui-select repo to report this bug (after testing it on a few Plunkrs to make sure it's not just an issue with some other interaction).

<img width="1186" alt="screen shot 2016-03-21 at 12 20 38 pm" src="https://cloud.githubusercontent.com/assets/3844502/13925751/ec40c81a-ef5f-11e5-8a82-fdf440d4c1ad.png">

cc @EricWittmann 