### PR TITLE
ElasticSearch 2.X fixes

### DIFF
--- a/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/ESRateLimiterComponent.java
+++ b/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/ESRateLimiterComponent.java
@@ -106,10 +106,12 @@ public class ESRateLimiterComponent extends AbstractESComponent implements IRate
             final RateBucketPeriod period, final long limit, final long increment,
             final IAsyncResultHandler<RateLimitResponse> handler) {
 
-        Index index = new Index.Builder(bucket).refresh(false).index(getIndexName())
-                .setParameter(Parameters.OP_TYPE, "index") //$NON-NLS-1$
-                .setParameter(Parameters.VERSION, String.valueOf(version))
-                .type("rateBucket").id(id).build(); //$NON-NLS-1$
+    	Index.Builder builder = new Index.Builder(bucket).refresh(false).index(getIndexName());
+    	if (version>0) {
+    		builder.setParameter(Parameters.VERSION, String.valueOf(version));
+        }
+    	Index index = builder.setParameter(Parameters.OP_TYPE, "index") //$NON-NLS-1$
+    			             .type("rateBucket").id(id).build(); //$NON-NLS-1$          
         try {
             getClient().execute(index);
             handler.handle(AsyncResultImpl.create(rlr));

--- a/manager/api/es/src/main/resources/io/apiman/manager/api/es/index-settings.json
+++ b/manager/api/es/src/main/resources/io/apiman/manager/api/es/index-settings.json
@@ -6,6 +6,7 @@
                     "type" : "string",
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
                 },
+                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "createdBy" : { "type" : "string", "index" : "not_analyzed" },
                 "modifiedBy" : { "type" : "string", "index" : "not_analyzed" },
                 "gatewayType" : { "type" : "string", "index" : "not_analyzed" }
@@ -13,6 +14,7 @@
         },
         "download" : {
             "properties" : {
+                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "path" : { "type" : "string", "index" : "not_analyzed" },
                 "type" : { "type" : "string", "index" : "not_analyzed" }
             }
@@ -23,6 +25,7 @@
                     "type" : "string",
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
                 },
+                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "formType" : { "type" : "string", "index" : "not_analyzed" }
             }
         },
@@ -46,6 +49,7 @@
                     "type" : "string",
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
                 },
+                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "createdBy" : { "type" : "string", "index" : "not_analyzed" }
             }
         },
@@ -71,12 +75,14 @@
                     "type" : "string",
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
                 },
+                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "createdBy" : { "type" : "string", "index" : "not_analyzed" },
                 "modifiedBy" : { "type" : "string", "index" : "not_analyzed" }
             }
         },
         "auditEntry" : {
             "properties" : {
+                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "organizationId" : { "type" : "string", "index" : "not_analyzed" },
                 "entityType" : { "type" : "string", "index" : "not_analyzed" },
                 "entityId" : { "type" : "string", "index" : "not_analyzed" },
@@ -93,6 +99,7 @@
                     "type" : "string",
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
                 },
+                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "name" : {
                     "type" : "string",
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
@@ -146,6 +153,7 @@
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
                 },
                 "organizationId" : { "type" : "string", "index" : "not_analyzed" },
+                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "createdBy" : { "type" : "string", "index" : "not_analyzed" }
             }
         },
@@ -191,6 +199,7 @@
                     "type" : "string",
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
                 },
+                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "name" : {
                     "type" : "string",
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
@@ -236,6 +245,7 @@
         },
         "contract" : {
             "properties" : {
+                "id" : { "type" : "string" ,"index" : "not_analyzed" },
                 "clientOrganizationId" : { "type" : "string", "index" : "not_analyzed" },
                 "clientId" : { "type" : "string", "index" : "not_analyzed" },
                 "clientVersion" : { "type" : "string", "index" : "not_analyzed" },

--- a/manager/api/es/src/main/resources/io/apiman/manager/api/es/index-settings.json
+++ b/manager/api/es/src/main/resources/io/apiman/manager/api/es/index-settings.json
@@ -6,7 +6,6 @@
                     "type" : "string",
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
                 },
-                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "createdBy" : { "type" : "string", "index" : "not_analyzed" },
                 "modifiedBy" : { "type" : "string", "index" : "not_analyzed" },
                 "gatewayType" : { "type" : "string", "index" : "not_analyzed" }
@@ -14,7 +13,6 @@
         },
         "download" : {
             "properties" : {
-                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "path" : { "type" : "string", "index" : "not_analyzed" },
                 "type" : { "type" : "string", "index" : "not_analyzed" }
             }
@@ -25,7 +23,6 @@
                     "type" : "string",
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
                 },
-                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "formType" : { "type" : "string", "index" : "not_analyzed" }
             }
         },
@@ -49,7 +46,6 @@
                     "type" : "string",
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
                 },
-                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "createdBy" : { "type" : "string", "index" : "not_analyzed" }
             }
         },
@@ -75,14 +71,12 @@
                     "type" : "string",
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
                 },
-                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "createdBy" : { "type" : "string", "index" : "not_analyzed" },
                 "modifiedBy" : { "type" : "string", "index" : "not_analyzed" }
             }
         },
         "auditEntry" : {
             "properties" : {
-                "id" : { "type" : "long", "index" : "not_analyzed" },
                 "organizationId" : { "type" : "string", "index" : "not_analyzed" },
                 "entityType" : { "type" : "string", "index" : "not_analyzed" },
                 "entityId" : { "type" : "string", "index" : "not_analyzed" },
@@ -99,7 +93,6 @@
                     "type" : "string",
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
                 },
-                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "name" : {
                     "type" : "string",
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
@@ -153,7 +146,6 @@
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
                 },
                 "organizationId" : { "type" : "string", "index" : "not_analyzed" },
-                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "createdBy" : { "type" : "string", "index" : "not_analyzed" }
             }
         },
@@ -199,7 +191,6 @@
                     "type" : "string",
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
                 },
-                "id" : { "type" : "string", "index" : "not_analyzed" },
                 "name" : {
                     "type" : "string",
                     "fields" : { "raw" : { "type" : "string", "index" : "not_analyzed" } }
@@ -245,7 +236,6 @@
         },
         "contract" : {
             "properties" : {
-                "id" : { "type" : "long" },
                 "clientOrganizationId" : { "type" : "string", "index" : "not_analyzed" },
                 "clientId" : { "type" : "string", "index" : "not_analyzed" },
                 "clientVersion" : { "type" : "string", "index" : "not_analyzed" },


### PR DESCRIPTION
 ElasticSearch 2.X has deprecated _id from specific mapping. It expect
id should be specified explicitly.ES won't offer to parse document first
time just to retrieve the field that was specified as the id field.
 ElasticSearch 2.X doesn't expect Version parameter at the time of index
creation.

the above two mentioned changes in ES 2.X were failing APIMan to work
for ElasticSearch 2.x. I have removed all the id field from
index-settings.json , and have put a hack in
ESRateLimiterComponent.java.It pass version only at the time of index
updation.