### PR TITLE
Build fat jar as own classifier & override version command.

### DIFF
--- a/gateway/platforms/vertx3/vertx3/pom.xml
+++ b/gateway/platforms/vertx3/vertx3/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-auth-common</artifactId>
-    </dependency>    
+    </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-auth-oauth2</artifactId>
@@ -217,13 +217,11 @@
         </executions>
       </plugin>
 
-      <!-- You only need the part below if you want to build your application into a fat executable jar.
-      This is a jar that contains all the dependencies required to run it, so you can just run it with
-      java -jar -->
+      <!-- Fat JAR -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4.3</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -231,10 +229,12 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>fat</shadedClassifierName>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
-                    <Main-Class>io.vertx.core.Starter</Main-Class>
+                    <Main-Class>io.apiman.gateway.platforms.vertx3.ApimanLauncher</Main-Class>
                     <Main-Verticle>${main.verticle}</Main-Verticle>
                   </manifestEntries>
                 </transformer>
@@ -244,7 +244,6 @@
               </transformers>
               <artifactSet>
               </artifactSet>
-              <outputFile>${project.build.directory}/${project.artifactId}-${project.version}-fat.jar</outputFile>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/ApimanLauncher.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/ApimanLauncher.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.gateway.platforms.vertx3;
+
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Launcher;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.impl.launcher.VertxCommandLauncher;
+import io.vertx.core.impl.launcher.VertxLifecycleHooks;
+import io.vertx.core.json.JsonObject;
+
+public class ApimanLauncher extends VertxCommandLauncher implements VertxLifecycleHooks {
+
+    /**
+     * Main entry point.
+     *
+     * @param args the user command line arguments.
+     */
+    public static void main(String[] args) {
+      new ApimanLauncher()
+          .register(ApimanVersionCommand.class)
+          .dispatch(args);
+    }
+
+    /**
+     * Utility method to execute a specific command.
+     *
+     * @param cmd  the command
+     * @param args the arguments
+     */
+    public static void executeCommand(String cmd, String... args) {
+      new ApimanLauncher().execute(cmd, args);
+    }
+
+    /**
+     * Hook for sub-classes of {@link Launcher} after the config has been parsed.
+     *
+     * @param config the read config, empty if none are provided.
+     */
+    @Override
+    public void afterConfigParsed(JsonObject config) {
+    }
+
+    /**
+     * Hook for sub-classes of {@link Launcher} before the vertx instance is started.
+     *
+     * @param options the configured Vert.x options. Modify them to customize the Vert.x instance.
+     */
+    @Override
+    public void beforeStartingVertx(VertxOptions options) {
+
+    }
+
+    /**
+     * Hook for sub-classes of {@link Launcher} after the vertx instance is started.
+     *
+     * @param vertx the created Vert.x instance
+     */
+    @Override
+    public void afterStartingVertx(Vertx vertx) {
+
+    }
+
+    /**
+     * Hook for sub-classes of {@link Launcher} before the verticle is deployed.
+     *
+     * @param deploymentOptions the current deployment options. Modify them to customize the deployment.
+     */
+    @Override
+    public void beforeDeployingVerticle(DeploymentOptions deploymentOptions) {
+
+    }
+
+    /**
+     * A deployment failure has been encountered. You can override this method to customize the behavior.
+     * By default it closes the `vertx` instance.
+     *
+     * @param vertx             the vert.x instance
+     * @param mainVerticle      the verticle
+     * @param deploymentOptions the verticle deployment options
+     * @param cause             the cause of the failure
+     */
+    @Override
+    public void handleDeployFailed(Vertx vertx, String mainVerticle, DeploymentOptions deploymentOptions, Throwable cause) {
+      // Default behaviour is to close Vert.x if the deploy failed
+      vertx.close();
+    }
+}

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/ApimanVersionCommand.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/ApimanVersionCommand.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.gateway.platforms.vertx3;
+
+import io.apiman.gateway.engine.Version;
+import io.vertx.core.cli.CLIException;
+import io.vertx.core.cli.annotations.Description;
+import io.vertx.core.cli.annotations.Name;
+import io.vertx.core.cli.annotations.Summary;
+import io.vertx.core.impl.launcher.commands.VersionCommand;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.spi.launcher.DefaultCommand;
+
+@Name("version")
+@Summary("Displays the version.")
+@Description("Prints the version of the apiman gateway.")
+@SuppressWarnings("nls")
+public class ApimanVersionCommand extends DefaultCommand {
+    private static final Logger log = LoggerFactory.getLogger(ApimanVersionCommand.class);
+
+    @Override
+    public void run() throws CLIException {
+      log.info("Apiman " + getApimanVersion());
+      log.info("Vert.x " + VersionCommand.getVersion());
+    }
+
+    private String getApimanVersion() {
+        if (Version.get().getVersionString().contains("SNAPSHOT")) {
+            return Version.get().getVersionString() + " @ " + Version.get().getVersionDate();
+        } else {
+            return Version.get().getVersionString();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -513,6 +513,12 @@
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>apiman-gateway-platforms-vertx3</artifactId>
+        <version>${project.version}</version>
+	<classifier>fat</classifier>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>apiman-gateway-platforms-vertx3-common</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <timestamp>${maven.build.timestamp}</timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
 
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -515,7 +517,7 @@
         <groupId>${project.groupId}</groupId>
         <artifactId>apiman-gateway-platforms-vertx3</artifactId>
         <version>${project.version}</version>
-	<classifier>fat</classifier>
+        <classifier>fat</classifier>
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
@@ -667,9 +669,9 @@
 
       <!-- Third Party Libraries -->
       <dependency>
-	<groupId>net.openhft</groupId>
-	<artifactId>zero-allocation-hashing</artifactId>
-	<version>${version.net.openhft}</version>
+        <groupId>net.openhft</groupId>
+        <artifactId>zero-allocation-hashing</artifactId>
+        <version>${version.net.openhft}</version>
       </dependency>
       <dependency>
         <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
* build(gateway-vertx) Build fat jar as own classifier.
* refactor(gateway-vertx) Own command launcher and override version.
* build(pom) Ensure timestamp is populated

```
Apr 23, 2017 5:53:20 PM io.apiman.gateway.platforms.vertx3.ApimanVersionCommand
INFO: Apiman 1.2.10-SNAPSHOT @ 2017-04-23 16:45:39
Apr 23, 2017 5:53:20 PM io.apiman.gateway.platforms.vertx3.ApimanVersionCommand
INFO: Vert.x 3.4.0
```

For releases date is not shown