### PR TITLE
bug(gateway-engine) MultiMap bug fix for deletion with specific collision ordering.

### DIFF
--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/util/CaseInsensitiveStringMultiMap.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/util/CaseInsensitiveStringMultiMap.java
@@ -312,6 +312,8 @@ public class CaseInsensitiveStringMultiMap implements IStringMultiMap, Serializa
                     current.previous = null;
                     current = prev;
                     removedAny = true;
+                    if (link != null)
+                        link.previous = prev;
                 } else if (newHead == null) {
                     newHead = link = current;
                     current = newHead.previous;

--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/util/IStringMultiMap.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/util/IStringMultiMap.java
@@ -94,7 +94,7 @@ public interface IStringMultiMap extends Iterable<Map.Entry<String, String>> {
     IStringMultiMap remove(String key);
 
     /**
-     * Get the first value for given <tt>key</tt>.
+     * Get the last value for given <tt>key</tt>.
      *
      * @param key the key
      * @return the value if present, else null
@@ -132,7 +132,7 @@ public interface IStringMultiMap extends Iterable<Map.Entry<String, String>> {
     /**
      * Converts this multimap into a plain map. Note that this method will be lossy
      * if multiple values have been associated with any given key. It will select
-     * only the first value.
+     * only the last value.
      *
      * @return the map
      */

--- a/gateway/engine/beans/src/test/java/io/apiman/gateway/engine/beans/util/CaseInsensitiveStringMultiMapTest.java
+++ b/gateway/engine/beans/src/test/java/io/apiman/gateway/engine/beans/util/CaseInsensitiveStringMultiMapTest.java
@@ -213,7 +213,7 @@ public class CaseInsensitiveStringMultiMapTest {
 
     @Test
     public void removeEntries() {
-        Map<String, String> expected = new LinkedHashMap<>(); // Expect empty
+        Map<String, String> expected = new LinkedHashMap<>();
         expected.put("C", "X_X");
 
         CaseInsensitiveStringMultiMap mmap = new CaseInsensitiveStringMultiMap();
@@ -227,14 +227,15 @@ public class CaseInsensitiveStringMultiMapTest {
 
     @Test // A and C will have same bucket by virtue of size 1 array
     public void removeEntriesWithCollision() {
-        Map<String, String> expected = new LinkedHashMap<>(); // Expect empty
+        Map<String, String> expected = new LinkedHashMap<>();
         expected.put("C", "X_X");
         expected.put("b", "b");
         expected.put("aa", "x");
 
         CaseInsensitiveStringMultiMap mmap = new CaseInsensitiveStringMultiMap(1);
         // Additional entries should be ignored
-        mmap.add("b", "b").add("aa", "x").add("a", "x").add("a", "y").add("A", "z").add("a", "XX").add("C", "X_X");
+        mmap.add("a", "x").add("a", "y").add("A", "z").add("a", "Problem").add("C", "X_X").add("aa", "x").add("b", "b");
+
         mmap.remove("a");
         Map<String, String> actual = mmap.toMap();
 


### PR DESCRIPTION
- MultiMap bug fix for deletion with specific collision ordering.
- Updated tests to hit this issue (requires specific ordering in combination with collision).