### PR TITLE
APIMAN-1221 Don't copy Connection and Transfer-Encoding header

### DIFF
--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpApiConnection.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpApiConnection.java
@@ -79,6 +79,8 @@ public class HttpApiConnection implements IApiConnection, IApiConnectionResponse
         SUPPRESSED_RESPONSE_HEADERS.add("OkHttp-Response-Source"); //$NON-NLS-1$
         SUPPRESSED_RESPONSE_HEADERS.add("OkHttp-Selected-Protocol"); //$NON-NLS-1$
         SUPPRESSED_RESPONSE_HEADERS.add("OkHttp-Sent-Millis"); //$NON-NLS-1$
+        SUPPRESSED_RESPONSE_HEADERS.add("Transfer-Encoding"); //$NON-NLS-1$
+        SUPPRESSED_RESPONSE_HEADERS.add("Connection"); //$NON-NLS-1$
     }
 
     private ApiRequest request;


### PR DESCRIPTION
Don't copy Connection and Transfer-Encoding header from the the response as these are set by the servlet container (Tomcat)