### PR TITLE
re #1025 Adjust styling again, fixes for hidden filters

### DIFF
--- a/manager/ui/war/plugins/api-manager/css/apiman.css
+++ b/manager/ui/war/plugins/api-manager/css/apiman.css
@@ -40,6 +40,10 @@ a.ui-select-match-close:hover {
   background-position: right -11px;
 }
 
+.api-type {
+  margin-top: -1px;
+}
+
 #apis-filter-b, #apis-filter-f, .api-namespaces button, .api-type button {
   height: 28px;
 }

--- a/manager/ui/war/plugins/api-manager/css/apiman.css
+++ b/manager/ui/war/plugins/api-manager/css/apiman.css
@@ -40,11 +40,7 @@ a.ui-select-match-close:hover {
   background-position: right -11px;
 }
 
-#apis-filter-b, #apis-filter-f {
-  height: 28px;
-}
-
-.api-type > button {
+#apis-filter-b, #apis-filter-f, .api-namespaces button, .api-type button {
   height: 28px;
 }
 

--- a/manager/ui/war/plugins/api-manager/html/catalog/api-catalog.html
+++ b/manager/ui/war/plugins/api-manager/html/catalog/api-catalog.html
@@ -73,7 +73,6 @@
               <select ng-model="epType"
                       apiman-select-picker=""
                       class="selectpicker api-type"
-                      style="height: 28px;"
                       data-style="btn-default">
                 <option value="" apiman-i18n-key="show-all-api-types">Show All API Types</option>
                 <option value="rest" apiman-i18n-key="show-only-rest">Show REST only</option>
@@ -81,8 +80,7 @@
               </select>
 
               <!-- Filter: Internal APIs -->
-              <span ng-show="hasInternalApis"
-                    style="margin-left: 8px; height: 28px;">
+              <span style="margin-left: 8px; height: 28px;">
                 <input id="hide-internal" type="checkbox" ng-model="hideInternal"></input>
                 <label for="hide-internal"
                        apiman-i18n-key="hide-internal-apis"
@@ -90,8 +88,7 @@
               </span>
 
               <!-- Filter: Namespace -->
-              <select ng-show="namespaces.length > 0"
-                      class="selectpicker api-namespaces"
+              <select class="selectpicker api-namespaces"
                       id="namespace"
                       apiman-select-picker=""
                       ng-model="namespace"

--- a/manager/ui/war/plugins/api-manager/html/catalog/api-catalog.html
+++ b/manager/ui/war/plugins/api-manager/html/catalog/api-catalog.html
@@ -38,7 +38,7 @@
             <!-- Filter and Actions -->
             <div class="row"
                  id="api-catalog-filters"
-                 style="display: flex;">
+                 style="display: inline;">
               <!-- Filter: Search -->
               <span>
                 <apiman-search-box id="apis-filter"
@@ -57,7 +57,7 @@
                          theme="bootstrap"
                          sortable="true"
                          class="selectpicker api-catalog-filters"
-                         style="width: 250px; margin: 0 10px; box-shadow: none; font-size: small; border-color: #bababa;"
+                         style="width: 250px; margin: 0 10px; box-shadow: none; font-size: small; border-color: #bababa; display: inline-table;"
                          title="Choose a tag">
                 <ui-select-match placeholder="Filter by tags...">{{$item}}</ui-select-match>
                 <ui-select-choices repeat="tag in tags | filter:$select.search | orderBy: tag"
@@ -66,7 +66,7 @@
                 </ui-select-choices>
               </ui-select>
               <button ng-show="selected.tags.length > 0" class="btn btn-default btn-xs"
-                      style="box-shadow: none; margin-left: -11px; border-left: none; margin-right: 10px"
+                      style="box-shadow: none; height: 28px; margin: -1px 10px 0 -14px; border-left: none;"
                       ng-click="clear()"><i class="fa fa-fw fa-close"></i></button>
 
               <!-- Filter: API Type -->
@@ -80,7 +80,8 @@
               </select>
 
               <!-- Filter: Internal APIs -->
-              <span style="margin-left: 8px; height: 28px;">
+              <span ng-show="hasInternalApis"
+                    style="margin-left: 8px; height: 28px;">
                 <input id="hide-internal" type="checkbox" ng-model="hideInternal"></input>
                 <label for="hide-internal"
                        apiman-i18n-key="hide-internal-apis"
@@ -88,13 +89,13 @@
               </span>
 
               <!-- Filter: Namespace -->
-              <select class="selectpicker api-namespaces"
+              <select ng-show="namespaces.length > 0"
+                      class="selectpicker api-namespaces"
                       id="namespace"
                       apiman-select-picker=""
                       ng-model="namespace"
                       ng-change="selectNamespace( namespace )"
                       title=""
-                      style="height: 28px;"
                       data-live-search="true"
                       apiman-i18n-skip
                       data-ng-options="ns.name for ns in namespaces | orderBy: ns.name">


### PR DESCRIPTION
Fixed styling issue where hidden filters were not displaying properly, adjusted height of all input fields.

Screenshots:

<img width="1194" alt="screen shot 2016-03-21 at 3 50 57 pm" src="https://cloud.githubusercontent.com/assets/3844502/13932248/8f22019e-ef7d-11e5-9673-b79f0ec21dd1.png">

<img width="1193" alt="screen shot 2016-03-21 at 3 54 39 pm" src="https://cloud.githubusercontent.com/assets/3844502/13932252/92716eca-ef7d-11e5-81fc-a8bedc910a05.png">

Vertical alignment of text:

<img width="1037" alt="screen shot 2016-03-21 at 3 46 56 pm" src="https://cloud.githubusercontent.com/assets/3844502/13932264/9c794834-ef7d-11e5-8a42-c67cffa82225.png">

cc @EricWittmann 