### PR TITLE
build(distro-vertx) Ensure shade plugin merges providers

### DIFF
--- a/gateway/platforms/vertx3/vertx3/pom.xml
+++ b/gateway/platforms/vertx3/vertx3/pom.xml
@@ -253,7 +253,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -264,6 +264,7 @@
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <shadedClassifierName>fat</shadedClassifierName>
               <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
                     <Main-Class>io.apiman.gateway.platforms.vertx3.ApimanLauncher</Main-Class>


### PR DESCRIPTION
Current configuration was causing providers manifests to be overwritten.