### PR TITLE
bug(gateway-engine) MultiMap: Correct ordering of values in #toString.

### DIFF
--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/util/CaseInsensitiveStringMultiMap.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/util/CaseInsensitiveStringMultiMap.java
@@ -28,6 +28,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import net.openhft.hashing.Access;
 import net.openhft.hashing.LongHashFunction;
@@ -247,7 +248,10 @@ public class CaseInsensitiveStringMultiMap implements IStringMultiMap, Serializa
 
     @SuppressWarnings("nls")
     private String joinValues(List<Entry<String, String>> pairs) {
-        return pairs.stream().map(Entry::getValue).collect(Collectors.joining(", "));
+        return IntStream.rangeClosed(1, pairs.size())
+                .mapToObj(i -> pairs.get(pairs.size() - i))
+                .map(Entry::getValue)
+                .collect(Collectors.joining(", "));
     }
 
     private static boolean insensitiveEquals(String a, String b) {

--- a/gateway/engine/beans/src/test/java/io/apiman/gateway/engine/beans/util/CaseInsensitiveStringMultiMapTest.java
+++ b/gateway/engine/beans/src/test/java/io/apiman/gateway/engine/beans/util/CaseInsensitiveStringMultiMapTest.java
@@ -114,8 +114,7 @@ public class CaseInsensitiveStringMultiMapTest {
     public void shouldGenerateSensibleToString() throws Exception {
         CaseInsensitiveStringMultiMap actual = new CaseInsensitiveStringMultiMap();
         actual.add("a", "b").add("c", "d").add("a", "x");
-        String str = actual.toString();
-        Assert.assertEquals("{a => [x, b], c => [d]}", str);
+        Assert.assertEquals("{a => [b, x], c => [d]}", actual.toString());
     }
 
     @Test


### PR DESCRIPTION
- MultiMap: Correct ordering of values in #toString. Now respects insertion order.

Hat tip to @outofcoffee 

Also thanks to Holger for neat IntStream [trick](http://stackoverflow.com/a/29409584/2766538). 