### PR TITLE
Adds Tomcat logging provider.

### DIFF
--- a/distro/tomcat8/pom.xml
+++ b/distro/tomcat8/pom.xml
@@ -50,6 +50,12 @@
       <artifactId>apiman-distro-es</artifactId>
       <type>war</type>
     </dependency>
+
+    <!-- tomcat default logging provider for slf4j -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -896,6 +896,11 @@
         <version>${version.org.slf4j}</version>
       </dependency>
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-jdk14</artifactId>
+        <version>${version.org.slf4j}</version>
+      </dependency>
+      <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-core</artifactId>
         <version>${version.org.infinispan}</version>


### PR DESCRIPTION
# Background

At the moment, the gateway logs in Tomcat don't work, as there's no SLF4J `StaticLoggerBinder` on the classpath. Tomcat uses JUL as its default logging provider.

# This PR

Adds the SLF4J-JUL bridge dependency, enabling SLF4J loggers to work, and removing the logging system error on startup (http://www.slf4j.org/codes.html#StaticLoggerBinder).