### PR TITLE
feat(gateway-vertx) Variables section in config to allow vars transclusion.

### DIFF
--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/common/config/VertxEngineConfig.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/common/config/VertxEngineConfig.java
@@ -427,8 +427,10 @@ public class VertxEngineConfig implements IEngineConfig {
     private class VertxEngineStrSubstitutor extends ApimanStrLookup {
         @Override
         public String lookup(String key) {
-            if (getVariables().containsKey(key)) {
-                return getVariables().getString(key);
+            Map<String, String> flattenedMap = new LinkedHashMap<>();
+            jsonMapToProperties("", getVariables().getMap(), flattenedMap);
+            if (flattenedMap.containsKey(key)) {
+                return flattenedMap.get(key);
             } else {
                 return super.lookup(key);
             }

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/common/config/VertxEngineConfig.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/common/config/VertxEngineConfig.java
@@ -428,7 +428,7 @@ public class VertxEngineConfig implements IEngineConfig {
         @Override
         public String lookup(String key) {
             Map<String, String> flattenedMap = new LinkedHashMap<>();
-            jsonMapToProperties("", getVariables().getMap(), flattenedMap);
+            jsonMapToProperties("", new JsonObject(getVariables().encode()).getMap(), flattenedMap); // TODO tidy up
             if (flattenedMap.containsKey(key)) {
                 return flattenedMap.get(key);
             } else {

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/common/config/VertxEngineConfig.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/common/config/VertxEngineConfig.java
@@ -91,6 +91,7 @@ public class VertxEngineConfig implements IEngineConfig {
     private static final String SSL_TRUSTSTORE = "truststore";
     private static final String SSL_KEYSTORE = "keystore";
     private static final String SSL_PATH = "path";
+    private static final String VARIABLES = "variables";
 
     private JsonObject config;
 
@@ -386,6 +387,10 @@ public class VertxEngineConfig implements IEngineConfig {
         return config.getJsonObject(VERTICLES).getJsonObject(verticleType.toLowerCase());
     }
 
+    private JsonObject getVariables() {
+        return config.getJsonObject(VARIABLES, new JsonObject());
+    }
+
 
 
     /**
@@ -417,6 +422,17 @@ public class VertxEngineConfig implements IEngineConfig {
             .forEach(pair -> map.put(pair.getKey(), SUBSTITUTOR.replace(pair.getValue())));
     }
 
-    private static final StrSubstitutor SUBSTITUTOR = new StrSubstitutor(new ApimanStrLookup());
+    private final StrSubstitutor SUBSTITUTOR = new StrSubstitutor(new VertxEngineStrSubstitutor());
+
+    private class VertxEngineStrSubstitutor extends ApimanStrLookup {
+        @Override
+        public String lookup(String key) {
+            if (getVariables().containsKey(key)) {
+                return getVariables().getString(key);
+            } else {
+                return super.lookup(key);
+            }
+        }
+    }
 
 }

--- a/gateway/test/src/test/resources/vertx3/conf-es.json
+++ b/gateway/test/src/test/resources/vertx3/conf-es.json
@@ -1,9 +1,14 @@
 { // Example ElasticSearch based config
+
+  "variables": {
+    "test-variables-es-type": "jest"
+  },
+
   "registry": {
     "class": "io.apiman.gateway.engine.es.ESRegistry",
     "config": {
       "client": {
-        "type": "jest",
+        "type": "${test-variables-es-type}",
         "cluster-name": "elasticsearch",
         "host": "localhost",
         "port": "9200",

--- a/gateway/test/src/test/resources/vertx3/conf-es.json
+++ b/gateway/test/src/test/resources/vertx3/conf-es.json
@@ -1,14 +1,20 @@
 { // Example ElasticSearch based config
 
   "variables": {
-    "test-variables-es-type": "jest"
+    "test": {
+      "variables": {
+        "es": {
+          "type": "jest"
+        }
+      }
+    }
   },
 
   "registry": {
     "class": "io.apiman.gateway.engine.es.ESRegistry",
     "config": {
       "client": {
-        "type": "${test-variables-es-type}",
+        "type": "${test.variables.es.type}",
         "cluster-name": "elasticsearch",
         "host": "localhost",
         "port": "9200",

--- a/gateway/test/src/test/resources/vertx3/conf-es.json
+++ b/gateway/test/src/test/resources/vertx3/conf-es.json
@@ -2,7 +2,7 @@
 
   "variables": {
     "test": {
-      "variables": {
+      "foo": {
         "es": {
           "type": "jest"
         }
@@ -14,7 +14,7 @@
     "class": "io.apiman.gateway.engine.es.ESRegistry",
     "config": {
       "client": {
-        "type": "${test.variables.es.type}",
+        "type": "${test.foo.es.type}",
         "cluster-name": "elasticsearch",
         "host": "localhost",
         "port": "9200",


### PR DESCRIPTION
This is the equivalent to the Servlet's properties definition feature, and helps avoid repetition - such as repeated ES component config.

Example:

```json
{ 
  "variables": {
    "test": {
      "foo": {
        "es": {
          "type": "jest"
        }
      }
    }
  },
   "registry": {
    "class": "io.apiman.gateway.engine.es.ESRegistry",
    "config": {
      "client": {
        "type": "${test.foo.es.type}",
        "cluster-name": "elasticsearch",
        "host": "localhost",
        "port": "9200",
        "initialize": true
      }
    }
  }
}
```