### PR TITLE
re #1135 #1108 Fix for bug with saving API gateway in UI

### DIFF
--- a/manager/ui/war/plugins/api-manager/html/api/api-impl.html
+++ b/manager/ui/war/plugins/api-manager/html/api/api-impl.html
@@ -46,7 +46,7 @@
                      name="endpoint"
                      class="apiman-form-control form-control"
                      type="text"
-                     ng-disabled="isEntityDisabled()"></input>
+                     ng-disabled="isEntityDisabled()">
             </div>
             <div style="color: #ff0000" ng-show="invalidEndpoint === true">
               <p apiman-i18n-key="invalid-endpiont-msg">Please enter a valid endpoint that begins with http:// or https://.</p>

--- a/manager/ui/war/plugins/api-manager/ts/api/api-impl.ts
+++ b/manager/ui/war/plugins/api-manager/ts/api/api-impl.ts
@@ -135,9 +135,11 @@ module Apiman {
                     if (newValue.endpoint != $scope.version.endpoint) {
                         dirty = true;
                     }
+
                     if (newValue.endpointType != $scope.version.endpointType) {
                         dirty = true;
                     }
+
                     if (newValue.endpointContentType != $scope.version.endpointContentType) {
                         dirty = true;
                     }
@@ -145,12 +147,14 @@ module Apiman {
                     if (newValue.gateways && newValue.gateways.length > 0) {
                         dirty = true;
                     }
+
                     if ($scope.version.endpointProperties && newValue.endpointProperties) {
                         if (!angular.equals($scope.version.endpointProperties, newValue.endpointProperties)) {
                             Logger.debug('Dirty due to EP:');
                             Logger.debug('    $scope.version:    {0}', $scope.version);
                             Logger.debug('    $scope.version.EP: {0}', $scope.version.endpointProperties);
                             Logger.debug('    newValue.EP:       {0}', newValue.endpointProperties);
+
                             dirty = true;
                         }
                     }
@@ -170,7 +174,7 @@ module Apiman {
 
 
             // Used, as you'd guess, to compare originally selected values to new values
-            function arraysAreEqual(one,two) {
+            function arraysAreEqual(one, two) {
                 return (one.join('') == two.join(''));
             }
 
@@ -186,8 +190,8 @@ module Apiman {
 
                     // Will need to compare newly selected gateways to available gateways again
                     // by plucking gatewayId values, inserting into an array, and comparing them
-                    var pluckedAfter = _.pluck(newSelectedArray, 'gatewayId');
-                    var pluckedBefore = _.pluck($scope.version.gateways, 'gatewayId');
+                    var pluckedAfter = _.map(newSelectedArray, 'gatewayId');
+                    var pluckedBefore = _.map($scope.version.gateways, 'gatewayId');
 
                     var compare = arraysAreEqual(pluckedAfter, pluckedBefore);
 


### PR DESCRIPTION
**Issue(s):**

**JIRA 1**: https://issues.jboss.org/browse/APIMAN-1135
**JIRA 2**: https://issues.jboss.org/browse/APIMAN-1108

There were two bugs occurring:

1. Regardless of whether you have a single gateway or multiple, the save button in the Implementation tab is disabled unless the endpoint field is dirtied. This is a bug because it should not be checking if the field is dirty, rather that there is a valid value there at all. For instance, if you were to add an endpoint, save it, and then add the gateway _after_, the save button would still be disabled unless you dirtied the endpoint field.
2. Assuming you _did_ dirty the endpoint field, the save button would become enabled, but upon pressing the save button, the gateway information is not retained or persisted. You will still see the error message in the Implementation tab if you had no gateways selected before, and in either case you'd still see that you have not selected a gateway in the 'Why Can't I Publish?' checklist.

--

**Changes:**
- Lodash's `pluck` method was deprecated, switched to use `map` instead.
- Minor changes such as semantics and spacing of HTML.

cc @EricWittmann @msavy 


--

**Notes:**

Currently, users are allowed to create the API, define the endpoint, etc. without having a gateway configured. They can go back, add the gateway, and continue configuring the API before publishing it. They can also "trick" the application so that if they unselect all gateways (if they have multiple) and then make the endpoint field "dirty", the save button will become enabled. So, if you were to press save and go back, it will just have the dropdown selection as 'Nothing selected'. They can then select whatever gateway they want. Spoke with @EricWittmann and this should be fine for now, but we can reevaluate this behavior at a later time. This is shown in the screenshots below.



--

**Screenshots:**

_Screencast:_ https://drive.google.com/open?id=0B9yOpcUD9qIaelhiaWFpMGNtOEU

The screenshots are not as illustrative as the screencast, so I'd recommend watching that instead.

_User deselects both gateways configured, presses save, navigates away and then comes back to the Implementations tab:_
<img width="862" alt="screen shot 2016-04-29 at 3 38 11 pm" src="https://cloud.githubusercontent.com/assets/3844502/14927669/3d98d02e-0e21-11e6-9116-0cb7438638d0.png">

_Showing that we have more than one gateway, and that selecting one now enables the save button without having to "dirty" the endpoint field:_
<img width="859" alt="screen shot 2016-04-29 at 3 38 26 pm" src="https://cloud.githubusercontent.com/assets/3844502/14927687/56880ca8-0e21-11e6-95d6-e77cd0b7f074.png">

_We have now saved one of our configured gateways, and this value is retained when navigating between tabs:_
<img width="866" alt="screen shot 2016-04-29 at 3 38 34 pm" src="https://cloud.githubusercontent.com/assets/3844502/14927781/ea45f428-0e21-11e6-8c1d-4d3113af37e6.png">