### PR TITLE
fix(gateway-vertx) HttpConnector predicate looked in wrong map for Content-Length

### DIFF
--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/HttpConnector.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/HttpConnector.java
@@ -192,7 +192,7 @@ class HttpConnector implements IApiConnectionResponse, IApiConnection {
 
         clientRequest.exceptionHandler(exceptionHandler);
 
-        if (options.hasDataPolicy() || !clientRequest.headers().contains("Content-Length")) {
+        if (options.hasDataPolicy() || !apiRequest.getHeaders().containsKey("Content-Length")) {
             clientRequest.headers().remove("Content-Length");
             clientRequest.setChunked(true);
         }


### PR DESCRIPTION
Was looking in the outbound set which was obviously always empty, whoops. It caused chunked mode to be used from the gateway to API (but would reappear for client). 