### PR TITLE
build(pom) No longer need MaxPermSize in Java 8+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1378,7 +1378,7 @@
               <value>${basedir}/target</value>
             </property>
           </systemProperties>
-          <argLine>-Xmx512m -XX:MaxPermSize=256m</argLine>
+          <argLine>-Xmx512m</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Gets rid of associated warnings in Maven output.