### PR TITLE
APIMAN-951 Adds MS SQL Server support.

### DIFF
--- a/distro/data/src/main/resources/ddls/apiman-gateway_mssql11.ddl
+++ b/distro/data/src/main/resources/ddls/apiman-gateway_mssql11.ddl
@@ -1,5 +1,5 @@
 
-USE [apiman];
+USE [apiman_gateway];
 GO
 
 CREATE TABLE [gw_apis] ([org_id] VARCHAR(255) NOT NULL, [id] VARCHAR(255) NOT NULL, [version] VARCHAR(255) NOT NULL, [bean] TEXT NOT NULL);

--- a/distro/data/src/main/resources/ddls/apiman-gateway_mssql11.ddl
+++ b/distro/data/src/main/resources/ddls/apiman-gateway_mssql11.ddl
@@ -1,0 +1,42 @@
+
+USE [apiman];
+GO
+
+CREATE TABLE [gw_apis] ([org_id] VARCHAR(255) NOT NULL, [id] VARCHAR(255) NOT NULL, [version] VARCHAR(255) NOT NULL, [bean] TEXT NOT NULL);
+GO
+
+ALTER TABLE [gw_apis] ADD PRIMARY KEY ([org_id], [id], [version]);
+GO
+
+CREATE TABLE [gw_clients] ([api_key] VARCHAR(255) NOT NULL, [org_id] VARCHAR(255) NOT NULL, [id] VARCHAR(255) NOT NULL, [version] VARCHAR(255) NOT NULL, [bean] TEXT NOT NULL);
+GO
+
+ALTER TABLE [gw_clients] ADD PRIMARY KEY ([api_key]);
+GO
+
+ALTER TABLE [gw_clients] ADD CONSTRAINT [UK_gw_clients_1] UNIQUE ([org_id], [id], [version]);
+GO
+
+CREATE NONCLUSTERED INDEX [IDX_gw_clients_1] ON [gw_clients]([org_id], [id], [version]);
+GO
+
+CREATE TABLE [gw_dataversion] ([version] BIGINT NOT NULL);
+GO
+
+CREATE TABLE [gw_requests] (
+	[rstart] BIGINT NOT NULL, [rend] BIGINT NOT NULL, [duration] BIGINT NOT NULL, 
+	[month] BIGINT NOT NULL, [week] BIGINT NOT NULL, [day] BIGINT NOT NULL, [hour] BIGINT NOT NULL, [minute] BIGINT NOT NULL,
+	[api_org_id] VARCHAR(255) NOT NULL, [api_id] VARCHAR(255) NOT NULL, [api_version] VARCHAR(255) NOT NULL, 
+	[client_org_id] VARCHAR(255), [client_id] VARCHAR(255), [client_version] VARCHAR(255), [plan] VARCHAR(255),
+	[user_id] VARCHAR(255), [resp_type] VARCHAR(255), [bytes_up] BIGINT NOT NULL, [bytes_down] BIGINT NOT NULL
+);
+GO
+
+CREATE NONCLUSTERED INDEX [IDX_gw_requests_1] ON [gw_requests]([api_org_id], [api_id], [api_version]);
+GO
+
+CREATE NONCLUSTERED INDEX [IDX_gw_requests_2] ON [gw_requests]([client_org_id], [client_id], [client_version]);
+GO
+
+CREATE NONCLUSTERED INDEX [IDX_gw_requests_3] ON [gw_requests]([resp_type]);
+GO

--- a/distro/data/src/main/resources/ddls/apiman_mssql11.ddl
+++ b/distro/data/src/main/resources/ddls/apiman_mssql11.ddl
@@ -1,0 +1,502 @@
+-- *********************************************************************
+-- Update Database Script
+-- *********************************************************************
+-- Change Log: C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/master.xml
+-- Ran at: 09/05/16 00:52
+-- Against: apiman@offline:mssql?version=11.0&caseSensitive=true&catalog=apiman&changeLogFile=C:\Users\Pete\projects\apiman\distro\ddl/target/changelog/mssql/databasechangelog.csv
+-- Liquibase version: 3.4.1
+-- *********************************************************************
+
+USE [apiman];
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-1::apiman (generated)
+CREATE TABLE [client_versions] ([id] [bigint] NOT NULL, [created_by] [varchar](255) NOT NULL, [created_on] [datetime] NOT NULL, [modified_by] [varchar](255) NOT NULL, [modified_on] [datetime] NOT NULL, [published_on] [datetime] NULL, [retired_on] [datetime] NULL, [status] [varchar](255) NOT NULL, [version] [varchar](255) NOT NULL, [client_id] [varchar](255) NULL, [client_org_id] [varchar](255) NULL, [apikey] [varchar](255) NOT NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-2::apiman (generated)
+CREATE TABLE [clients] ([id] [varchar](255) NOT NULL, [created_by] [varchar](255) NOT NULL, [created_on] [datetime] NOT NULL, [description] [varchar](512) NULL, [name] [varchar](255) NOT NULL, [organization_id] [varchar](255) NOT NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-3::apiman (generated)
+CREATE TABLE [auditlog] ([id] [bigint] NOT NULL, [created_on] [datetime] NOT NULL, [data] [varchar](MAX) NULL, [entity_id] [varchar](255) NULL, [entity_type] [varchar](255) NOT NULL, [entity_version] [varchar](255) NULL, [organization_id] [varchar](255) NOT NULL, [what] [varchar](255) NOT NULL, [who] [varchar](255) NOT NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-4::apiman (generated)
+CREATE TABLE [contracts] ([id] [bigint] NOT NULL, [created_by] [varchar](255) NOT NULL, [created_on] [datetime] NOT NULL, [clientv_id] [bigint] NULL, [planv_id] [bigint] NULL, [apiv_id] [bigint] NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-5::apiman (generated)
+CREATE TABLE [endpoint_properties] ([api_version_id] [bigint] NOT NULL, [value] [varchar](255) NULL, [name] [varchar](255) NOT NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-6::apiman (generated)
+CREATE TABLE [gateways] ([id] [varchar](255) NOT NULL, [configuration] [varchar](MAX) NOT NULL, [created_by] [varchar](255) NOT NULL, [created_on] [datetime] NOT NULL, [description] [varchar](512) NULL, [modified_by] [varchar](255) NOT NULL, [modified_on] [datetime] NOT NULL, [name] [varchar](255) NOT NULL, [type] [varchar](255) NOT NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-7::apiman (generated)
+CREATE TABLE [memberships] ([id] [bigint] NOT NULL, [created_on] [datetime] NULL, [org_id] [varchar](255) NULL, [role_id] [varchar](255) NULL, [user_id] [varchar](255) NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-8::apiman (generated)
+CREATE TABLE [organizations] ([id] [varchar](255) NOT NULL, [created_by] [varchar](255) NOT NULL, [created_on] [datetime] NOT NULL, [description] [varchar](512) NULL, [modified_by] [varchar](255) NOT NULL, [modified_on] [datetime] NOT NULL, [name] [varchar](255) NOT NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-9::apiman (generated)
+CREATE TABLE [pd_templates] ([policydef_id] [varchar](255) NOT NULL, [language] [varchar](255) NULL, [template] [varchar](2048) NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-10::apiman (generated)
+CREATE TABLE [permissions] ([role_id] [varchar](255) NOT NULL, [permissions] [int] NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-11::apiman (generated)
+CREATE TABLE [plan_versions] ([id] [bigint] NOT NULL, [created_by] [varchar](255) NOT NULL, [created_on] [datetime] NOT NULL, [locked_on] [datetime] NULL, [modified_by] [varchar](255) NOT NULL, [modified_on] [datetime] NOT NULL, [status] [varchar](255) NOT NULL, [version] [varchar](255) NOT NULL, [plan_id] [varchar](255) NULL, [plan_org_id] [varchar](255) NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-12::apiman (generated)
+CREATE TABLE [plans] ([id] [varchar](255) NOT NULL, [created_by] [varchar](255) NOT NULL, [created_on] [datetime] NOT NULL, [description] [varchar](512) NULL, [name] [varchar](255) NOT NULL, [organization_id] [varchar](255) NOT NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-13::apiman (generated)
+CREATE TABLE [plugins] ([id] [bigint] NOT NULL, [artifact_id] [varchar](255) NOT NULL, [classifier] [varchar](255) NULL, [created_by] [varchar](255) NOT NULL, [created_on] [datetime] NOT NULL, [description] [varchar](512) NULL, [group_id] [varchar](255) NOT NULL, [name] [varchar](255) NOT NULL, [type] [varchar](255) NULL, [version] [varchar](255) NOT NULL, [deleted] [bit] NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-14::apiman (generated)
+CREATE TABLE [policies] ([id] [bigint] NOT NULL, [configuration] [varchar](MAX) NULL, [created_by] [varchar](255) NOT NULL, [created_on] [datetime] NOT NULL, [entity_id] [varchar](255) NOT NULL, [entity_version] [varchar](255) NOT NULL, [modified_by] [varchar](255) NOT NULL, [modified_on] [datetime] NOT NULL, [name] [varchar](255) NOT NULL, [order_index] [int] NOT NULL, [organization_id] [varchar](255) NOT NULL, [type] [varchar](255) NOT NULL, [definition_id] [varchar](255) NOT NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-15::apiman (generated)
+CREATE TABLE [policydefs] ([id] [varchar](255) NOT NULL, [description] [varchar](512) NOT NULL, [form] [varchar](255) NULL, [form_type] [varchar](255) NULL, [icon] [varchar](255) NOT NULL, [name] [varchar](255) NOT NULL, [plugin_id] [bigint] NULL, [policy_impl] [varchar](255) NOT NULL, [deleted] [bit] NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-16::apiman (generated)
+CREATE TABLE [roles] ([id] [varchar](255) NOT NULL, [auto_grant] [bit] NULL, [created_by] [varchar](255) NOT NULL, [created_on] [datetime] NOT NULL, [description] [varchar](512) NULL, [name] [varchar](255) NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-17::apiman (generated)
+CREATE TABLE [api_defs] ([id] [bigint] NOT NULL, [data] [varbinary](MAX) NULL, [api_version_id] [bigint] NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-18::apiman (generated)
+CREATE TABLE [api_versions] ([id] [bigint] NOT NULL, [created_by] [varchar](255) NOT NULL, [created_on] [datetime] NOT NULL, [definition_type] [varchar](255) NULL, [endpoint] [varchar](255) NULL, [endpoint_type] [varchar](255) NULL, [endpoint_ct] [varchar](255) NULL, [modified_by] [varchar](255) NOT NULL, [modified_on] [datetime] NOT NULL, [public_api] [bit] NOT NULL, [parse_payload] [bit] NULL, [published_on] [datetime] NULL, [retired_on] [datetime] NULL, [status] [varchar](255) NOT NULL, [version] [varchar](255) NULL, [api_id] [varchar](255) NULL, [api_org_id] [varchar](255) NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-19::apiman (generated)
+CREATE TABLE [apis] ([id] [varchar](255) NOT NULL, [created_by] [varchar](255) NOT NULL, [created_on] [datetime] NOT NULL, [description] [varchar](512) NULL, [name] [varchar](255) NOT NULL, [organization_id] [varchar](255) NOT NULL, [num_published] [int] NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-20::apiman (generated)
+CREATE TABLE [api_gateways] ([api_version_id] [bigint] NOT NULL, [gateway_id] [varchar](255) NOT NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-21::apiman (generated)
+CREATE TABLE [api_plans] ([api_version_id] [bigint] NOT NULL, [plan_id] [varchar](255) NOT NULL, [version] [varchar](255) NOT NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-22::apiman (generated)
+CREATE TABLE [users] ([username] [varchar](255) NOT NULL, [email] [varchar](255) NULL, [full_name] [varchar](255) NULL, [joined_on] [datetime] NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/010-apiman-manager-api.db.tables.changelog.xml::1436469846462-23::apiman (generated)
+CREATE TABLE [downloads] ([id] [varchar](255) NOT NULL, [type] [varchar](255) NULL, [path] [varchar](255) NULL, [expires] [datetime] NULL)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/050-apiman-manager-api.db.data.changelog.xml::1434686531709-1::apiman
+INSERT INTO [gateways] ([id], [configuration], [created_by], [created_on], [description], [modified_by], [modified_on], [name], [type]) VALUES ('TheGateway', '$CRYPT::PmrNC1m25oGSO8fC3XnxKSepmQsbxEZCldn+hYi9bQ10m8m4tEOHYU7gz5w2hcY2cMRPB3Rw+4FZYoeX0n3qEvyk+2Yf+ym3nKw3UtmtHViHLibBzWPY+8OTtJlZVb8dA8yd0TMkiwqk1WGHLSbyjmQujZ07RBK9wkwDahYwQEw=', 'admin', '2015-06-18T17:56:58.083', 'This is the gateway.', 'admin', '2015-06-18T17:56:58.083', 'The Gateway', 'REST')
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/050-apiman-manager-api.db.data.changelog.xml::1434686531709-2::apiman
+INSERT INTO [pd_templates] ([policydef_id], [language], [template]) VALUES ('IPWhitelistPolicy', NULL, 'Only requests that originate from the set of @{ipList.size()} configured IP address(es) will be allowed to invoke the managed api.')
+GO
+
+INSERT INTO [pd_templates] ([policydef_id], [language], [template]) VALUES ('IPBlacklistPolicy', NULL, 'Requests that originate from the set of @{ipList.size()} configured IP address(es) will be denied access to the managed api.')
+GO
+
+INSERT INTO [pd_templates] ([policydef_id], [language], [template]) VALUES ('BASICAuthenticationPolicy', NULL, 'Access to the api is protected by BASIC Authentication through the ''@{realm}'' authentication realm.  @if{forwardIdentityHttpHeader != null}Successfully authenticated requests will forward the authenticated identity to the back end api via the ''@{forwardIdentityHttpHeader}'' custom HTTP header.@end{}')
+GO
+
+INSERT INTO [pd_templates] ([policydef_id], [language], [template]) VALUES ('RateLimitingPolicy', NULL, 'Consumers are limited to @{limit} requests per @{granularity} per @{period}.')
+GO
+
+INSERT INTO [pd_templates] ([policydef_id], [language], [template]) VALUES ('IgnoredResourcesPolicy', NULL, 'Requests matching any of the @{rules.size()} regular expressions provided will receive a 404 error code.')
+GO
+
+INSERT INTO [pd_templates] ([policydef_id], [language], [template]) VALUES ('URLRewritingPolicy', NULL, 'Responses will be modified by finding all text matching regular expression ''@{fromRegex}'' with ''@{toReplacement}''.')
+GO
+
+INSERT INTO [pd_templates] ([policydef_id], [language], [template]) VALUES ('CachingPolicy', NULL, 'API responses will be cached for @{ttl} seconds.')
+GO
+
+INSERT INTO [pd_templates] ([policydef_id], [language], [template]) VALUES ('AuthorizationPolicy', NULL, 'Appropriate authorization roles are required.  There are @{rules.size()} authorization rules defined.')
+GO
+
+INSERT INTO [pd_templates] ([policydef_id], [language], [template]) VALUES ('QuotaPolicy', NULL, 'Consumers cannot exceed their quota of @{limit} requests per @{granularity} per @{period}.')
+GO
+
+INSERT INTO [pd_templates] ([policydef_id], [language], [template]) VALUES ('TransferQuotaPolicy', NULL, 'Consumers are limited to transferring @{limit} bytes per @{granularity} per @{period}.')
+GO
+
+INSERT INTO [pd_templates] ([policydef_id], [language], [template]) VALUES ('TimeRestrictedAccessPolicy', NULL, 'Requests matching the regular expression and made outside the specified time period will receive a 423 error code.')
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/050-apiman-manager-api.db.data.changelog.xml::1434686531709-3::apiman
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('OrganizationOwner', 1)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('OrganizationOwner', 2)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('OrganizationOwner', 3)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('OrganizationOwner', 6)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('OrganizationOwner', 8)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('OrganizationOwner', 5)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('OrganizationOwner', 9)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('OrganizationOwner', 11)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('OrganizationOwner', 7)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('OrganizationOwner', 4)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('OrganizationOwner', 10)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('OrganizationOwner', 0)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('ClientAppDeveloper', 6)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('ClientAppDeveloper', 8)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('ClientAppDeveloper', 7)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('APIDeveloper', 3)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('APIDeveloper', 5)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('APIDeveloper', 9)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('APIDeveloper', 11)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('APIDeveloper', 4)
+GO
+
+INSERT INTO [permissions] ([role_id], [permissions]) VALUES ('APIDeveloper', 10)
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/050-apiman-manager-api.db.data.changelog.xml::1434686531709-4::apiman
+INSERT INTO [policydefs] ([id], [description], [form], [form_type], [icon], [name], [plugin_id], [policy_impl]) VALUES ('IPWhitelistPolicy', 'Only requests that originate from a specified set of valid IP addresses will be allowed through.', NULL, 'Default', 'filter', 'IP Whitelist Policy', NULL, 'class:io.apiman.gateway.engine.policies.IPWhitelistPolicy')
+GO
+
+INSERT INTO [policydefs] ([id], [description], [form], [form_type], [icon], [name], [plugin_id], [policy_impl]) VALUES ('IPBlacklistPolicy', 'Requests that originate from a specified set of valid IP addresses will be denied access.', NULL, 'Default', 'thumbs-down', 'IP Blacklist Policy', NULL, 'class:io.apiman.gateway.engine.policies.IPBlacklistPolicy')
+GO
+
+INSERT INTO [policydefs] ([id], [description], [form], [form_type], [icon], [name], [plugin_id], [policy_impl]) VALUES ('BASICAuthenticationPolicy', 'Enables HTTP BASIC Authentication on an API.  Some configuration required.', NULL, 'Default', 'lock', 'BASIC Authentication Policy', NULL, 'class:io.apiman.gateway.engine.policies.BasicAuthenticationPolicy')
+GO
+
+INSERT INTO [policydefs] ([id], [description], [form], [form_type], [icon], [name], [plugin_id], [policy_impl]) VALUES ('RateLimitingPolicy', 'Enforces rate configurable request rate limits on an API.  This ensures that consumers can''t overload an API with too many requests.', NULL, 'Default', 'sliders', 'Rate Limiting Policy', NULL, 'class:io.apiman.gateway.engine.policies.RateLimitingPolicy')
+GO
+
+INSERT INTO [policydefs] ([id], [description], [form], [form_type], [icon], [name], [plugin_id], [policy_impl]) VALUES ('IgnoredResourcesPolicy', 'Requests satisfying the provided regular expression will be ignored.', NULL, 'Default', 'eye-slash', 'Ignored Resources Policy', NULL, 'class:io.apiman.gateway.engine.policies.IgnoredResourcesPolicy')
+GO
+
+INSERT INTO [policydefs] ([id], [description], [form], [form_type], [icon], [name], [plugin_id], [policy_impl]) VALUES ('URLRewritingPolicy', 'Responses from the back-end API will be modified by fixing up any incorrect URLs found with modified ones.  This is useful because apiman works through an API Gateway.', NULL, 'Default', 'pencil-square', 'URL Rewriting Policy', NULL, 'class:io.apiman.gateway.engine.policies.URLRewritingPolicy')
+GO
+
+INSERT INTO [policydefs] ([id], [description], [form], [form_type], [icon], [name], [plugin_id], [policy_impl]) VALUES ('CachingPolicy', 'Allows caching of API responses in the Gateway to reduce overall traffic to the back-end API.', NULL, 'Default', 'hdd-o', 'Caching Policy', NULL, 'class:io.apiman.gateway.engine.policies.CachingPolicy')
+GO
+
+INSERT INTO [policydefs] ([id], [description], [form], [form_type], [icon], [name], [plugin_id], [policy_impl]) VALUES ('AuthorizationPolicy', 'Enables fine grained authorization to API resources based on authenticated user roles.', NULL, 'Default', 'users', 'Authorization Policy', NULL, 'class:io.apiman.gateway.engine.policies.AuthorizationPolicy')
+GO
+
+INSERT INTO [policydefs] ([id], [description], [form], [form_type], [icon], [name], [plugin_id], [policy_impl]) VALUES ('QuotaPolicy', 'Provides a way to limit the total number of requests that can be sent to an API.', NULL, 'Default', 'exchange', 'Quota Policy', NULL, 'class:io.apiman.gateway.engine.policies.QuotaPolicy')
+GO
+
+INSERT INTO [policydefs] ([id], [description], [form], [form_type], [icon], [name], [plugin_id], [policy_impl]) VALUES ('TransferQuotaPolicy', 'Provides a way to limit the total number of bytes that can be transferred from (or to) an API.', NULL, 'Default', 'download', 'Transfer Quota Policy', NULL, 'class:io.apiman.gateway.engine.policies.TransferQuotaPolicy')
+GO
+
+INSERT INTO [policydefs] ([id], [description], [form], [form_type], [icon], [name], [plugin_id], [policy_impl]) VALUES ('TimeRestrictedAccessPolicy', 'Requests matching the specified regular expression and made within the specified time period will be ignored.', NULL, 'Default', 'fa-clock-o', 'Time Restricted Access', NULL, 'class:io.apiman.gateway.engine.policies.TimeRestrictedAccessPolicy')
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/050-apiman-manager-api.db.data.changelog.xml::1434686531709-5::apiman
+INSERT INTO [roles] ([id], [auto_grant], [created_by], [created_on], [description], [name]) VALUES ('OrganizationOwner', 1, 'admin', '2015-06-18T17:56:57.496', 'Automatically granted to the user who creates an Organization.  Grants all privileges.', 'Organization Owner')
+GO
+
+INSERT INTO [roles] ([id], [auto_grant], [created_by], [created_on], [description], [name]) VALUES ('ClientAppDeveloper', NULL, 'admin', '2015-06-18T17:56:57.632', 'Users responsible for creating and managing client apps should be granted this role within an Organization.', 'ClientApp Developer')
+GO
+
+INSERT INTO [roles] ([id], [auto_grant], [created_by], [created_on], [description], [name]) VALUES ('APIDeveloper', NULL, 'admin', '2015-06-18T17:56:57.641', 'Users responsible for creating and managing APIs should be granted this role within an Organization.', 'API Developer')
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/050-apiman-manager-api.db.data.changelog.xml::1434686531709-6::apiman
+INSERT INTO [users] ([username], [email], [full_name], [joined_on]) VALUES ('admin', 'admin@example.org', 'Admin', '2015-06-18T17:56:54.794')
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-23::apiman (generated)
+ALTER TABLE [endpoint_properties] ADD PRIMARY KEY ([api_version_id], [name])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-24::apiman (generated)
+ALTER TABLE [api_gateways] ADD PRIMARY KEY ([api_version_id], [gateway_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-25::apiman (generated)
+ALTER TABLE [api_plans] ADD PRIMARY KEY ([api_version_id], [plan_id], [version])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-26::apiman (generated)
+ALTER TABLE [client_versions] ADD CONSTRAINT [client_versionsPK] PRIMARY KEY ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-27::apiman (generated)
+ALTER TABLE [clients] ADD CONSTRAINT [clientsPK] PRIMARY KEY ([id], [organization_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-28::apiman (generated)
+ALTER TABLE [auditlog] ADD CONSTRAINT [auditlogPK] PRIMARY KEY ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-29::apiman (generated)
+ALTER TABLE [contracts] ADD CONSTRAINT [contractsPK] PRIMARY KEY ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-30::apiman (generated)
+ALTER TABLE [gateways] ADD CONSTRAINT [gatewaysPK] PRIMARY KEY ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-31::apiman (generated)
+ALTER TABLE [memberships] ADD CONSTRAINT [membershipsPK] PRIMARY KEY ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-32::apiman (generated)
+ALTER TABLE [organizations] ADD CONSTRAINT [organizationsPK] PRIMARY KEY ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-33::apiman (generated)
+ALTER TABLE [plan_versions] ADD CONSTRAINT [plan_versionsPK] PRIMARY KEY ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-34::apiman (generated)
+ALTER TABLE [plans] ADD CONSTRAINT [plansPK] PRIMARY KEY ([id], [organization_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-35::apiman (generated)
+ALTER TABLE [plugins] ADD CONSTRAINT [pluginsPK] PRIMARY KEY ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-36::apiman (generated)
+ALTER TABLE [policies] ADD CONSTRAINT [policiesPK] PRIMARY KEY ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-37::apiman (generated)
+ALTER TABLE [policydefs] ADD CONSTRAINT [policydefsPK] PRIMARY KEY ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-38::apiman (generated)
+ALTER TABLE [roles] ADD CONSTRAINT [rolesPK] PRIMARY KEY ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-39::apiman (generated)
+ALTER TABLE [api_defs] ADD CONSTRAINT [api_defsPK] PRIMARY KEY ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-40::apiman (generated)
+ALTER TABLE [api_versions] ADD CONSTRAINT [api_versionsPK] PRIMARY KEY ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-41::apiman (generated)
+ALTER TABLE [apis] ADD CONSTRAINT [apisPK] PRIMARY KEY ([id], [organization_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-42::apiman (generated)
+ALTER TABLE [users] ADD CONSTRAINT [usersPK] PRIMARY KEY ([username])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-43::apiman (generated)
+ALTER TABLE [apis] ADD CONSTRAINT [FK_31hj3xmhp1wedxjh5bklnlg15] FOREIGN KEY ([organization_id]) REFERENCES [organizations] ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-44::apiman (generated)
+ALTER TABLE [contracts] ADD CONSTRAINT [FK_6h06sgs4dudh1wehmk0us973g] FOREIGN KEY ([clientv_id]) REFERENCES [client_versions] ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-45::apiman (generated)
+ALTER TABLE [api_defs] ADD CONSTRAINT [FK_81fuw1n8afmvpw4buk7l4tyxk] FOREIGN KEY ([api_version_id]) REFERENCES [api_versions] ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-46::apiman (generated)
+ALTER TABLE [client_versions] ADD CONSTRAINT [FK_8epnoby31bt7xakegakigpikp] FOREIGN KEY ([client_id], [client_org_id]) REFERENCES [clients] ([id], [organization_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-47::apiman (generated)
+ALTER TABLE [contracts] ADD CONSTRAINT [FK_8o6t1f3kg96rxy5uv51f6k9fy] FOREIGN KEY ([apiv_id]) REFERENCES [api_versions] ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-48::apiman (generated)
+ALTER TABLE [api_versions] ADD CONSTRAINT [FK_92erjg9k1lni97gd87nt6tq37] FOREIGN KEY ([api_id], [api_org_id]) REFERENCES [apis] ([id], [organization_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-49::apiman (generated)
+ALTER TABLE [endpoint_properties] ADD CONSTRAINT [FK_gn0ydqur10sxuvpyw2jvv4xxb] FOREIGN KEY ([api_version_id]) REFERENCES [api_versions] ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-50::apiman (generated)
+ALTER TABLE [clients] ADD CONSTRAINT [FK_jenpu34rtuncsgvtw0sfo8qq9] FOREIGN KEY ([organization_id]) REFERENCES [organizations] ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-51::apiman (generated)
+ALTER TABLE [policies] ADD CONSTRAINT [FK_l4q6we1bos1yl9unmogei6aja] FOREIGN KEY ([definition_id]) REFERENCES [policydefs] ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-52::apiman (generated)
+ALTER TABLE [plans] ADD CONSTRAINT [FK_lwhc7xrdbsun1ak2uvfu0prj8] FOREIGN KEY ([organization_id]) REFERENCES [organizations] ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-53::apiman (generated)
+ALTER TABLE [contracts] ADD CONSTRAINT [FK_nyw8xu6m8cx4rwwbtrxbjneui] FOREIGN KEY ([planv_id]) REFERENCES [plan_versions] ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-54::apiman (generated)
+ALTER TABLE [api_gateways] ADD CONSTRAINT [FK_p5dm3cngljt6yrsnvc7uc6a75] FOREIGN KEY ([api_version_id]) REFERENCES [api_versions] ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-55::apiman (generated)
+ALTER TABLE [pd_templates] ADD CONSTRAINT [FK_prbnn7j7m6m3pxt2dsn9gwlw8] FOREIGN KEY ([policydef_id]) REFERENCES [policydefs] ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-56::apiman (generated)
+ALTER TABLE [permissions] ADD CONSTRAINT [FK_sq51ihfrapwdr98uufenhcocg] FOREIGN KEY ([role_id]) REFERENCES [roles] ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-57::apiman (generated)
+ALTER TABLE [api_plans] ADD CONSTRAINT [FK_t7uvfcsswopb9kh8wpa86blqr] FOREIGN KEY ([api_version_id]) REFERENCES [api_versions] ([id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/100-apiman-manager-api.db.constraints.changelog.xml::1436469846462-58::apiman (generated)
+ALTER TABLE [plan_versions] ADD CONSTRAINT [FK_tonylvm2ypnq3efxqr1g0m9fs] FOREIGN KEY ([plan_id], [plan_org_id]) REFERENCES [plans] ([id], [organization_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/110-apiman-manager-api.db.unique.constraints.changelog.xml::addUniqueConstraint-1::apiman
+ALTER TABLE [plugins] ADD CONSTRAINT [UK_plugins_1] UNIQUE ([group_id], [artifact_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/110-apiman-manager-api.db.unique.constraints.changelog.xml::addUniqueConstraint-2::apiman
+ALTER TABLE [memberships] ADD CONSTRAINT [UK_memberships_1] UNIQUE ([user_id], [role_id], [org_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/110-apiman-manager-api.db.unique.constraints.changelog.xml::addUniqueConstraint-3::apiman
+ALTER TABLE [plan_versions] ADD CONSTRAINT [UK_plan_versions_1] UNIQUE ([plan_id], [plan_org_id], [version])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/110-apiman-manager-api.db.unique.constraints.changelog.xml::addUniqueConstraint-4::apiman
+ALTER TABLE [client_versions] ADD CONSTRAINT [UK_client_versions_1] UNIQUE ([client_id], [client_org_id], [version])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/110-apiman-manager-api.db.unique.constraints.changelog.xml::addUniqueConstraint-5::apiman
+ALTER TABLE [api_versions] ADD CONSTRAINT [UK_api_versions_1] UNIQUE ([api_id], [api_org_id], [version])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/110-apiman-manager-api.db.unique.constraints.changelog.xml::addUniqueConstraint-6::apiman
+ALTER TABLE [api_defs] ADD CONSTRAINT [UK_api_defs_1] UNIQUE ([api_version_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/110-apiman-manager-api.db.unique.constraints.changelog.xml::addUniqueConstraint-7::apiman
+ALTER TABLE [contracts] ADD CONSTRAINT [UK_contracts_1] UNIQUE ([clientv_id], [apiv_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/110-apiman-manager-api.db.unique.constraints.changelog.xml::addUniqueConstraint-8::apiman
+ALTER TABLE [client_versions] ADD CONSTRAINT [UK_client_versions_2] UNIQUE ([apikey])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-1::apiman
+CREATE NONCLUSTERED INDEX [IDX_auditlog_1] ON [auditlog]([who])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-2::apiman
+CREATE NONCLUSTERED INDEX [IDX_auditlog_2] ON [auditlog]([organization_id], [entity_id], [entity_version], [entity_type])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-3::apiman
+CREATE NONCLUSTERED INDEX [IDX_FK_pd_templates_1] ON [pd_templates]([policydef_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-4::apiman
+CREATE NONCLUSTERED INDEX [IDX_users_1] ON [users]([username])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-5::apiman
+CREATE NONCLUSTERED INDEX [IDX_users_2] ON [users]([full_name])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-6::apiman
+CREATE NONCLUSTERED INDEX [IDX_FK_permissions_1] ON [permissions]([role_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-7::apiman
+CREATE NONCLUSTERED INDEX [IDX_memberships_1] ON [memberships]([user_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-8::apiman
+CREATE NONCLUSTERED INDEX [IDX_organizations_1] ON [organizations]([name])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-9::apiman
+CREATE NONCLUSTERED INDEX [IDX_FK_plans_1] ON [plans]([organization_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-10::apiman
+CREATE NONCLUSTERED INDEX [IDX_FK_clients_1] ON [clients]([organization_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-11::apiman
+CREATE NONCLUSTERED INDEX [IDX_apis_1] ON [apis]([name])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-12::apiman
+CREATE NONCLUSTERED INDEX [IDX_FK_apis_1] ON [apis]([organization_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-13::apiman
+CREATE NONCLUSTERED INDEX [IDX_policies_1] ON [policies]([organization_id], [entity_id], [entity_version])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-14::apiman
+CREATE NONCLUSTERED INDEX [IDX_policies_2] ON [policies]([order_index])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-15::apiman
+CREATE NONCLUSTERED INDEX [IDX_FK_policies_1] ON [policies]([definition_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-16::apiman
+CREATE NONCLUSTERED INDEX [IDX_FK_contracts_p] ON [contracts]([planv_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-17::apiman
+CREATE NONCLUSTERED INDEX [IDX_FK_contracts_s] ON [contracts]([apiv_id])
+GO
+
+-- Changeset C:/Users/Pete/projects/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-18::apiman
+CREATE NONCLUSTERED INDEX [IDX_FK_contracts_a] ON [contracts]([clientv_id])
+GO
+

--- a/distro/data/src/main/resources/sample-configs/apiman-ds_mssql.xml
+++ b/distro/data/src/main/resources/sample-configs/apiman-ds_mssql.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<datasources>
+  <datasource jndi-name="java:jboss/datasources/apiman-manager" pool-name="apiman-manager-api" enabled="true" use-java-context="true">
+    <connection-url>jdbc:sqlserver://SQLSERVER:1433;databaseName=apiman;</connection-url>
+    <driver>sqljdbc42.jar</driver>
+    <pool>
+      <max-pool-size>30</max-pool-size>
+    </pool>
+    <security>
+      <user-name>DBUSER</user-name>
+      <password>DBPASS</password>
+    </security>
+  </datasource>
+</datasources>

--- a/distro/data/src/main/resources/sample-configs/apiman_gw-ds_mssql.xml
+++ b/distro/data/src/main/resources/sample-configs/apiman_gw-ds_mssql.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<datasources>
+  <datasource jndi-name="java:jboss/datasources/apiman-gateway" pool-name="apiman-gateway" enabled="true" use-java-context="true">
+    <connection-url>jdbc:sqlserver://SQLSERVER:1433;databaseName=apiman_gateway;</connection-url>
+    <driver>sqljdbc42.jar</driver>
+    <pool>
+      <max-pool-size>30</max-pool-size>
+    </pool>
+    <security>
+      <user-name>DBUSER</user-name>
+      <password>DBPASS</password>
+    </security>
+  </datasource>
+</datasources>

--- a/distro/ddl/pom.xml
+++ b/distro/ddl/pom.xml
@@ -13,6 +13,7 @@
     <version.org.postgresql.jdbc.driver>9.4-1201-jdbc41</version.org.postgresql.jdbc.driver>
     <version.mysql.jdbc.driver>5.1.35</version.mysql.jdbc.driver>
     <version.com.oracle.driver>12.1.0.2</version.com.oracle.driver>
+    <version.mssql.driver>4.2</version.mssql.driver>
     <version.liquibase>3.4.1</version.liquibase>
   </properties>
 
@@ -53,6 +54,13 @@
             <groupId>com.oracle</groupId>
             <artifactId>ojdbc7</artifactId>
             <version>${version.com.oracle.driver}</version>
+          </dependency>
+           -->
+          <!-- The MS SQL Server dependency - uncomment to generate the MS SQL Server DDL
+          <dependency>
+            <groupId>com.microsoft</groupId>
+            <artifactId>sqljdbc42</artifactId>
+            <version>${version.mssql.driver}</version>
           </dependency>
            -->
           <!-- Liquibase -->
@@ -194,6 +202,28 @@
               <migrationSqlOutputFile>${basedir}/target/apiman_oracle12.ddl</migrationSqlOutputFile>
               <driver>oracle.jdbc.OracleDriver</driver>
               <url>offline:oracle?version=12&amp;caseSensitive=true&amp;changeLogFile=${basedir}/target/changelog/oracle/databasechangelog.csv</url>
+              <username>apiman</username>
+              <password>apiman</password>
+              <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>
+              <verbose>true</verbose>
+            </configuration>
+          </execution>
+           -->
+          <!-- Commented out because you need to manually install the MS SQL Server JDBC driver JAR as a
+               Maven dependency for this to work.  Here's how you do that:
+
+               1) Download the MS SQL Server driver:  https://www.microsoft.com/en-us/download/details.aspx?displaylang=en&id=11774
+               2) Install it:  mvn install:install-file -Dfile=sqljdbc42.jar -DgroupId=com.microsoft -DartifactId=sqljdbc42 -Dversion=4.2 -Dpackaging=jar
+          <execution>
+            <id>mssql-ddl</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>updateSQL</goal>
+            </goals>
+            <configuration>
+              <migrationSqlOutputFile>${basedir}/target/apiman_mssql.ddl</migrationSqlOutputFile>
+              <driver>com.microsoft.sqlserver.jdbc.SQLServerDriver</driver>
+              <url>offline:mssql?version=11.0&amp;caseSensitive=true&amp;catalog=apiman&amp;changeLogFile=${basedir}/target/changelog/mssql/databasechangelog.csv</url>
               <username>apiman</username>
               <password>apiman</password>
               <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>


### PR DESCRIPTION
# Purpose

This PR adds DDL and Maven plugin configuration to support MS SQL Server.

See https://issues.jboss.org/browse/APIMAN-951

# Implementation
* Instructions and config (commented, in line with current Oracle example) added to POM to enable DDL generation
* Schema files added
* JBoss datasource examples added

# Notes
The sample DS files assume separate schemas (again, in line with the Oracle ones), but GW and Manager should be able to cooexist within the same schema, assuming no naming conflicts (https://issues.jboss.org/browse/APIMAN-1092).