### PR TITLE
Use case insensitive comparison for suppressed headers.

### DIFF
--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpApiConnection.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpApiConnection.java
@@ -190,7 +190,7 @@ public class HttpApiConnection implements IApiConnection, IApiConnectionResponse
             for (Entry<String, String> entry : request.getHeaders()) {
                 String hname = entry.getKey();
                 String hval = entry.getValue();
-                if (!suppressedHeaders.contains(hname)) {
+                if (!suppressedHeaders.stream().anyMatch(suppressedHeader -> suppressedHeader.equalsIgnoreCase(hname))) {
                     connection.setRequestProperty(hname, hval);
                 }
             }
@@ -348,7 +348,7 @@ public class HttpApiConnection implements IApiConnection, IApiConnectionResponse
             response = GatewayThreadContext.getApiResponse();
             Map<String, List<String>> headerFields = connection.getHeaderFields();
             for (String headerName : headerFields.keySet()) {
-                if (headerName != null && !SUPPRESSED_RESPONSE_HEADERS.contains(headerName)) {
+                if (headerName != null && !SUPPRESSED_RESPONSE_HEADERS.stream().anyMatch(suppressedHeader -> suppressedHeader.equalsIgnoreCase(headerName))) {
                     response.getHeaders().add(headerName, connection.getHeaderField(headerName));
                 }
             }


### PR DESCRIPTION
# Rationale

Suppressed headers are not always removed from downstream requests to back-end APIs, nor in responses to the caller. This is because the comparison of header names is done in a _case-sensitive_ manner. According to [RFC-2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2):

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

# Background

There is a set of 'suppressed headers' in `io.apiman.gateway.platforms.servlet.connectors.HttpApiConnection`. There are two comparison loops - one for requests and one for responses. In these loops the header keys are checked against the suppressed set and conditionally included if absent.

Currently, the comparison with the suppressed set is case-sensitive, resulting in suppressed headers being erroneously included if they have the same name but different case. This is particularly problematic as it seems that at runtime, the list of header keys returned by `io.apiman.gateway.engine.beans.ApiRequest.getHeaders()` is in lowercase, meaning none of them match the suppressed set.

# Implementation

The `java.util.HashSet` used for the suppressed headers is replaced with a `java.util.TreeSet`, specifying the `String.CASE_INSENSITIVE_ORDER` comparator.