### PR TITLE
Adds Hazelcast cache store implementation.

### DIFF
--- a/gateway/engine/hazelcast/pom.xml
+++ b/gateway/engine/hazelcast/pom.xml
@@ -26,10 +26,18 @@
     </dependency>
 
     <!-- Third Party Dependencies -->
+
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast</artifactId>
+      <!--
+        Important: Hazelcast should be added to the container's classpath (e.g. 'lib'),
+        not packaged within the engine deployable (e.g. WAR), otherwise odd classloading
+        issues can occur.
+       -->
+      <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>

--- a/gateway/engine/hazelcast/pom.xml
+++ b/gateway/engine/hazelcast/pom.xml
@@ -30,6 +30,25 @@
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!-- Test only -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/AbstractHazelcastComponent.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/AbstractHazelcastComponent.java
@@ -27,6 +27,7 @@ import java.util.Map;
  * @author Pete Cornish
  */
 abstract class AbstractHazelcastComponent {
+    public static final String CONFIG_EAGER_INIT = "eager-init";
     private final String storeName;
     private final Config config;
     private final Object mutex = new Object();
@@ -39,8 +40,8 @@ abstract class AbstractHazelcastComponent {
     /**
      * Constructor.
      */
-    public AbstractHazelcastComponent(String storeName) {
-        this(storeName, null);
+    public AbstractHazelcastComponent(Map<String, String> componentConfig, String storeName) {
+        this(componentConfig, storeName, null);
     }
 
     /**
@@ -48,9 +49,13 @@ abstract class AbstractHazelcastComponent {
      *
      * @param config the config
      */
-    public AbstractHazelcastComponent(String storeName, Config config) {
+    public AbstractHazelcastComponent(Map<String, String> componentConfig, String storeName, Config config) {
         this.storeName = storeName;
         this.config = config;
+
+        if (Boolean.valueOf(componentConfig.get(CONFIG_EAGER_INIT))) {
+            getHazelcastInstance();
+        }
     }
 
     /**

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/AbstractHazelcastComponent.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/AbstractHazelcastComponent.java
@@ -40,7 +40,7 @@ abstract class AbstractHazelcastComponent {
      * Constructor.
      */
     public AbstractHazelcastComponent(String storeName) {
-        this(storeName, new Config());
+        this(storeName, null);
     }
 
     /**

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheEntry.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheEntry.java
@@ -16,13 +16,15 @@
 package io.apiman.gateway.engine.hazelcast;
 
 
+import java.io.Serializable;
+
 /**
  * This is what gets stored in the Hazelcast cache.
  *
  * @author Pete Cornish
  */
-public class HazelcastCacheEntry<H> {
-    private H head;
+public class HazelcastCacheEntry implements Serializable {
+    private String head;
     private String data;
     private long expiresOn;
 
@@ -63,14 +65,14 @@ public class HazelcastCacheEntry<H> {
     /**
      * @return the head
      */
-    public H getHead() {
+    public String getHead() {
         return head;
     }
 
     /**
      * @param head the head to set
      */
-    public void setHead(H head) {
+    public void setHead(String head) {
         this.head = head;
     }
 }

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheEntry.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheEntry.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.hazelcast;
+
+
+/**
+ * This is what gets stored in the Hazelcast cache.
+ *
+ * @author Pete Cornish
+ */
+public class HazelcastCacheEntry<H> {
+    private H head;
+    private String data;
+    private long expiresOn;
+
+    /**
+     * Constructor.
+     */
+    public HazelcastCacheEntry() {
+    }
+
+    /**
+     * @return the data
+     */
+    public String getData() {
+        return data;
+    }
+
+    /**
+     * @param data the data to set
+     */
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    /**
+     * @return the expiresOn
+     */
+    public long getExpiresOn() {
+        return expiresOn;
+    }
+
+    /**
+     * @param expiresOn the expiresOn to set
+     */
+    public void setExpiresOn(long expiresOn) {
+        this.expiresOn = expiresOn;
+    }
+
+    /**
+     * @return the head
+     */
+    public H getHead() {
+        return head;
+    }
+
+    /**
+     * @param head the head to set
+     */
+    public void setHead(H head) {
+        this.head = head;
+    }
+}

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheStoreComponent.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheStoreComponent.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * A Hazelcast implementation of a cache store.
@@ -53,8 +54,8 @@ public class HazelcastCacheStoreComponent extends AbstractHazelcastComponent imp
     /**
      * Constructor.
      */
-    public HazelcastCacheStoreComponent() {
-        super(STORE_NAME);
+    public HazelcastCacheStoreComponent(Map<String, String> componentConfig) {
+        super(componentConfig, STORE_NAME);
     }
 
     /**
@@ -62,8 +63,8 @@ public class HazelcastCacheStoreComponent extends AbstractHazelcastComponent imp
      *
      * @param config the config
      */
-    public HazelcastCacheStoreComponent(Config config) {
-        super(STORE_NAME, config);
+    public HazelcastCacheStoreComponent(Map<String, String> componentConfig, Config config) {
+        super(componentConfig, STORE_NAME, config);
     }
 
     /**

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheStoreComponent.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheStoreComponent.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2017 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.hazelcast;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hazelcast.config.Config;
+import io.apiman.gateway.engine.DependsOnComponents;
+import io.apiman.gateway.engine.async.AsyncResultImpl;
+import io.apiman.gateway.engine.async.IAsyncHandler;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.components.IBufferFactoryComponent;
+import io.apiman.gateway.engine.components.ICacheStoreComponent;
+import io.apiman.gateway.engine.io.IApimanBuffer;
+import io.apiman.gateway.engine.io.ISignalReadStream;
+import io.apiman.gateway.engine.io.ISignalWriteStream;
+import org.apache.commons.codec.binary.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * A Hazelcast implementation of a cache store.
+ *
+ * @author Pete Cornish
+ */
+@DependsOnComponents({IBufferFactoryComponent.class})
+public class HazelcastCacheStoreComponent extends AbstractHazelcastComponent implements ICacheStoreComponent {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HazelcastCacheStoreComponent.class);
+    private static final String STORE_NAME = "cache"; //$NON-NLS-1$
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    static {
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    private IBufferFactoryComponent bufferFactory;
+
+    /**
+     * Constructor.
+     */
+    public HazelcastCacheStoreComponent() {
+        super(STORE_NAME);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param config the config
+     */
+    public HazelcastCacheStoreComponent(Config config) {
+        super(STORE_NAME, config);
+    }
+
+    /**
+     * @param bufferFactory the bufferFactory to set
+     */
+    public void setBufferFactory(IBufferFactoryComponent bufferFactory) {
+        this.bufferFactory = bufferFactory;
+    }
+
+    /**
+     * @see ICacheStoreComponent#put(String, Object, long)
+     */
+    @Override
+    public <T> void put(String cacheKey, T jsonObject, long timeToLive) throws IOException {
+        final HazelcastCacheEntry<T> entry = new HazelcastCacheEntry<>();
+        entry.setData(null);
+        entry.setExpiresOn(System.currentTimeMillis() + (timeToLive * 1000));
+        entry.setHead(jsonObject);
+        try {
+            getMap().put(cacheKey, mapper.writeValueAsString(entry));
+        } catch (Throwable e) {
+            LOGGER.error("Error writing cache entry with key: {}", cacheKey, e);
+        }
+    }
+
+    /**
+     * @see ICacheStoreComponent#putBinary(String, Object, long)
+     */
+    @Override
+    public <T> ISignalWriteStream putBinary(final String cacheKey, final T jsonObject, final long timeToLive)
+            throws IOException {
+        final HazelcastCacheEntry<T> entry = new HazelcastCacheEntry<>();
+        entry.setExpiresOn(System.currentTimeMillis() + (timeToLive * 1000));
+        entry.setHead(jsonObject);
+
+        final IApimanBuffer data = bufferFactory.createBuffer();
+        return new ISignalWriteStream() {
+            boolean finished = false;
+            boolean aborted = false;
+
+            @Override
+            public void abort(Throwable t) {
+                finished = true;
+                aborted = false;
+            }
+
+            @Override
+            public boolean isFinished() {
+                return finished;
+            }
+
+            @Override
+            public void write(IApimanBuffer chunk) {
+                data.append(chunk);
+            }
+
+            @Override
+            public void end() {
+                if (!aborted) {
+                    entry.setData(Base64.encodeBase64String(data.getBytes()));
+                    try {
+                        getMap().put(cacheKey, mapper.writeValueAsString(entry));
+                    } catch (Throwable e) {
+                        LOGGER.error("Error writing binary cache entry with key: {}", cacheKey, e);
+                    }
+                }
+                finished = true;
+            }
+        };
+    }
+
+    /**
+     * @see ICacheStoreComponent#get(String, Class, IAsyncResultHandler)
+     */
+    @Override
+    public <T> void get(String cacheKey, final Class<T> type, final IAsyncResultHandler<T> handler) {
+        try {
+            final String mapEntry = (String) getMap().get(cacheKey);
+            if (null != mapEntry) {
+                try {
+                    @SuppressWarnings("unchecked")
+                    final HazelcastCacheEntry<T> cacheEntry = mapper.readValue(mapEntry, HazelcastCacheEntry.class);
+                    handler.handle(AsyncResultImpl.create(cacheEntry.getHead()));
+                } catch (Exception e) {
+                    LOGGER.error("Error reading cache entry with key: {}", cacheKey, e);
+                    handler.handle(AsyncResultImpl.create((T) null));
+                }
+            } else {
+                handler.handle(AsyncResultImpl.create((T) null));
+            }
+        } catch (Throwable e) {
+            handler.handle(AsyncResultImpl.create(e, type));
+        }
+    }
+
+    /**
+     * @see ICacheStoreComponent#getBinary(String, Class, IAsyncResultHandler)
+     */
+    @Override
+    public <T> void getBinary(final String cacheKey, final Class<T> type,
+                              final IAsyncResultHandler<ISignalReadStream<T>> handler) {
+        try {
+            final String mapEntry = (String) getMap().get(cacheKey);
+
+            // Did the fetch succeed? If not, return null.
+            if (null == mapEntry) {
+                handler.handle(AsyncResultImpl.create((ISignalReadStream<T>) null));
+                return;
+            }
+
+            @SuppressWarnings("unchecked")
+            final HazelcastCacheEntry cacheEntry = mapper.readValue(mapEntry, HazelcastCacheEntry.class);
+
+            // Is the cache entry expired?  If so return null.
+            if (System.currentTimeMillis() > cacheEntry.getExpiresOn()) {
+                // Cache item has expired.  Return null instead of the cached data.
+                handler.handle(AsyncResultImpl.create((ISignalReadStream<T>) null));
+                return;
+            }
+
+            try {
+                @SuppressWarnings("unchecked") final T head = (T) cacheEntry.getHead();
+                final String b64Data = cacheEntry.getData();
+                final IApimanBuffer data = bufferFactory.createBuffer(Base64.decodeBase64(b64Data));
+                final ISignalReadStream<T> rval = new ISignalReadStream<T>() {
+                    IAsyncHandler<IApimanBuffer> bodyHandler;
+                    IAsyncHandler<Void> endHandler;
+                    boolean finished = false;
+                    boolean aborted = false;
+
+                    @Override
+                    public void bodyHandler(IAsyncHandler<IApimanBuffer> bodyHandler) {
+                        this.bodyHandler = bodyHandler;
+                    }
+
+                    @Override
+                    public void endHandler(IAsyncHandler<Void> endHandler) {
+                        this.endHandler = endHandler;
+                    }
+
+                    @Override
+                    public T getHead() {
+                        return head;
+                    }
+
+                    @Override
+                    public boolean isFinished() {
+                        return finished;
+                    }
+
+                    @Override
+                    public void abort(Throwable t) {
+                        finished = true;
+                        aborted = true;
+                    }
+
+                    @Override
+                    public void transmit() {
+                        if (!aborted) {
+                            bodyHandler.handle(data);
+                            endHandler.handle(null);
+                        }
+                        finished = true;
+                    }
+                };
+                handler.handle(AsyncResultImpl.create(rval));
+            } catch (Throwable e) {
+                LOGGER.error("Error reading binary cache entry with key: {}", cacheKey, e);
+                handler.handle(AsyncResultImpl.create((ISignalReadStream<T>) null));
+            }
+        } catch (Throwable e) {
+            handler.handle(AsyncResultImpl.create((ISignalReadStream<T>) null));
+        }
+    }
+}

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheStoreComponent.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheStoreComponent.java
@@ -17,13 +17,14 @@ package io.apiman.gateway.engine.hazelcast;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hazelcast.config.Config;
 import io.apiman.gateway.engine.DependsOnComponents;
 import io.apiman.gateway.engine.async.AsyncResultImpl;
 import io.apiman.gateway.engine.async.IAsyncHandler;
 import io.apiman.gateway.engine.async.IAsyncResultHandler;
 import io.apiman.gateway.engine.components.IBufferFactoryComponent;
 import io.apiman.gateway.engine.components.ICacheStoreComponent;
+import io.apiman.gateway.engine.hazelcast.config.HazelcastInstanceManager;
+import io.apiman.gateway.engine.hazelcast.model.HazelcastCacheEntry;
 import io.apiman.gateway.engine.io.IApimanBuffer;
 import io.apiman.gateway.engine.io.ISignalReadStream;
 import io.apiman.gateway.engine.io.ISignalWriteStream;
@@ -60,11 +61,9 @@ public class HazelcastCacheStoreComponent extends AbstractHazelcastComponent imp
 
     /**
      * Constructor.
-     *
-     * @param config the config
      */
-    public HazelcastCacheStoreComponent(Map<String, String> componentConfig, Config config) {
-        super(componentConfig, STORE_NAME, config);
+    public HazelcastCacheStoreComponent(HazelcastInstanceManager instanceManager, Map<String, String> componentConfig) {
+        super(instanceManager, componentConfig, STORE_NAME);
     }
 
     /**

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastRateLimiterComponent.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastRateLimiterComponent.java
@@ -23,6 +23,8 @@ import io.apiman.gateway.engine.components.rate.RateLimitResponse;
 import io.apiman.gateway.engine.rates.RateBucketPeriod;
 import io.apiman.gateway.engine.rates.RateLimiterBucket;
 
+import java.util.Map;
+
 /**
  * Rate limiter component backed by a Hazelcast Map. This allows rate limiting
  * to be done across nodes in a cluster of gateways.
@@ -37,8 +39,8 @@ public class HazelcastRateLimiterComponent extends AbstractHazelcastComponent im
     /**
      * Constructor.
      */
-    public HazelcastRateLimiterComponent() {
-        super(STORE_NAME);
+    public HazelcastRateLimiterComponent(Map<String, String> componentConfig) {
+        super(componentConfig, STORE_NAME);
     }
 
     /**
@@ -46,8 +48,8 @@ public class HazelcastRateLimiterComponent extends AbstractHazelcastComponent im
      *
      * @param config the config
      */
-    public HazelcastRateLimiterComponent(Config config) {
-        super(STORE_NAME, config);
+    public HazelcastRateLimiterComponent(Map<String, String> componentConfig, Config config) {
+        super(componentConfig, STORE_NAME, config);
     }
 
     /**

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastRateLimiterComponent.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastRateLimiterComponent.java
@@ -58,10 +58,10 @@ public class HazelcastRateLimiterComponent extends AbstractHazelcastComponent im
                        final long increment, final IAsyncResultHandler<RateLimitResponse> handler) {
         RateLimiterBucket bucket;
         synchronized (mutex) {
-            bucket = (RateLimiterBucket) getSharedState().get(bucketId);
+            bucket = (RateLimiterBucket) getMap().get(bucketId);
             if (bucket == null) {
                 bucket = new RateLimiterBucket();
-                getSharedState().put(bucketId, bucket);
+                getMap().put(bucketId, bucket);
             }
             bucket.resetIfNecessary(period);
 
@@ -77,7 +77,7 @@ public class HazelcastRateLimiterComponent extends AbstractHazelcastComponent im
             response.setReset(reset);
             response.setRemaining(limit - bucket.getCount());
             handler.handle(AsyncResultImpl.create(response));
-            getSharedState().put(bucketId, bucket);
+            getMap().put(bucketId, bucket);
         }
     }
 }

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastRateLimiterComponent.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastRateLimiterComponent.java
@@ -15,7 +15,6 @@
  */
 package io.apiman.gateway.engine.hazelcast;
 
-import com.hazelcast.config.Config;
 import io.apiman.gateway.engine.async.AsyncResultImpl;
 import io.apiman.gateway.engine.async.IAsyncResultHandler;
 import io.apiman.gateway.engine.components.IRateLimiterComponent;
@@ -41,15 +40,6 @@ public class HazelcastRateLimiterComponent extends AbstractHazelcastComponent im
      */
     public HazelcastRateLimiterComponent(Map<String, String> componentConfig) {
         super(componentConfig, STORE_NAME);
-    }
-
-    /**
-     * Constructor.
-     *
-     * @param config the config
-     */
-    public HazelcastRateLimiterComponent(Map<String, String> componentConfig, Config config) {
-        super(componentConfig, STORE_NAME, config);
     }
 
     /**

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastSharedStateComponent.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastSharedStateComponent.java
@@ -52,9 +52,9 @@ public class HazelcastSharedStateComponent extends AbstractHazelcastComponent im
     @Override
     public <T> void getProperty(String namespace, String propertyName, T defaultValue, IAsyncResultHandler<T> handler) {
         final String namespacedKey = buildNamespacedKey(namespace, propertyName);
-        if (getSharedState().containsKey(namespacedKey)) {
+        if (getMap().containsKey(namespacedKey)) {
             try {
-                T rval = (T) getSharedState().get(namespacedKey);
+                T rval = (T) getMap().get(namespacedKey);
                 handler.handle(AsyncResultImpl.create(rval));
             } catch (Exception e) {
                 handler.handle(AsyncResultImpl.create(e));
@@ -72,7 +72,7 @@ public class HazelcastSharedStateComponent extends AbstractHazelcastComponent im
     public <T> void setProperty(String namespace, String propertyName, T value, IAsyncResultHandler<Void> handler) {
         final String namespacedKey = buildNamespacedKey(namespace, propertyName);
         try {
-            getSharedState().put(namespacedKey, value);
+            getMap().put(namespacedKey, value);
             handler.handle(AsyncResultImpl.create((Void) null));
         } catch (Exception e) {
             handler.handle(AsyncResultImpl.create(e));
@@ -86,7 +86,7 @@ public class HazelcastSharedStateComponent extends AbstractHazelcastComponent im
     public <T> void clearProperty(String namespace, String propertyName, IAsyncResultHandler<Void> handler) {
         final String namespacedKey = buildNamespacedKey(namespace, propertyName);
         try {
-            getSharedState().remove(namespacedKey);
+            getMap().remove(namespacedKey);
             handler.handle(AsyncResultImpl.create((Void) null));
         } catch (Exception e) {
             handler.handle(AsyncResultImpl.create(e));

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastSharedStateComponent.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastSharedStateComponent.java
@@ -20,6 +20,8 @@ import io.apiman.gateway.engine.async.AsyncResultImpl;
 import io.apiman.gateway.engine.async.IAsyncResultHandler;
 import io.apiman.gateway.engine.components.ISharedStateComponent;
 
+import java.util.Map;
+
 /**
  * Shared state component backed by a Hazelcast Map. This allows the shared state
  * to be easily clusterable.
@@ -32,8 +34,8 @@ public class HazelcastSharedStateComponent extends AbstractHazelcastComponent im
     /**
      * Constructor.
      */
-    public HazelcastSharedStateComponent() {
-        super(STORE_NAME);
+    public HazelcastSharedStateComponent(Map<String, String> componentConfig) {
+        super(componentConfig, STORE_NAME);
     }
 
     /**
@@ -41,8 +43,8 @@ public class HazelcastSharedStateComponent extends AbstractHazelcastComponent im
      *
      * @param config the config
      */
-    public HazelcastSharedStateComponent(Config config) {
-        super(STORE_NAME, config);
+    public HazelcastSharedStateComponent(Map<String, String> componentConfig, Config config) {
+        super(componentConfig, STORE_NAME, config);
     }
 
     /**

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastSharedStateComponent.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastSharedStateComponent.java
@@ -15,7 +15,6 @@
  */
 package io.apiman.gateway.engine.hazelcast;
 
-import com.hazelcast.config.Config;
 import io.apiman.gateway.engine.async.AsyncResultImpl;
 import io.apiman.gateway.engine.async.IAsyncResultHandler;
 import io.apiman.gateway.engine.components.ISharedStateComponent;
@@ -36,15 +35,6 @@ public class HazelcastSharedStateComponent extends AbstractHazelcastComponent im
      */
     public HazelcastSharedStateComponent(Map<String, String> componentConfig) {
         super(componentConfig, STORE_NAME);
-    }
-
-    /**
-     * Constructor.
-     *
-     * @param config the config
-     */
-    public HazelcastSharedStateComponent(Map<String, String> componentConfig, Config config) {
-        super(componentConfig, STORE_NAME, config);
     }
 
     /**

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/config/HazelcastInstanceManager.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/config/HazelcastInstanceManager.java
@@ -1,0 +1,71 @@
+package io.apiman.gateway.engine.hazelcast.config;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Manages Hazelcast instances to reduce the amount of initialisation work on each I/O operation.
+ *
+ * @author Pete Cornish
+ */
+public final class HazelcastInstanceManager {
+    public static final HazelcastInstanceManager DEFAULT_MANAGER = new HazelcastInstanceManager();
+
+    private final Object mutex = new Object();
+    private final Map<String, Map<String, ?>> stores = Collections.synchronizedMap(new HashMap<>());
+    private Config overrideConfig;
+    private HazelcastInstance hazelcastInstance;
+
+    /**
+     * Generally, you don't want to initialise your own manager - instead, use the {@link #DEFAULT_MANAGER}.
+     */
+    public HazelcastInstanceManager() {
+    }
+
+    /**
+     * Override the default Hazelcast configuration discovery strategy.
+     */
+    public void setOverrideConfig(Config overrideConfig) {
+        this.overrideConfig = overrideConfig;
+    }
+
+    /**
+     * @param storeName a name to associate with the instance
+     * @return a new or existing Hazelcast instance for the given store name
+     */
+    @SuppressWarnings("unchecked")
+    public <T> Map<String, T> getHazelcastMap(String storeName) {
+        Map<String, ?> hzMap = stores.get(storeName);
+        if (null == hzMap) {
+            synchronized (mutex) {
+                if (null == hazelcastInstance) {
+                    hazelcastInstance = Hazelcast.newHazelcastInstance(overrideConfig);
+                }
+                if (null == stores.get(storeName)) {
+                    hzMap = hazelcastInstance.getMap(storeName);
+                    stores.put(storeName, hzMap);
+                }
+            }
+        }
+        return (Map<String, T>) hzMap;
+    }
+
+    /**
+     * Shut down the Hazelcast instance.
+     */
+    public void reset() {
+        if (null != hazelcastInstance) {
+            synchronized (mutex) {
+                if (null == hazelcastInstance) {
+                    hazelcastInstance.shutdown();
+                    hazelcastInstance = null;
+                }
+            }
+        }
+    }
+}

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/model/HazelcastCacheEntry.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/model/HazelcastCacheEntry.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.apiman.gateway.engine.hazelcast;
+package io.apiman.gateway.engine.hazelcast.model;
 
 
 import java.io.Serializable;

--- a/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheStoreComponentTest.java
+++ b/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheStoreComponentTest.java
@@ -1,6 +1,7 @@
 package io.apiman.gateway.engine.hazelcast;
 
 import com.hazelcast.config.*;
+import io.apiman.gateway.engine.hazelcast.model.Example;
 import io.apiman.gateway.engine.impl.ByteBufferFactoryComponent;
 import io.apiman.gateway.engine.io.ByteBuffer;
 import io.apiman.gateway.engine.io.ISignalReadStream;
@@ -114,16 +115,16 @@ public class HazelcastCacheStoreComponentTest {
     @Test
     public void putAndGetFromCluster() throws Exception {
         final String cacheKey = "cacheKeySimple";
-        final String cacheValue = "cacheValue";
+        final Example cacheValue = new Example("cacheValue");
 
         member1.put(cacheKey, cacheValue, 120);
-        member1.get(cacheKey, String.class, result -> {
+        member1.get(cacheKey, Example.class, result -> {
             assertFalse("Result should be retrieved successfully from initial member", result.isError());
             assertEquals(cacheValue, result.getResult());
         });
 
         // verify propagation
-        member2.get(cacheKey, String.class, result -> {
+        member2.get(cacheKey, Example.class, result -> {
             assertFalse("Result should be retrieved successfully from peer member", result.isError());
             assertEquals(cacheValue, result.getResult());
         });
@@ -151,8 +152,8 @@ public class HazelcastCacheStoreComponentTest {
         });
 
         // verify propagation
-        member2.getBinary(cacheKey, String.class, result -> {
-            assertFalse("Result should be retrieved successfully from peer member", result.isError());
+            member2.getBinary(cacheKey, String.class, result -> {
+                assertFalse("Result should be retrieved successfully from peer member", result.isError());
 
             final ISignalReadStream<String> readStream = result.getResult();
             readStream.bodyHandler(bodyResult -> assertEquals(cacheBody, new String(bodyResult.getBytes())));
@@ -163,3 +164,4 @@ public class HazelcastCacheStoreComponentTest {
         });
     }
 }
+

--- a/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheStoreComponentTest.java
+++ b/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheStoreComponentTest.java
@@ -1,26 +1,16 @@
 package io.apiman.gateway.engine.hazelcast;
 
-import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.JoinConfig;
-import com.hazelcast.config.MulticastConfig;
-import com.hazelcast.config.TcpIpConfig;
 import io.apiman.gateway.engine.hazelcast.config.HazelcastInstanceManager;
 import io.apiman.gateway.engine.hazelcast.model.Example;
 import io.apiman.gateway.engine.impl.ByteBufferFactoryComponent;
 import io.apiman.gateway.engine.io.ByteBuffer;
 import io.apiman.gateway.engine.io.ISignalReadStream;
 import io.apiman.gateway.engine.io.ISignalWriteStream;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-
+import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -30,87 +20,15 @@ import static org.junit.Assert.assertFalse;
  * @author Pete Cornish
  */
 public class HazelcastCacheStoreComponentTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(HazelcastCacheStoreComponentTest.class);
+    private HazelcastCacheStoreComponent component;
 
-    private static volatile boolean shouldRun;
-    private static CountDownLatch latch;
-    private static TestObjectHolder first, second;
+    @Before
+    public void setUp() {
+        final Config config = HazelcastConfigUtil.buildConfigWithDisabledNetwork();
+        HazelcastInstanceManager.DEFAULT_MANAGER.setOverrideConfig(config);
 
-    @BeforeClass
-    public static void setUp() throws Exception {
-        shouldRun = true;
-        latch = new CountDownLatch(2);
-        first = startMemberThread("member1", 5701, 5702);
-        second = startMemberThread("member2", 5702, 5701);
-
-        // Instances are configured with a minimum cluster size of 2, so they will block on initialisation
-        // until this condition is set.
-        LOGGER.info("Waiting for quorum");
-        latch.await();
-    }
-
-    @AfterClass
-    public static void tearDown() throws InterruptedException {
-        LOGGER.info("Stopping Hazelcast instances");
-        first.manager.reset();
-        second.manager.reset();
-
-        LOGGER.info("Waiting for threads to stop");
-        shouldRun = false;
-        first.thread.join();
-        second.thread.join();
-    }
-
-    /**
-     * Start a {@link HazelcastCacheStoreComponent} with its own Hazelcast instance in its own thread,
-     * peered with the member on the given port.
-     *
-     * @param name       the unique name of this instance
-     * @param memberPort the port on which this member should listen
-     * @param peerPort   the port of this member's peer in the group
-     * @return TestObjectHolder      the instance, member and its thread
-     */
-    private static TestObjectHolder startMemberThread(String name, int memberPort, int peerPort) {
-        final Config config = new Config() {{
-            setInstanceName(name);
-            getGroupConfig().setName("test-cluster");
-            setProperty("hazelcast.initial.min.cluster.size", "2");
-
-            getNetworkConfig().setPort(memberPort);
-            getNetworkConfig().setJoin(new JoinConfig() {{
-                setMulticastConfig(new MulticastConfig() {{
-                    setEnabled(false);
-                }});
-                setTcpIpConfig(new TcpIpConfig() {{
-                    setEnabled(true);
-                    addMember("localhost:" + peerPort);
-                }});
-                setAwsConfig(new AwsConfig() {{
-                    setEnabled(false);
-                }});
-            }});
-        }};
-
-        final HazelcastInstanceManager manager = new HazelcastInstanceManager();
-        manager.setOverrideConfig(config);
-
-        final Map<String, String> componentConfig = new HashMap<>();
-        componentConfig.put(AbstractHazelcastComponent.CONFIG_EAGER_INIT, "false");
-
-        final HazelcastCacheStoreComponent member = new HazelcastCacheStoreComponent(manager, componentConfig);
-        member.setBufferFactory(new ByteBufferFactoryComponent());
-
-        final Thread memberThread = new Thread(() -> {
-            // force the member to initialise, then signal when complete
-            member.getMap();
-            latch.countDown();
-
-            // await shutdown command
-            while (shouldRun) Thread.yield();
-        });
-
-        memberThread.start();
-        return new TestObjectHolder(manager, member, memberThread);
+        component = new HazelcastCacheStoreComponent(emptyMap());
+        component.setBufferFactory(new ByteBufferFactoryComponent());
     }
 
     @Test
@@ -118,15 +36,9 @@ public class HazelcastCacheStoreComponentTest {
         final String cacheKey = "cacheKeySimple";
         final Example cacheValue = new Example("cacheValue");
 
-        first.cacheStore.put(cacheKey, cacheValue, 120);
-        first.cacheStore.get(cacheKey, Example.class, result -> {
+        component.put(cacheKey, cacheValue, 120);
+        component.get(cacheKey, Example.class, result -> {
             assertFalse("Result should be retrieved successfully from initial member", result.isError());
-            assertEquals(cacheValue, result.getResult());
-        });
-
-        // verify propagation
-        second.cacheStore.get(cacheKey, Example.class, result -> {
-            assertFalse("Result should be retrieved successfully from peer member", result.isError());
             assertEquals(cacheValue, result.getResult());
         });
     }
@@ -137,11 +49,11 @@ public class HazelcastCacheStoreComponentTest {
         final String cacheHead = "cacheHead";
         final String cacheBody = "cacheBody";
 
-        final ISignalWriteStream writeStream = first.cacheStore.putBinary(cacheKey, cacheHead, 120);
+        final ISignalWriteStream writeStream = component.putBinary(cacheKey, cacheHead, 120);
         writeStream.write(new ByteBuffer(cacheBody));
         writeStream.end();
 
-        first.cacheStore.getBinary(cacheKey, String.class, result -> {
+        component.getBinary(cacheKey, String.class, result -> {
             assertFalse("Result should be retrieved successfully from initial member", result.isError());
 
             final ISignalReadStream<String> readStream = result.getResult();
@@ -151,29 +63,5 @@ public class HazelcastCacheStoreComponentTest {
 
             assertEquals(cacheHead, readStream.getHead());
         });
-
-        // verify propagation
-        second.cacheStore.getBinary(cacheKey, String.class, result -> {
-            assertFalse("Result should be retrieved successfully from peer member", result.isError());
-
-            final ISignalReadStream<String> readStream = result.getResult();
-            readStream.bodyHandler(bodyResult -> assertEquals(cacheBody, new String(bodyResult.getBytes())));
-            readStream.endHandler(endResult -> { /* no op */});
-            readStream.transmit();
-
-            assertEquals(cacheHead, readStream.getHead());
-        });
-    }
-
-    private static class TestObjectHolder {
-        HazelcastInstanceManager manager;
-        HazelcastCacheStoreComponent cacheStore;
-        Thread thread;
-
-        TestObjectHolder(HazelcastInstanceManager manager, HazelcastCacheStoreComponent cacheStore, Thread thread) {
-            this.manager = manager;
-            this.cacheStore = cacheStore;
-            this.thread = thread;
-        }
     }
 }

--- a/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheStoreComponentTest.java
+++ b/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheStoreComponentTest.java
@@ -1,0 +1,165 @@
+package io.apiman.gateway.engine.hazelcast;
+
+import com.hazelcast.config.*;
+import io.apiman.gateway.engine.impl.ByteBufferFactoryComponent;
+import io.apiman.gateway.engine.io.ByteBuffer;
+import io.apiman.gateway.engine.io.ISignalReadStream;
+import io.apiman.gateway.engine.io.ISignalWriteStream;
+import org.junit.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.function.BiConsumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Tests for {@link HazelcastCacheStoreComponent}.
+ *
+ * @author Pete Cornish
+ */
+public class HazelcastCacheStoreComponentTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HazelcastCacheStoreComponentTest.class);
+
+    private static HazelcastCacheStoreComponent member1;
+    private static HazelcastCacheStoreComponent member2;
+    private static Thread thread1;
+    private static Thread thread2;
+    private static volatile boolean shouldRun;
+    private static CountDownLatch latch;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        shouldRun = true;
+        latch = new CountDownLatch(2);
+
+        startMemberThread("member1", 5701, 5702, (member, thread) -> {
+            member1 = member;
+            thread1 = thread;
+        });
+
+        startMemberThread("member2", 5702, 5701, (member, thread) -> {
+            member2 = member;
+            thread2 = thread;
+        });
+
+        // Instances are configured with a minimum cluster size of 2, so they will block on initialisation
+        // until this condition is set.
+        LOGGER.info("Waiting for quorum");
+        latch.await();
+    }
+
+    @AfterClass
+    public static void tearDown() throws InterruptedException {
+        LOGGER.info("Stopping Hazelcast instances");
+        member1.reset();
+        member2.reset();
+
+        LOGGER.info("Waiting for threads to stop");
+        shouldRun = false;
+        thread1.join();
+        thread2.join();
+    }
+
+    /**
+     * Start a {@link HazelcastCacheStoreComponent} with its own Hazelcast instance in its own thread,
+     * peered with the member on the given port.
+     *
+     * @param instanceName the unique name of this instance
+     * @param memberPort   the port on which this member should listen
+     * @param peerPort     the port of this member's peer in the group
+     * @param callback     consumes the member and its thread
+     */
+    private static void startMemberThread(String instanceName, int memberPort, int peerPort,
+                                   BiConsumer<HazelcastCacheStoreComponent, Thread> callback) {
+
+        final Config config = new Config() {{
+            setInstanceName(instanceName);
+            getGroupConfig().setName("test-cluster");
+            setProperty("hazelcast.initial.min.cluster.size", "2");
+
+            getNetworkConfig().setPort(memberPort);
+            getNetworkConfig().setJoin(new JoinConfig() {{
+                setMulticastConfig(new MulticastConfig() {{
+                    setEnabled(false);
+                }});
+                setTcpIpConfig(new TcpIpConfig() {{
+                    setEnabled(true);
+                    addMember("localhost:" + peerPort);
+                }});
+                setAwsConfig(new AwsConfig() {{
+                    setEnabled(false);
+                }});
+            }});
+        }};
+
+        final HazelcastCacheStoreComponent member = new HazelcastCacheStoreComponent(config);
+        member.setBufferFactory(new ByteBufferFactoryComponent());
+
+        final Thread memberThread = new Thread(() -> {
+            // force the member to initialise, then signal when complete
+            member.getMap();
+            latch.countDown();
+
+            // wait shutdown command
+            while (shouldRun) Thread.yield();
+        });
+
+        callback.accept(member, memberThread);
+        memberThread.start();
+    }
+
+    @Test
+    public void putAndGetFromCluster() throws Exception {
+        final String cacheKey = "cacheKeySimple";
+        final String cacheValue = "cacheValue";
+
+        member1.put(cacheKey, cacheValue, 120);
+        member1.get(cacheKey, String.class, result -> {
+            assertFalse("Result should be retrieved successfully from initial member", result.isError());
+            assertEquals(cacheValue, result.getResult());
+        });
+
+        // verify propagation
+        member2.get(cacheKey, String.class, result -> {
+            assertFalse("Result should be retrieved successfully from peer member", result.isError());
+            assertEquals(cacheValue, result.getResult());
+        });
+    }
+
+    @Test
+    public void putAndGetBinaryFromCluster() throws Exception {
+        final String cacheKey = "cacheKeyBinary";
+        final String cacheHead = "cacheHead";
+        final String cacheBody = "cacheBody";
+
+        final ISignalWriteStream writeStream = member1.putBinary(cacheKey, cacheHead, 120);
+        writeStream.write(new ByteBuffer(cacheBody));
+        writeStream.end();
+
+        member1.getBinary(cacheKey, String.class, result -> {
+            assertFalse("Result should be retrieved successfully from initial member", result.isError());
+
+            final ISignalReadStream<String> readStream = result.getResult();
+            readStream.bodyHandler(bodyResult -> assertEquals(cacheBody, new String(bodyResult.getBytes())));
+            readStream.endHandler(endResult -> { /* no op */});
+            readStream.transmit();
+
+            assertEquals(cacheHead, readStream.getHead());
+        });
+
+        // verify propagation
+        member2.getBinary(cacheKey, String.class, result -> {
+            assertFalse("Result should be retrieved successfully from peer member", result.isError());
+
+            final ISignalReadStream<String> readStream = result.getResult();
+            readStream.bodyHandler(bodyResult -> assertEquals(cacheBody, new String(bodyResult.getBytes())));
+            readStream.endHandler(endResult -> { /* no op */});
+            readStream.transmit();
+
+            assertEquals(cacheHead, readStream.getHead());
+        });
+    }
+}

--- a/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastConfigUtil.java
+++ b/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastConfigUtil.java
@@ -1,0 +1,30 @@
+package io.apiman.gateway.engine.hazelcast;
+
+import com.hazelcast.config.*;
+
+/**
+ * @author Pete Cornish
+ */
+final class HazelcastConfigUtil {
+    private HazelcastConfigUtil() {
+    }
+
+    /**
+     * @return a Hazelcast configuration with network options disabled.
+     */
+    static Config buildConfigWithDisabledNetwork() {
+        return new Config() {{
+            getNetworkConfig().setJoin(new JoinConfig() {{
+                setMulticastConfig(new MulticastConfig() {{
+                    setEnabled(false);
+                }});
+                setTcpIpConfig(new TcpIpConfig() {{
+                    setEnabled(false);
+                }});
+                setAwsConfig(new AwsConfig() {{
+                    setEnabled(false);
+                }});
+            }});
+        }};
+    }
+}

--- a/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastRateLimiterComponentTest.java
+++ b/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastRateLimiterComponentTest.java
@@ -5,6 +5,7 @@ import io.apiman.gateway.engine.rates.RateBucketPeriod;
 import org.junit.Before;
 import org.junit.Test;
 
+import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -20,7 +21,7 @@ public class HazelcastRateLimiterComponentTest {
     @Before
     public void setUp() throws Exception {
         final Config config = HazelcastConfigUtil.buildConfigWithDisabledNetwork();
-        component = new HazelcastRateLimiterComponent(config);
+        component = new HazelcastRateLimiterComponent(emptyMap(), config);
     }
 
     @Test

--- a/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastRateLimiterComponentTest.java
+++ b/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastRateLimiterComponentTest.java
@@ -1,6 +1,7 @@
 package io.apiman.gateway.engine.hazelcast;
 
-import com.hazelcast.config.*;
+import com.hazelcast.config.Config;
+import io.apiman.gateway.engine.hazelcast.config.HazelcastInstanceManager;
 import io.apiman.gateway.engine.rates.RateBucketPeriod;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,7 +22,9 @@ public class HazelcastRateLimiterComponentTest {
     @Before
     public void setUp() throws Exception {
         final Config config = HazelcastConfigUtil.buildConfigWithDisabledNetwork();
-        component = new HazelcastRateLimiterComponent(emptyMap(), config);
+        HazelcastInstanceManager.DEFAULT_MANAGER.setOverrideConfig(config);
+
+        component = new HazelcastRateLimiterComponent(emptyMap());
     }
 
     @Test

--- a/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastRateLimiterComponentTest.java
+++ b/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastRateLimiterComponentTest.java
@@ -1,0 +1,48 @@
+package io.apiman.gateway.engine.hazelcast;
+
+import com.hazelcast.config.*;
+import io.apiman.gateway.engine.rates.RateBucketPeriod;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link HazelcastRateLimiterComponent}.
+ *
+ * @author Pete Cornish
+ */
+public class HazelcastRateLimiterComponentTest {
+    private HazelcastRateLimiterComponent component;
+
+    @Before
+    public void setUp() throws Exception {
+        final Config config = HazelcastConfigUtil.buildConfigWithDisabledNetwork();
+        component = new HazelcastRateLimiterComponent(config);
+    }
+
+    @Test
+    public void updateBucket_LimitNotReached() throws Exception {
+        component.accept("bucketId", RateBucketPeriod.Hour, 10, 1, result -> {
+            assertFalse("The bucket should be updated successfully", result.isError());
+            assertEquals("The remaining count should be correct", 9, result.getResult().getRemaining());
+            assertTrue(result.getResult().isAccepted());
+        });
+    }
+
+    @Test
+    public void updateBucket_LimitReached() throws Exception {
+        component.accept("bucketId", RateBucketPeriod.Hour, 10, 10, result -> {
+            assertFalse("The bucket should be updated successfully", result.isError());
+        });
+
+        // should now be at limit
+        component.accept("bucketId", RateBucketPeriod.Hour, 10, 1, result -> {
+            assertFalse("The bucket should be updated successfully", result.isError());
+            assertEquals("The remaining count should be correct", -1, result.getResult().getRemaining());
+            assertFalse(result.getResult().isAccepted());
+        });
+    }
+}

--- a/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastSharedStateComponentTest.java
+++ b/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastSharedStateComponentTest.java
@@ -1,0 +1,48 @@
+package io.apiman.gateway.engine.hazelcast;
+
+import com.hazelcast.config.Config;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link HazelcastSharedStateComponent}.
+
+ * @author Pete Cornish
+ */
+public class HazelcastSharedStateComponentTest {
+    private HazelcastSharedStateComponent component;
+
+    @Before
+    public void setUp() throws Exception {
+        final Config config = HazelcastConfigUtil.buildConfigWithDisabledNetwork();
+        component = new HazelcastSharedStateComponent(config);
+    }
+
+    @Test
+    public void getSetAndClearProperty() throws Exception {
+        final String namespace = "namespace";
+        final String propertyName = "propertyName";
+        final String propertyValue = "propertyValue";
+
+        component.setProperty(namespace, propertyName, propertyValue, result -> {
+            assertFalse("The property should be set successfully", result.isError());
+        });
+
+        component.getProperty(namespace, propertyName, null, result -> {
+            assertFalse("The property should be fetched successfully", result.isError());
+            assertEquals(propertyValue, result.getResult());
+        });
+
+        component.clearProperty(namespace, propertyName, result -> {
+            assertFalse("The property should be cleared successfully", result.isError());
+        });
+
+        // retrieve the default for a non-existent property
+        component.getProperty(namespace, propertyName, "defaultValue", result -> {
+            assertFalse("The default property value should be returned", result.isError());
+            assertEquals("defaultValue", result.getResult());
+        });
+    }
+}

--- a/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastSharedStateComponentTest.java
+++ b/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastSharedStateComponentTest.java
@@ -4,6 +4,7 @@ import com.hazelcast.config.Config;
 import org.junit.Before;
 import org.junit.Test;
 
+import static java.util.Collections.emptyMap;
 import static org.junit.Assert.*;
 
 /**
@@ -17,7 +18,7 @@ public class HazelcastSharedStateComponentTest {
     @Before
     public void setUp() throws Exception {
         final Config config = HazelcastConfigUtil.buildConfigWithDisabledNetwork();
-        component = new HazelcastSharedStateComponent(config);
+        component = new HazelcastSharedStateComponent(emptyMap(), config);
     }
 
     @Test

--- a/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastSharedStateComponentTest.java
+++ b/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastSharedStateComponentTest.java
@@ -1,6 +1,7 @@
 package io.apiman.gateway.engine.hazelcast;
 
 import com.hazelcast.config.Config;
+import io.apiman.gateway.engine.hazelcast.config.HazelcastInstanceManager;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -18,7 +19,9 @@ public class HazelcastSharedStateComponentTest {
     @Before
     public void setUp() throws Exception {
         final Config config = HazelcastConfigUtil.buildConfigWithDisabledNetwork();
-        component = new HazelcastSharedStateComponent(emptyMap(), config);
+        HazelcastInstanceManager.DEFAULT_MANAGER.setOverrideConfig(config);
+
+        component = new HazelcastSharedStateComponent(emptyMap());
     }
 
     @Test

--- a/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/model/Example.java
+++ b/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/model/Example.java
@@ -1,0 +1,38 @@
+package io.apiman.gateway.engine.hazelcast.model;
+
+import java.util.Objects;
+
+/**
+ * @author Pete Cornish
+ */
+public class Example {
+    private String data;
+
+    public Example() {
+    }
+
+    public Example(String data) {
+        this.data = data;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Example)) return false;
+        Example example = (Example) o;
+        return Objects.equals(data, example.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data);
+    }
+}

--- a/gateway/engine/hazelcast/src/test/resources/log4j.properties
+++ b/gateway/engine/hazelcast/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %m%n
+
+# Root logger option
+log4j.rootLogger=INFO, stdout

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <version.io.vertx>3.4.2</version.io.vertx>
     <version.net.openhft>0.6</version.net.openhft>
     <version.com.ibm.icu4j>57.1</version.com.ibm.icu4j>
-    <version.com.hazelcast>3.6.4</version.com.hazelcast>
+    <version.com.hazelcast>3.9.1</version.com.hazelcast>
     <version.com.jcbai>1.16</version.com.jcbai>
     <version.javax.json.javax.json-api>1.0</version.javax.json.javax.json-api>
     <version.pl.allegro.tech.embedded-elastic>2.5.0</version.pl.allegro.tech.embedded-elastic>


### PR DESCRIPTION
### Background

Hazelcast is one of the existing shared store providers. It did not have an implementation for caching.

### This PR

* Adds a Hazelcast cache store implementation, modelled on the ES one.
* Improves test coverage of Hazelcast components.

### Impl notes

@msavy @EricWittmann the cache entry beans for ES, ISPN and now Hazelcast (`ESCacheEntry`, `InfinispanCacheEntry`, `HazelcastCacheEntry`) are essentially duplicates. As is much of the store/retrieve logic in `getBinary` and `putBinary` for ES and Hazelcast. Do you think it makes sense to factor these out into a shared/common module under `engine`?