### PR TITLE
fix(platform-vertx) Add LRUCache of HttpClient in ClientConnector.

### DIFF
--- a/gateway/platforms/vertx3/vertx3/pom.xml
+++ b/gateway/platforms/vertx3/vertx3/pom.xml
@@ -140,6 +140,10 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
 
     <!--  Spec Only -->
     <dependency>

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/HttpConnectorOptions.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/HttpConnectorOptions.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.gateway.platforms.vertx3.connector;
+
+import io.apiman.common.config.options.TLSOptions;
+import io.apiman.gateway.engine.auth.RequiredAuthType;
+import io.vertx.core.http.HttpClientOptions;
+
+import java.net.URI;
+
+/**
+ * Options for {@link HttpConnector}.
+ *
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+public class HttpConnectorOptions {
+    private RequiredAuthType requiredAuthType = RequiredAuthType.DEFAULT;
+    private boolean hasDataPolicy = false;
+    private int connectionTimeout = HttpClientOptions.DEFAULT_CONNECT_TIMEOUT;
+    private int idleTimeout = HttpClientOptions.DEFAULT_IDLE_TIMEOUT;
+    private boolean keepAlive = HttpClientOptions.DEFAULT_KEEP_ALIVE;
+    private boolean tryUseCompression = HttpClientOptions.DEFAULT_TRY_USE_COMPRESSION;
+    private TLSOptions tlsOptions;
+    private URI endpoint;
+
+    /**
+     * @return the requiredAuthType
+     */
+    public RequiredAuthType getRequiredAuthType() {
+        return requiredAuthType;
+    }
+    /**
+     * @param requiredAuthType the requiredAuthType to set
+     * @return this
+     */
+    public HttpConnectorOptions setRequiredAuthType(RequiredAuthType requiredAuthType) {
+        this.requiredAuthType = requiredAuthType;
+        return this;
+    }
+    /**
+     * @return the hasDataPolicy
+     */
+    public boolean hasDataPolicy() {
+        return hasDataPolicy;
+    }
+    /**
+     * @param hasDataPolicy the hasDataPolicy to set
+     * @return this
+     */
+    public HttpConnectorOptions setHasDataPolicy(boolean hasDataPolicy) {
+        this.hasDataPolicy = hasDataPolicy;
+        return this;
+    }
+    /**
+     * @return the connectionTimeout
+     */
+    public int getConnectionTimeout() {
+        return connectionTimeout;
+    }
+    /**
+     * @param connectionTimeout the connectionTimeout to set
+     * @return this
+     */
+    public HttpConnectorOptions setConnectionTimeout(int connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+        return this;
+    }
+    /**
+     * @return the idleTimeout
+     */
+    public int getIdleTimeout() {
+        return idleTimeout;
+    }
+    /**
+     * @param idleTimeout the idleTimeout to set
+     * @return this
+     */
+    public HttpConnectorOptions setIdleTimeout(int idleTimeout) {
+        this.idleTimeout = idleTimeout;
+        return this;
+    }
+    /**
+     * @return the keepAlive
+     */
+    public boolean isKeepAlive() {
+        return keepAlive;
+    }
+    /**
+     * @param keepAlive the keepAlive to set
+     * @return this
+     */
+    public HttpConnectorOptions setKeepAlive(boolean keepAlive) {
+        this.keepAlive = keepAlive;
+        return this;
+    }
+    /**
+     * @return the tryUseCompression
+     */
+    public boolean isTryUseCompression() {
+        return tryUseCompression;
+    }
+    /**
+     * @param tryUseCompression the tryUseCompression to set
+     * @return this
+     */
+    public HttpConnectorOptions setTryUseCompression(boolean tryUseCompression) {
+        this.tryUseCompression = tryUseCompression;
+        return this;
+    }
+
+    public TLSOptions getTlsOptions() {
+        return tlsOptions;
+    }
+
+    public HttpConnectorOptions setTlsOptions(TLSOptions tlsOptions) {
+        this.tlsOptions = tlsOptions;
+        return this;
+    }
+
+    public URI getUri() {
+        return endpoint;
+    }
+
+    public HttpConnectorOptions setUri(URI endpoint) {
+        this.endpoint = endpoint;
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + connectionTimeout;
+        result = prime * result + idleTimeout;
+        result = prime * result + (keepAlive ? 1231 : 1237);
+        result = prime * result + ((tlsOptions == null) ? 0 : tlsOptions.hashCode());
+        result = prime * result + (tryUseCompression ? 1231 : 1237);
+        return result;
+    }
+    /* (non-Javadoc)
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        HttpConnectorOptions other = (HttpConnectorOptions) obj;
+        if (connectionTimeout != other.connectionTimeout)
+            return false;
+        if (idleTimeout != other.idleTimeout)
+            return false;
+        if (keepAlive != other.keepAlive)
+            return false;
+        if (tlsOptions == null) {
+            if (other.tlsOptions != null)
+                return false;
+        } else if (!tlsOptions.equals(other.tlsOptions))
+            return false;
+        if (tryUseCompression != other.tryUseCompression)
+            return false;
+        return true;
+    }
+}

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/http/HttpClientOptionsFactory.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/http/HttpClientOptionsFactory.java
@@ -21,7 +21,7 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.JksOptions;
 
-import java.net.URL;
+import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,7 +41,7 @@ public class HttpClientOptionsFactory {
     private static Map<TLSOptions, HttpClientOptions> configCache = new HashMap<>();
     private static Logger log = LoggerFactory.getLogger(HttpClientOptionsFactory.class);
 
-    public static HttpClientOptions parseOptions(TLSOptions tlsOptions, URL apiEndpoint) {
+    public static HttpClientOptions parseTlsOptions(TLSOptions tlsOptions, URI apiEndpoint) {
         if (configCache.containsKey(tlsOptions))
             return configCache.get(tlsOptions);
 
@@ -50,10 +50,10 @@ public class HttpClientOptionsFactory {
         return clientOptions;
     }
 
-    private static HttpClientOptions doParse(TLSOptions tlsOptions, URL apiEndpoint) {
+    private static HttpClientOptions doParse(TLSOptions tlsOptions, URI apiEndpoint) {
         HttpClientOptions clientOptions = new HttpClientOptions();
 
-        if (apiEndpoint.getProtocol().equals("http")) { //$NON-NLS-1$
+        if (apiEndpoint.getScheme().equals("http")) { //$NON-NLS-1$
             return clientOptions.setSsl(false);
         } else {
             clientOptions.setSsl(true);

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
     <version.commons-pool>1.6</version.commons-pool>
     <version.com.zaxxer>2.4.0</version.com.zaxxer>
     <version.com.google.code.gson>2.3.1</version.com.google.code.gson>
+    <version.com.google.guava>21.0</version.com.google.guava>
     <version.io.searchbox.jest>0.1.7</version.io.searchbox.jest>
     <version.io.prometheus>0.0.13</version.io.prometheus>
     <version.javax.enterprise>1.2</version.javax.enterprise>
@@ -941,6 +942,11 @@
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>${version.com.google.code.gson}</version>
+      </dependency>
+      <dependency>
+	<groupId>com.google.guava</groupId>
+	<artifactId>guava</artifactId>
+	<version>${version.com.google.guava}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
* Add LRUCache of HttpClient in ClientConnector to make use of connection pooling when connecting to similarly configured backends (e.g. same endpoint,  same security settings, etc).

* Clean up constructor by adding HttpConnectorOptions.

* Change some URL to URI (URL is blocking in `equals`).