### PR TITLE
APIMAN-1235: override maven .m2 local repository system property added

### DIFF
--- a/common/plugin/src/main/java/io/apiman/common/plugin/PluginUtils.java
+++ b/common/plugin/src/main/java/io/apiman/common/plugin/PluginUtils.java
@@ -98,6 +98,12 @@ public class PluginUtils {
      * @return user's M2 repo
      */
     public static File getUserM2Repository() {
+		// if there is m2override system propery, use it.
+        String m2Override = System.getProperty("apiman.gateway.m2-repository-path"); //$NON-NLS-1$
+        if (m2Override != null) {
+            return new File(m2Override).getAbsoluteFile();
+        }
+		
         String userHome = System.getProperty("user.home"); //$NON-NLS-1$
         if (userHome != null) {
             File userHomeDir = new File(userHome);

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/DefaultPluginRegistry.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/DefaultPluginRegistry.java
@@ -237,10 +237,6 @@ public class DefaultPluginRegistry implements IPluginRegistry {
         // registry first though)
         if (!handled) {
             File m2Dir = PluginUtils.getUserM2Repository();
-            String m2Override = System.getProperty("apiman.gateway.m2-repository-path"); //$NON-NLS-1$
-            if (m2Override != null) {
-                m2Dir = new File(m2Override).getAbsoluteFile();
-            }
             if (m2Dir != null) {
                 File artifactFile = PluginUtils.getM2Path(m2Dir, coordinates);
                 if (artifactFile.isFile()) {


### PR DESCRIPTION
@EricWittmann 
as discussed, I haved added below commit for APIMAN-1235.
maven .m2 local repository system property is added to the common method so it is used by both apiman-gateway and apiman-manager.