### PR TITLE
Add slf4j logger factory to WAR path

### DIFF
--- a/gateway/platforms/war/pom.xml
+++ b/gateway/platforms/war/pom.xml
@@ -21,6 +21,10 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>apiman-common-logging-slf4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>apiman-gateway-engine-beans</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
@EricWittmann Is there a way to add JARs to the classpath easily in our WAR/WF distros? For instance, adding the log4j2-slf4j JAR if people wanted to use that, or logback, etc as their implementation?

