### PR TITLE
fix(gateway-vertx): InitVerticle log use {0} syntax instead of {}.

### DIFF
--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/verticles/InitVerticle.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/verticles/InitVerticle.java
@@ -56,12 +56,12 @@ public class InitVerticle extends ApimanVerticleBase {
                 log.fatal("Failed to deploy verticles: " + compositeResult.cause().getMessage());
                 start.fail(compositeResult.cause());
             } else {
-                log.info("Apiman Version: {}", ApimanVersionCommand.getApimanVersion());
-                if (log.isDebugEnabled()) log.debug("Git commit info: {}", Version.get().getVerbose());
-                log.info("Vert.x Version: {}", VersionCommand.getVersion());
+                log.info("Apiman Version: {0}", ApimanVersionCommand.getApimanVersion());
+                if (log.isDebugEnabled()) log.debug("Git commit info: {0}", Version.get().getVerbose());
+                log.info("Vert.x Version: {0}", VersionCommand.getVersion());
 
                 log.info("Successfully deployed all verticles");
-                log.info("Gateway API port: {}", apimanConfig.getPort(ApiVerticle.VERTICLE_TYPE));
+                log.info("Gateway API port: {0}", apimanConfig.getPort(ApiVerticle.VERTICLE_TYPE));
 
                 start.complete();
             }


### PR DESCRIPTION
InitVerticle log use {0} syntax instead of {} as this ensures JUL will still work.