### PR TITLE
fix(gateway-vertx) Ensure #resume called in error cases before #end to avoid potential TCP hang.

### DIFF
--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/http/HttpPolicyAdapter.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/http/HttpPolicyAdapter.java
@@ -139,16 +139,19 @@ public class HttpPolicyAdapter {
 
             @Override
             public void write(StringBuffer buffer) {
+                vertxRequest.resume();
                 vertxResponse.end(buffer.toString());
             }
 
             @Override
             public void write(StringBuilder builder) {
+                vertxRequest.resume();
                 vertxResponse.end(builder.toString());
             }
 
             @Override
             public void write(String body) {
+                vertxRequest.resume();
                 vertxResponse.end(body);
             }
 
@@ -170,16 +173,19 @@ public class HttpPolicyAdapter {
 
             @Override
             public void write(StringBuffer buffer) {
+                vertxRequest.resume();
                 vertxResponse.end(buffer.toString());
             }
 
             @Override
             public void write(StringBuilder builder) {
+                vertxRequest.resume();
                 vertxResponse.end(builder.toString());
             }
 
             @Override
             public void write(String body) {
+                vertxRequest.resume();
                 vertxResponse.end(body);
             }
 


### PR DESCRIPTION
Thanks to @EricWittmann for helping me discover this one. I was aided in fixing the issue by @vietj's comment @ https://github.com/eclipse/vert.x/issues/1244#issuecomment-165532673.