### PR TITLE
Fixes broken ES cache population.

### DIFF
--- a/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/ESCacheStoreComponent.java
+++ b/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/ESCacheStoreComponent.java
@@ -73,7 +73,7 @@ public class ESCacheStoreComponent extends AbstractESComponent implements ICache
         ESCacheEntry entry = new ESCacheEntry();
         entry.setData(null);
         entry.setExpiresOn(System.currentTimeMillis() + (timeToLive * 1000));
-        entry.setHead(mapper.writeValueAsString(entry));
+        entry.setHead(mapper.writeValueAsString(jsonObject));
         Index index = new Index.Builder(entry).refresh(false).index(getIndexName())
                 .type("cacheEntry").id(cacheKey).build(); //$NON-NLS-1$
         try {


### PR DESCRIPTION
### Background

Cache population for ES doesn't work for the simple/non-binary implementation.

### This PR

Ensures the JSON object is set in the `head`, instead of the cache entry itself(!) in `ESCacheStoreComponent.put()`, from where it is expected to be read in `ESCacheStoreComponent.get()`.