### PR TITLE
[APIMAN-1109] (Bug) Add workaround for MySQL shortfalls by using Native SQL. 

### DIFF
--- a/manager/api/jpa/pom.xml
+++ b/manager/api/jpa/pom.xml
@@ -54,6 +54,10 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/AbstractJpaStorage.java
+++ b/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/AbstractJpaStorage.java
@@ -56,6 +56,10 @@ public abstract class AbstractJpaStorage {
     @Inject
     private IEntityManagerFactoryAccessor emfAccessor;
 
+    public String getDialect() {
+        return (String) emfAccessor.getEntityManagerFactory().getProperties().get("hibernate.dialect");
+    }
+
     private static ThreadLocal<EntityManager> activeEM = new ThreadLocal<>();
     public static boolean isTxActive() {
         return activeEM.get() != null;

--- a/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/JpaStorage.java
+++ b/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/JpaStorage.java
@@ -2415,50 +2415,59 @@ public class JpaStorage extends AbstractJpaStorage implements IStorage, IStorage
     }
 
     private void deleteAllContracts(ApiBean apiBean) throws StorageException {
-        String jpql = "DELETE ContractBean deleteBean "
-                + "WHERE deleteBean IN ( "
-                + "SELECT b "
-                + "  FROM ContractBean b "
-                + "  JOIN b.api apiVersion "
-                + "  JOIN apiVersion.api api "
-                + "  JOIN api.organization o "
-                + " WHERE o.id = :orgId "
-                + " AND api.id = :apiId ) ";
+        String nativeSql =
+            "DELETE c " +
+            "    FROM contracts c " +
+            "    INNER JOIN api_versions " +
+            "        ON c.apiv_id = api_versions.id " +
+            "    INNER JOIN apis " +
+            "        ON api_versions.api_id = apis.id " +
+            "        AND api_versions.api_org_id = apis.organization_id " +
+            "    INNER JOIN organizations " +
+            "        ON apis.organization_id = organizations.id " +
+            "WHERE organizations.id = :orgId " +
+            "AND apis.id = :apiId ;";
 
-        Query query = getActiveEntityManager().createQuery(jpql);
+        Query query = getActiveEntityManager().createNativeQuery(nativeSql);
         query.setParameter("orgId", apiBean.getOrganization().getId());
         query.setParameter("apiId", apiBean.getId());
         query.executeUpdate();
     }
 
     private void deleteAllContracts(ClientBean clientBean) throws StorageException {
-        String jpql = "DELETE ContractBean deleteBean "
-                + "WHERE deleteBean IN ( "
-                + "SELECT b "
-                + "  FROM ContractBean b "
-                + "  JOIN b.client clientVersion "
-                + "  JOIN clientVersion.client client "
-                + "  JOIN client.organization o "
-                + " WHERE o.id = :orgId "
-                + " AND client.id = :clientId ) ";
+        String nativeSql =
+            "DELETE c " +
+            "    FROM contracts c " +
+            "    INNER JOIN client_versions " +
+            "        ON c.clientv_id = client_versions.id " +
+            "    INNER JOIN clients " +
+            "        ON client_versions.client_id = clients.id " +
+            "        AND client_versions.client_org_id = clients.organization_id " +
+            "    INNER JOIN organizations " +
+            "        ON clients.organization_id = organizations.id " +
+            "WHERE organizations.id = :orgId " +
+            "AND clients.id = :clientId ;";
 
-        Query query = getActiveEntityManager().createQuery(jpql);
+        Query query = getActiveEntityManager().createNativeQuery(nativeSql);
         query.setParameter("orgId", clientBean.getOrganization().getId());
         query.setParameter("clientId", clientBean.getId());
         query.executeUpdate();
     }
 
     private void deleteAllContracts(OrganizationBean organizationBean) throws StorageException {
-        String jpql = "DELETE ContractBean deleteBean "
-                + "WHERE deleteBean IN ( "
-                + "SELECT b "
-                + "  FROM ContractBean b "
-                + "  JOIN b.api apiVersion "
-                + "  JOIN apiVersion.api api "
-                + "  JOIN api.organization o "
-                + " WHERE o.id = :orgId ) ";
-
-        Query query = getActiveEntityManager().createQuery(jpql);
+        String nativeSql =
+            "DELETE c " +
+            "    FROM contracts c " +
+            "    INNER JOIN api_versions " +
+            "        ON c.apiv_id = api_versions.id " +
+            "    INNER JOIN apis " +
+            "        ON api_versions.api_id = apis.id " +
+            "        AND api_versions.api_org_id = apis.organization_id " +
+            "    INNER JOIN organizations " +
+            "        ON apis.organization_id = organizations.id " +
+            "WHERE organizations.id = :orgId ;";
+        
+        Query query = getActiveEntityManager().createNativeQuery(nativeSql);
         query.setParameter("orgId", organizationBean.getId());
         query.executeUpdate();
     }

--- a/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/JpaStorage.java
+++ b/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/JpaStorage.java
@@ -93,6 +93,7 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -2415,61 +2416,115 @@ public class JpaStorage extends AbstractJpaStorage implements IStorage, IStorage
     }
 
     private void deleteAllContracts(ApiBean apiBean) throws StorageException {
-        String nativeSql =
-            "DELETE c " +
-            "    FROM contracts c " +
-            "    INNER JOIN api_versions " +
-            "        ON c.apiv_id = api_versions.id " +
-            "    INNER JOIN apis " +
-            "        ON api_versions.api_id = apis.id " +
-            "        AND api_versions.api_org_id = apis.organization_id " +
-            "    INNER JOIN organizations " +
-            "        ON apis.organization_id = organizations.id " +
-            "WHERE organizations.id = :orgId " +
-            "AND apis.id = :apiId ;";
+        Query query;
 
-        Query query = getActiveEntityManager().createNativeQuery(nativeSql);
+        if (isMySql()) {
+            String sql =
+                "DELETE c " +
+                "    FROM contracts c " +
+                "    JOIN api_versions " +
+                "        ON c.apiv_id = api_versions.id " +
+                "    JOIN apis " +
+                "        ON api_versions.api_id = apis.id " +
+                "        AND api_versions.api_org_id = apis.organization_id " +
+                "    JOIN organizations " +
+                "        ON apis.organization_id = organizations.id " +
+                "WHERE organizations.id = :orgId " +
+                "AND apis.id = :apiId ;";
+            query = getActiveEntityManager().createNativeQuery(sql);
+        } else {
+            String jpql =
+                "DELETE ContractBean deleteBean " +
+                "   WHERE deleteBean IN ( " +
+                "       SELECT b " +
+                "           FROM ContractBean b " +
+                "           JOIN b.api apiVersion " +
+                "           JOIN apiVersion.api api " +
+                "           JOIN api.organization o " +
+                "       WHERE o.id = :orgId " +
+                "       AND api.id = :apiId " +
+                "   )";
+            query = getActiveEntityManager().createQuery(jpql);
+        }
+
         query.setParameter("orgId", apiBean.getOrganization().getId());
         query.setParameter("apiId", apiBean.getId());
         query.executeUpdate();
     }
 
     private void deleteAllContracts(ClientBean clientBean) throws StorageException {
-        String nativeSql =
-            "DELETE c " +
-            "    FROM contracts c " +
-            "    INNER JOIN client_versions " +
-            "        ON c.clientv_id = client_versions.id " +
-            "    INNER JOIN clients " +
-            "        ON client_versions.client_id = clients.id " +
-            "        AND client_versions.client_org_id = clients.organization_id " +
-            "    INNER JOIN organizations " +
-            "        ON clients.organization_id = organizations.id " +
-            "WHERE organizations.id = :orgId " +
-            "AND clients.id = :clientId ;";
+        Query query;
 
-        Query query = getActiveEntityManager().createNativeQuery(nativeSql);
+        if (isMySql()) {
+            String sql =
+                "DELETE c " +
+                "    FROM contracts c " +
+                "    JOIN client_versions " +
+                "        ON c.clientv_id = client_versions.id " +
+                "    JOIN clients " +
+                "        ON client_versions.client_id = clients.id " +
+                "        AND client_versions.client_org_id = clients.organization_id " +
+                "    JOIN organizations " +
+                "        ON clients.organization_id = organizations.id " +
+                "WHERE organizations.id = :orgId " +
+                "AND clients.id = :clientId ;";
+            query = getActiveEntityManager().createNativeQuery(sql);
+        } else {
+            String jpql =
+                "DELETE ContractBean deleteBean " +
+                "   WHERE deleteBean IN ( " +
+                "       SELECT b " +
+                "           FROM ContractBean b " +
+                "           JOIN b.client clientVersion " +
+                "           JOIN clientVersion.client client " +
+                "           JOIN client.organization o " +
+                "       WHERE o.id = :orgId " +
+                "       AND client.id = :clientId " +
+                "   )";
+            query = getActiveEntityManager().createQuery(jpql);
+        }
+
         query.setParameter("orgId", clientBean.getOrganization().getId());
         query.setParameter("clientId", clientBean.getId());
         query.executeUpdate();
     }
 
     private void deleteAllContracts(OrganizationBean organizationBean) throws StorageException {
-        String nativeSql =
-            "DELETE c " +
-            "    FROM contracts c " +
-            "    INNER JOIN api_versions " +
-            "        ON c.apiv_id = api_versions.id " +
-            "    INNER JOIN apis " +
-            "        ON api_versions.api_id = apis.id " +
-            "        AND api_versions.api_org_id = apis.organization_id " +
-            "    INNER JOIN organizations " +
-            "        ON apis.organization_id = organizations.id " +
-            "WHERE organizations.id = :orgId ;";
-        
-        Query query = getActiveEntityManager().createNativeQuery(nativeSql);
+        Query query;
+
+        if (isMySql()) {
+            String sql =
+                "DELETE c " +
+                "    FROM contracts c " +
+                "    JOIN api_versions " +
+                "        ON c.apiv_id = api_versions.id " +
+                "    JOIN apis " +
+                "        ON api_versions.api_id = apis.id " +
+                "        AND api_versions.api_org_id = apis.organization_id " +
+                "    JOIN organizations " +
+                "        ON apis.organization_id = organizations.id " +
+                "WHERE organizations.id = :orgId ;";
+            query = getActiveEntityManager().createNativeQuery(sql);
+        } else {
+            String jpql =
+                "DELETE ContractBean deleteBean " +
+                "   WHERE deleteBean IN ( " +
+                "       SELECT b " +
+                "           FROM ContractBean b " +
+                "           JOIN b.api apiVersion " +
+                "           JOIN apiVersion.api api " +
+                "           JOIN api.organization o " +
+                "       WHERE o.id = :orgId " +
+                "   )";
+            query = getActiveEntityManager().createQuery(jpql);
+        }
+
         query.setParameter("orgId", organizationBean.getId());
         query.executeUpdate();
+    }
+
+    private boolean isMySql() throws StorageException {
+        return StringUtils.containsIgnoreCase(getDialect(), "mysql");
     }
 
     private <T> void remove(T entity) throws StorageException {


### PR DESCRIPTION
Unfortunately it doesn't seem possible to do these delete queries in any reasonable way with just JQPL that also works around MySQL's inability to execute correlated subqueries.

Hibernate seems unable to cope with rewriting the correlated subquery for MySQL (some of the other JPA impls are possibly able to do it, so this solution only targets hibernate).

Hence, this solution uses 2 different paths. One for MySQL and another for all other DBs (which seem to support correlated subqueries with no issue).