### PR TITLE
fix(gateway-platforms-vertx3) Filter out Connection header when HTTP2 

### DIFF
--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/http/HttpApiFactory.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/http/HttpApiFactory.java
@@ -24,6 +24,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.HttpVersion;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -53,8 +54,12 @@ public class HttpApiFactory {
         return apimanResponse;
     }
 
-    public static void buildResponse(HttpServerResponse httpServerResponse, ApiResponse amanResponse) {
-        amanResponse.getHeaders().forEach(e -> httpServerResponse.headers().add(e.getKey(), e.getValue()));
+    public static void buildResponse(HttpServerResponse httpServerResponse, ApiResponse amanResponse, HttpVersion httpVersion) {
+        amanResponse.getHeaders().forEach(e -> {
+            if (httpVersion == HttpVersion.HTTP_1_0 || httpVersion == HttpVersion.HTTP_1_1 || !e.getKey().equals("Connection")) {
+                httpServerResponse.headers().add(e.getKey(), e.getValue());
+            }
+        });
         httpServerResponse.setStatusCode(amanResponse.getCode());
         httpServerResponse.setStatusMessage(amanResponse.getMessage());
     }

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/http/HttpPolicyAdapter.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/http/HttpPolicyAdapter.java
@@ -23,7 +23,6 @@ import io.apiman.gateway.engine.beans.ApiRequest;
 import io.apiman.gateway.engine.beans.ApiResponse;
 import io.apiman.gateway.engine.beans.EngineErrorResponse;
 import io.apiman.gateway.engine.beans.PolicyFailure;
-import io.apiman.gateway.platforms.vertx3.http.HttpApiFactory;
 import io.apiman.gateway.platforms.vertx3.io.VertxApimanBuffer;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.buffer.Buffer;
@@ -98,7 +97,7 @@ public class HttpPolicyAdapter {
         // Everything worked
         if (engineResult.isResponse()) {
             ApiResponse response = engineResult.getApiResponse();
-            HttpApiFactory.buildResponse(vertxResponse, response);
+            HttpApiFactory.buildResponse(vertxResponse, response, vertxRequest.version());
             vertxResponse.setChunked(true);
 
             engineResult.bodyHandler(buffer -> {


### PR DESCRIPTION
> An endpoint MUST NOT generate an HTTP/2 message containing
> connection-specific header fields 

https://tools.ietf.org/html/rfc7540

This error was occurring because the backend was HTTP/1.1 and
hence we were inadvertently setting an illegal value.

Thanks to @bagder [for pointing this out](https://twitter.com/bagder/status/767052367686688768 ).

Need to do a little bit more work before I enable ALPN by default (as it's a bit fussy and needs JARs putting on the class-path and such), but this fixes a key issue.

JIRA: APIMAN-1217