### PR TITLE
re #802 Fix for Chrome inline editor buttons

### DIFF
--- a/manager/ui/war/plugins/api-manager/css/apiman.css
+++ b/manager/ui/war/plugins/api-manager/css/apiman.css
@@ -1228,6 +1228,10 @@ div.admin-page .admin-content .apiman-summaryrow .emphasis {
   border-radius: 0 3px 3px 0;
 }
 
+.editable-options {
+  -webkit-margin-before: -4px;
+}
+
 div.editable-click { 
   color: black;
   border-bottom: hidden;

--- a/manager/ui/war/plugins/api-manager/ts/directives.ts
+++ b/manager/ui/war/plugins/api-manager/ts/directives.ts
@@ -585,7 +585,7 @@ module Apiman {
       // overwrite templates
       editableThemes['default'].submitTpl = '<button class="btn btn-default inline-save-btn" type="submit"><i class="fa fa-check fa-fw"></i></button>';
       editableThemes['default'].cancelTpl = '<button class="btn btn-default" type="button" ng-click="$form.$cancel()"><i class="fa fa-times fa-fw"></i></button>';
-      editableThemes['default'].buttonsTpl = '<div></div>';
+      editableThemes['default'].buttonsTpl = '<div class="editable-options"></div>';
       editableThemes['default'].formTpl = '<form class="editable-wrap apiman-inline-edit"></form>';
     }]);
 


### PR DESCRIPTION
Fixed the issue where inline editor buttons had a gap between them and the editor textarea, only in Chrome.

Tested on Chrome, FF, and Safari.

Screenshot:
<img width="1235" alt="screen shot 2016-03-22 at 2 37 33 pm" src="https://cloud.githubusercontent.com/assets/3844502/13963453/c906ba26-f03b-11e5-9470-7f444492a605.png">


JIRA: https://issues.jboss.org/browse/APIMAN-802

cc @EricWittmann 