### PR TITLE
Allows Prometheus metrics implementation to be used with no client ID

### DIFF
--- a/gateway/engine/prometheus/pom.xml
+++ b/gateway/engine/prometheus/pom.xml
@@ -45,5 +45,12 @@
       <groupId>com.squareup.okhttp</groupId>
       <artifactId>okhttp</artifactId>
     </dependency>
+
+    <!-- Test only -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/gateway/engine/prometheus/src/test/resources/log4j.properties
+++ b/gateway/engine/prometheus/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %m%n
+
+# Root logger option
+log4j.rootLogger=INFO, stdout


### PR DESCRIPTION
### Background

The Prometheus metrics implementation throws an exception when `null` is passed as the client ID. This is because client ID is a mandatory label, and labels can't be `null`.

### This PR

* Allows Prometheus metrics implementation to be used with no client ID.
* Reenables the Prometheus metrics tests (which start their own server).