### PR TITLE
bug(gateway-engine-beans) Fixes collision filtration on CaseInsenstiveStringMultiMap #getAllEntries and #getAllValues.

### DIFF
--- a/gateway/engine/beans/src/test/java/io/apiman/gateway/engine/beans/util/CaseInsensitiveStringMultiMapTest.java
+++ b/gateway/engine/beans/src/test/java/io/apiman/gateway/engine/beans/util/CaseInsensitiveStringMultiMapTest.java
@@ -242,6 +242,26 @@ public class CaseInsensitiveStringMultiMapTest {
     }
 
     @Test
+    public void shouldDistinguishBetweenCollisionsWithGetAll() {
+        CaseInsensitiveStringMultiMap mmap = new CaseInsensitiveStringMultiMap(1);
+        mmap.add("Access-Control-Allow-Origin", "*").add("Server", "WildFly/10");
+        Assert.assertEquals(2, mmap.size());
+        Assert.assertEquals(mmap.getAll("Access-Control-Allow-Origin").size(), 1);
+        Assert.assertEquals(mmap.getAll("Access-Control-Allow-Origin").get(0), "*");
+        Assert.assertEquals(mmap.getAll("Server").size(), 1);
+    }
+
+    @Test
+    public void shouldDistinguishBetweenCollisionsWithGetEntries() {
+        CaseInsensitiveStringMultiMap mmap = new CaseInsensitiveStringMultiMap(1);
+        mmap.add("Access-Control-Allow-Origin", "*").add("Server", "WildFly/10");
+        Assert.assertEquals(2, mmap.size());
+        Assert.assertEquals(mmap.getAllEntries("Access-Control-Allow-Origin").size(), 1);
+        Assert.assertEquals(mmap.getAllEntries("Access-Control-Allow-Origin").get(0).getValue(), "*");
+        Assert.assertEquals(mmap.getAllEntries("Server").size(), 1);
+    }
+
+    @Test
     public void getShouldReturnTheLastValueOnly() {
         CaseInsensitiveStringMultiMap mmap = new CaseInsensitiveStringMultiMap();
         // Additional entries should be ignored


### PR DESCRIPTION
Different bits of code were using #getAllEntries/#getAllValues in different ways. Some required collision filtering, others not. The solution was to overload with additional parameters so that both can be provided.

Also:

- spec(gateway-engine-beans) Tests to verify the above.

- bug(gateway-engine-beans) Incidentally discovered bug that caused #size to
be inaccurate in certain collision cases. May want to consider deprecating
size as it is likely not quite what people expect and therefore not very
useful.