### PR TITLE
build(platform-vertx) Fix shade plugin build warnings. Upgrade to 2.4.3.

### DIFF
--- a/gateway/platforms/vertx3/vertx3/pom.xml
+++ b/gateway/platforms/vertx3/vertx3/pom.xml
@@ -219,7 +219,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>2.4.3</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
Sorry, another small warning-eliminating build PR :-).