### PR TITLE
fix(gateway-engine-beans) CaseInsensitiveStringMultiMap put didn't handle hash collisions properly.

### DIFF
--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/util/CaseInsensitiveStringMultiMap.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/util/CaseInsensitiveStringMultiMap.java
@@ -79,10 +79,13 @@ public class CaseInsensitiveStringMultiMap implements IStringMultiMap, Serializa
     public IStringMultiMap put(String key, String value) {
         long keyHash = getHash(key);
         int idx = getIndex(keyHash);
-        if (hashArray[idx] == null)
+        if (hashArray[idx] == null) {
             keyCount++;
-
-        hashArray[idx] = new Element(key, value, keyHash);
+            hashArray[idx] = new Element(key, value, keyHash);
+        } else {
+            remove(key);
+            add(key, value);
+        }
         return this;
     }
 


### PR DESCRIPTION
This fixes APIMAN-1142 - but it's actually completely coincidental. It's lucky that I was the one who implemented that map, so it occurred to me that it could be where the issue lay.