### PR TITLE
(Bug) Fix ES query accidentally left with hard-coded dev values

### DIFF
--- a/manager/api/es/src/main/java/io/apiman/manager/api/es/EsStorage.java
+++ b/manager/api/es/src/main/java/io/apiman/manager/api/es/EsStorage.java
@@ -839,6 +839,9 @@ public class EsStorage implements IStorage, IStorageQuery {
     @Override
     @SuppressWarnings("nls")
     public void deletePlan(PlanBean plan) throws StorageException {
+        String planId = plan.getId().replace('"', '_');
+        String orgId = plan.getOrganization().getId().replace('"', '_');
+
         String query = "{\n" +
                 "  \"query\": {\n" +
                 "    \"filtered\": {\n" +
@@ -851,17 +854,17 @@ public class EsStorage implements IStorage, IStorageQuery {
                 "            \"and\": [\n" +
                 "              {\n" +
                 "                \"term\": {\n" +
-                "                  \"entityId\": \"testplan\"\n" +
+                "                  \"entityId\": \"" + planId + "\"\n" +
                 "                }\n" +
                 "              },\n" +
                 "              {\n" +
                 "                \"term\": {\n" +
-                "                  \"entityType\": \"Plan\"\n" +
+                "                  \"entityType\": \"" + AuditEntityType.Plan.name() + "\"\n" +
                 "                }\n" +
                 "              },\n" +
                 "              {\n" +
                 "                \"term\": {\n" +
-                "                  \"organizationId\": \"test\"\n" +
+                "                  \"organizationId\": \"" + orgId + "\"\n" +
                 "                }\n" +
                 "              }\n" +
                 "            ]\n" +
@@ -870,12 +873,12 @@ public class EsStorage implements IStorage, IStorageQuery {
                 "            \"and\": [\n" +
                 "              {\n" +
                 "                \"term\": {\n" +
-                "                  \"planId\": \"testplan\"\n" +
+                "                  \"planId\": \"" + planId + "\"\n" +
                 "                }\n" +
                 "              },\n" +
                 "              {\n" +
                 "                \"term\": {\n" +
-                "                  \"organizationId\": \"test\"\n" +
+                "                  \"organizationId\": \"" + orgId + "\"\n" +
                 "                }\n" +
                 "              }\n" +
                 "            ]\n" +

--- a/manager/test/api/src/test/resources/test-plan-data/plans/delete/005_activity.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/plans/delete/005_activity.resttest
@@ -1,0 +1,9 @@
+GET /organizations/Organization1/plans/Plan2/activity admin/admin
+----
+200
+Content-Type: application/json
+
+{
+  "beans" : [],
+  "totalSize" : 0
+}

--- a/manager/test/api/src/test/resources/test-plan-data/plans/delete/006_version-activity.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/plans/delete/006_version-activity.resttest
@@ -1,0 +1,9 @@
+GET /organizations/Organization1/plans/Plan2/versions/1.0/activity admin/admin
+----
+200
+Content-Type: application/json
+
+{
+  "beans" : [],
+  "totalSize" : 0
+}

--- a/manager/test/api/src/test/resources/test-plans/plans-testPlan.xml
+++ b/manager/test/api/src/test/resources/test-plans/plans-testPlan.xml
@@ -67,6 +67,8 @@
     <test name="Delete Plan 2">test-plan-data/plans/delete/003_delete-plan2.resttest</test>
     <test name="Wait" delay="1000" />
     <test name="Get Plan 2 (not found)">test-plan-data/plans/delete/004_get-plan2-not-found.resttest</test>
+    <test name="Get Plan 2 activity (empty) ">test-plan-data/plans/delete/005_activity.resttest</test>
+    <test name="Get Plan 2 version activity (empty)">test-plan-data/plans/delete/006_version-activity.resttest</test>
   </testGroup>
 
 </testPlan>


### PR DESCRIPTION
Whoops. How embarrassing. Somehow I ended up using the development query in my PR. 

I've added some extra tests, as I obviously wasn't covering this properly before (but coincidentally it seemed to be working).