### PR TITLE
build(manager-api-micro): Missing ICU dep for micro

### DIFF
--- a/manager/api/micro/pom.xml
+++ b/manager/api/micro/pom.xml
@@ -115,6 +115,10 @@
       <groupId>io.searchbox</groupId>
       <artifactId>jest-common</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.ibm.icu</groupId>
+      <artifactId>icu4j</artifactId>
+    </dependency>
 
     <!-- Jetty -->
     <dependency>


### PR DESCRIPTION
@EricWittmann I think this issue was caused when you added something around i18n to WAR but it wasn't also added to Micro. Not sure if I need to add it anywhere else? 

It seems to cause some failures in certain parts of the UI when using any of the micro distros, anyway.