### PR TITLE
APIMAN-1102 - Modify the Time Restricted Access Policy config format

### DIFF
--- a/gateway/engine/policies/pom.xml
+++ b/gateway/engine/policies/pom.xml
@@ -44,6 +44,10 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>

--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/TimeRestrictedAccessPolicy.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/TimeRestrictedAccessPolicy.java
@@ -32,6 +32,8 @@ import java.util.List;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.LocalTime;
+import org.joda.time.format.DateTimeFormat;
 
 /**
  * Policy that restrict access to resource by time when resource can be accessed.
@@ -96,7 +98,7 @@ public class TimeRestrictedAccessPolicy extends AbstractMappedPolicy<TimeRestric
             for (TimeRestrictedAccess rule : rulesEnabledForPath) {
                 boolean matchesDay = matchesDay(currentTime, rule);
                 if (matchesDay) {
-                    boolean matchesTime = matchesTime(currentTime, rule);
+                    boolean matchesTime = matchesTime(rule);
                     if (matchesTime) {
                         return true;
                     }
@@ -130,7 +132,7 @@ public class TimeRestrictedAccessPolicy extends AbstractMappedPolicy<TimeRestric
      * @param currentTime
      * @param filter
      */
-    private boolean matchesTime(DateTime currentTime, TimeRestrictedAccess filter) {
+    private boolean matchesTime(TimeRestrictedAccess filter) {
         Date start = filter.getTimeStart();
         Date end = filter.getTimeEnd();
         if (end == null || start == null) {
@@ -138,6 +140,7 @@ public class TimeRestrictedAccessPolicy extends AbstractMappedPolicy<TimeRestric
         }
         long startMs = start.getTime();
         long endMs = end.getTime();
+        DateTime currentTime = new LocalTime(DateTimeZone.UTC).toDateTime(new DateTime(0l));
         long nowMs = currentTime.toDate().getTime();
         
         return nowMs >= startMs && nowMs < endMs;

--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/config/TimeRestrictedAccess.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/config/TimeRestrictedAccess.java
@@ -17,6 +17,8 @@ package io.apiman.gateway.engine.policies.config;
 
 import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 /**
  * Determines timeslot when service with specific path pattern can be called.
  * Extendible by adding additional cron type ranges like weeks,month years.
@@ -31,7 +33,12 @@ import java.util.Date;
  * @author wtr@redhat.com
  */
 public class TimeRestrictedAccess {
+    
+    private static final String TIME_PATTERN = "HH:mm:ss";
+    
+    @JsonFormat(shape=JsonFormat.Shape.STRING, pattern=TIME_PATTERN)
     private Date timeStart;
+    @JsonFormat(shape=JsonFormat.Shape.STRING, pattern=TIME_PATTERN)
     private Date timeEnd;
     private Integer dayStart;
     private Integer dayEnd;

--- a/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/TimeRestrictedAccessPolicyTest.java
+++ b/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/TimeRestrictedAccessPolicyTest.java
@@ -38,10 +38,12 @@ import io.apiman.gateway.engine.policies.config.TimeRestrictedAccess;
 import io.apiman.gateway.engine.policies.config.TimeRestrictedAccessConfig;
 import io.apiman.gateway.engine.policy.IPolicyChain;
 import io.apiman.gateway.engine.policy.IPolicyContext;
+import io.apiman.test.policies.TestingPolicy;
 
 /**
  * TimeRestrictedAccess rule tests
  */
+@TestingPolicy(BasicAuthenticationPolicy.class)
 @SuppressWarnings({ "nls" })
 public class TimeRestrictedAccessPolicyTest extends PolicyTestBase {
 
@@ -82,7 +84,12 @@ public class TimeRestrictedAccessPolicyTest extends PolicyTestBase {
         parsedConfig = policy.parseConfiguration(config);
         assertNotNull(parsedConfig.getRules());
         expectedConfiguration = configObj.getRules();
-        assertEquals(expectedConfiguration, parsedConfig.getRules());
+        List<TimeRestrictedAccess> rules = parsedConfig.getRules();
+        TimeRestrictedAccess expected = expectedConfiguration.get(0);
+        TimeRestrictedAccess actual = rules.get(0);
+        assertEquals(expected.getDayEnd(), actual.getDayEnd());
+        assertEquals(expected.getDayStart(), actual.getDayStart());
+        assertEquals(expected.getPathPattern(), actual.getPathPattern());
     }
 
     @Test
@@ -106,8 +113,8 @@ public class TimeRestrictedAccessPolicyTest extends PolicyTestBase {
         int dayOfWeek = new DateTime().getDayOfWeek();
         rule.setDayEnd(7);
         rule.setDayStart(dayOfWeek);
-        rule.setTimeEnd(new DateTime().plusHours(1).toDate());
-        rule.setTimeStart(new Date());
+        rule.setTimeEnd(new DateTime().plusHours(2).toDate());
+        rule.setTimeStart(new DateTime().minusHours(2).toDate());
         rule.setPathPattern("PathNotListed");
         configObj.setRules(elements);
         Object config = updateConfig(policy, configObj);

--- a/manager/ui/war/plugins/api-manager/ts/policies.ts
+++ b/manager/ui/war/plugins/api-manager/ts/policies.ts
@@ -683,6 +683,8 @@ module Apiman {
       _module.controller('Apiman.TimeRestrictedAccessFormController',
         ['$window','$scope', 'Logger', 'EntityStatusSvc',
         ($window, $scope, Logger, EntityStatusSvc) => {
+            var moment=$window.moment;
+            var isoTimeFormat="HH:mm:ss";
             var validate = function(config) {
               	var valid = config.rules && config.rules.length > 0;
                 $scope.setValid(valid);
@@ -698,9 +700,11 @@ module Apiman {
                 if (!$scope.config.rules) {
                     $scope.config.rules = [];
                 }
+                var timeStart = moment($scope.timeStart).utc().format(isoTimeFormat);
+                var timeEnd = moment($scope.timeEnd).utc().format(isoTimeFormat);
                 var rule = {
-                    'timeStart' : $window.moment($scope.timeStart).utc().toDate(),
-                    'timeEnd' :   $window.moment($scope.timeEnd).utc().toDate(),
+                    'timeStart' : timeStart,
+                    'timeEnd' : timeEnd,
                     'dayStart' : $scope.getDayIndex($scope.dayStart),
                     'dayEnd' : $scope.getDayIndex($scope.dayEnd),
                     'pathPattern' : $scope.pathPattern
@@ -729,7 +733,7 @@ module Apiman {
             };
             $scope.resetModel();
             $scope.formatToTime = function(time){
-                return new $window.moment(time).format("HH:mm");
+                return moment.utc(time,isoTimeFormat).local().format("HH:mm");
             };
             $scope.getDayIndex = function(day){
                return $scope.weekdays.indexOf(day)+1;


### PR DESCRIPTION
## Implementation details

Implementation supporting ISO 8601 format as api input (more human readable format):

Old format:
``"timeStart": "2016-04-12T12:00:00.000Z"``
New format:
``"timeStart": "12:00:00"``

Internal implementation still using Date object for flexibility. 
If we want to store data as strings some additional refactoring will be required.

## Note
No user interface changes - everything should be as it was :)
I tried to use new `TestingPolicy` annotation, but it wasn't flexible enough to use it for that particular example.
