### PR TITLE
test(gateway-vertx) Fix build issue that could occur due to TZ contraindiction

### DIFF
--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/components/jdbc/IJdbcConnection.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/components/jdbc/IJdbcConnection.java
@@ -20,7 +20,7 @@ import io.apiman.gateway.engine.async.IAsyncResultHandler;
 import java.sql.Connection;
 
 /**
- * This is essentially an simple, async subset rendition of the standard SQL {@link Connection} interface.
+ * This is a simple, async subset rendition of the standard SQL {@link Connection} interface.
  *
  * Extending the {@link AutoCloseable} interface means we can use this with the
  * Java 7 try-catch-autoclose feature.

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/components/jdbc/IJdbcResultSet.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/components/jdbc/IJdbcResultSet.java
@@ -50,6 +50,7 @@ public interface IJdbcResultSet {
 
     /**
      * Point at next row in result set
+     * @return true if next
      */
     boolean next();
 

--- a/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/components/jdbc/JdbcTestSuite.java
+++ b/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/components/jdbc/JdbcTestSuite.java
@@ -22,8 +22,10 @@ import io.apiman.gateway.platforms.vertx3.components.jdbc.suitetests.NestedQuery
 import io.apiman.gateway.platforms.vertx3.components.jdbc.suitetests.QueryTest;
 
 import java.sql.SQLException;
+import java.util.TimeZone;
 
 import org.h2.tools.Server;
+import org.joda.time.DateTimeZone;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -39,17 +41,22 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({ CreateTableTest.class, ExecuteTest.class, QueryTest.class, NestedQueryTest.class })
 @SuppressWarnings("nls")
 public class JdbcTestSuite {
-
-    public static Server h2Server;
-
     private static JdbcOptionsBean options = new JdbcOptionsBean();
     private static final String JDBC_URL = String.format("jdbc:h2:tcp://localhost/%s/JdbcClientComponentTestDb",
             System.getProperty("java.io.tmpdir"));
+
     static {
+        // Important, this should occur BEFORE H2 is loaded otherwise it'll use local TZ and break everything.
+        System.err.println("Permanently attempting to set the TZ to UTC.");
+        System.setProperty("user.timezone", "UTC");
+        TimeZone.setDefault(TimeZone.getTimeZone("Etc/UTC"));
+        DateTimeZone.setDefault(DateTimeZone.UTC);
         options.setJdbcUrl(JDBC_URL);
         options.setAutoCommit(true);
         options.setPoolName("JdbcClientComponentTestPool");
     }
+
+    public static Server h2Server;
 
     /**
      * Slow to start & stop so do this as infrequently as possible.


### PR DESCRIPTION
Generally this would only occur if there was a TZ disagreement between various parts of the system. Previous failed attempts to fix this missed that H2 picks up its TZ from System properties and can't be overridden via API.