### PR TITLE
Update SSLSessionStrategy for devMode to allow all TLS version

### DIFF
--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/ssl/SSLSessionStrategyFactory.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/ssl/SSLSessionStrategyFactory.java
@@ -245,7 +245,7 @@ public class SSLSessionStrategyFactory {
                 + " This is extremely unsafe for production. Caveat utilitor!"); //$NON-NLS-1$
 
         try {
-            SSLContext sslContext = SSLContext.getInstance("TLSv1"); //$NON-NLS-1$
+            SSLContext sslContext = SSLContext.getInstance("TLS"); //$NON-NLS-1$
 
             // This accepts anything.
             sslContext.init(null, new X509TrustManager[] { new X509TrustManager() {


### PR DESCRIPTION
The previous code allow only TLS v1.0 when devMode is true.

With this modification, all versions of TLS will be accepted.