### PR TITLE
fix(gateway-engine) Clearer handling of unexpected exceptions in ErrorWriter impls

### DIFF
--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/EngineErrorResponse.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/EngineErrorResponse.java
@@ -21,12 +21,16 @@ import java.io.StringWriter;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
 /**
  * Models an error from the engine.
  *
  * @author Marc Savy <msavy@redhat.com>
  */
 @XmlRootElement
+@JsonInclude(Include.NON_NULL)
 public class EngineErrorResponse implements Serializable {
 
     private static final long serialVersionUID = 8881390951647532958L;

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/TracePolicyErrorWriter.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/TracePolicyErrorWriter.java
@@ -16,6 +16,7 @@
 
 package io.apiman.gateway.engine.impl;
 
+import io.apiman.gateway.engine.beans.ApiRequest;
 import io.apiman.gateway.engine.beans.EngineErrorResponse;
 
 /**
@@ -27,11 +28,18 @@ public class TracePolicyErrorWriter extends DefaultPolicyErrorWriter {
      * @see io.apiman.gateway.engine.impl.DefaultPolicyErrorWriter#createErrorResponse(java.lang.Throwable)
      */
     @Override
-    protected EngineErrorResponse createErrorResponse(Throwable error, int statusCode) {
-        EngineErrorResponse response = super.createErrorResponse(error, statusCode);
+    protected EngineErrorResponse createErrorResponse(Throwable error, String message, int statusCode) {
+        EngineErrorResponse response = super.createErrorResponse(error, message, statusCode);
         response.setTrace(error);
-        response.setResponseCode(statusCode);
         return response;
+    }
+
+    @Override
+    protected String createErrorMessage(ApiRequest request, Throwable error) {
+        if (error.getMessage() == null) {
+            return error.getClass().getCanonicalName();
+        }
+        return error.getMessage();
     }
 
 }


### PR DESCRIPTION
* For example if NPE occurs in a custom policy it now returns a clearer message to the user.