### PR TITLE
fix(gateway-vertx) Ensure ApiVerticle parses body early to avoid losing it if OAuth2 kicks in.

### DIFF
--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/ApiResourceImpl.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/ApiResourceImpl.java
@@ -27,8 +27,6 @@ import io.apiman.gateway.engine.beans.exceptions.PublishingException;
 import io.apiman.gateway.engine.beans.exceptions.RegistrationException;
 import io.apiman.gateway.platforms.vertx3.common.config.VertxEngineConfig;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.vertx.core.Handler;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.Json;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -88,13 +86,11 @@ public class ApiResourceImpl implements IApiResource, IRouteBuilder {
     }
 
     public void publish() {
-        routingContext.request().bodyHandler((Handler<Buffer>) buffer -> {
-            try {
-                publish(Json.decodeValue(buffer.toString("utf-8"), Api.class));
-            } catch (Exception e) {
-                error(routingContext, HttpResponseStatus.BAD_REQUEST, e.getMessage(), e);
-            }
-        });
+      try {
+          publish(Json.decodeValue(routingContext.getBodyAsString(), Api.class));
+      } catch (Exception e) {
+          error(routingContext, HttpResponseStatus.BAD_REQUEST, e.getMessage(), e);
+      }
     }
 
     @Override

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/ClientResourceImpl.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/ClientResourceImpl.java
@@ -24,8 +24,6 @@ import io.apiman.gateway.engine.beans.Client;
 import io.apiman.gateway.engine.beans.exceptions.RegistrationException;
 import io.apiman.gateway.platforms.vertx3.common.config.VertxEngineConfig;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.vertx.core.Handler;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.Json;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -79,13 +77,11 @@ public class ClientResourceImpl implements IClientResource, IRouteBuilder {
     }
 
     public void register() {
-        routingContext.request().bodyHandler((Handler<Buffer>) buffer -> {
-            try {
-                register(Json.decodeValue(buffer.toString("utf-8"), Client.class)); //$NON-NLS-1$
-            } catch (Exception e) {
-                error(routingContext, HttpResponseStatus.BAD_REQUEST, e.getMessage(), e);
-            }
-        });
+        try {
+            register(Json.decodeValue(routingContext.getBodyAsString(), Client.class));
+        } catch (Exception e) {
+            error(routingContext, HttpResponseStatus.BAD_REQUEST, e.getMessage(), e);
+        }
     }
 
     @Override

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/auth/AuthFactory.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/auth/AuthFactory.java
@@ -43,9 +43,17 @@ public class AuthFactory {
         }
     }
 
-    public static AuthHandler getAuth(Vertx vertx, Router router, VertxEngineConfig apimanConfig, JsonObject auth) {
-        String type = auth.getString("type", "NONE");
-        JsonObject authConfig = auth.getJsonObject("config", new JsonObject());
+    /**
+     * Creates an auth handler of the type indicated in the `auth` section of config.
+     *
+     * @param vertx the vert.x instance
+     * @param router the vert.x web router to protect
+     * @param apimanConfig the apiman config
+     * @return an auth handler
+     */
+    public static AuthHandler getAuth(Vertx vertx, Router router, VertxEngineConfig apimanConfig) {
+        String type = apimanConfig.getAuth().getString("type", "NONE");
+        JsonObject authConfig = apimanConfig.getAuth().getJsonObject("config", new JsonObject());
 
         switch(AuthType.getType(type)) {
         case BASIC:


### PR DESCRIPTION
This was only evident when doing some manual testing using KC OAuth2, as automated tests only use BASIC. 