### PR TITLE
Fix example configuration with comma separated list

### DIFF
--- a/distro/tomcat8/src/main/resources/overlay/conf/apiman.properties
+++ b/distro/tomcat8/src/main/resources/overlay/conf/apiman.properties
@@ -117,9 +117,9 @@ apiman-gateway.connector-factory.tls.devMode=true
 # Uses JVM defaults depending if not explicitly provided.
 # See: https://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html
 # You may wish to consider global JVM settings by modifying java.security
-#apiman-gateway.connector-factory.tls.allowedProtocols=TLSv1.2,TLSv1.1
-#apiman-gateway.connector-factory.tls.disallowedProtocols=SSLv1,SSLv2
-#apiman-gateway.connector-factory.tls.allowedCiphers=TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+#apiman-gateway.connector-factory.tls.allowedProtocols=TLSv1.2\,TLSv1.1
+#apiman-gateway.connector-factory.tls.disallowedProtocols=SSLv1\,SSLv2
+#apiman-gateway.connector-factory.tls.allowedCiphers=TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA\,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
 #apiman-gateway.connector-factory.tls.disallowedCiphers=RC4
 
 # Whether certificate host checks should be bypassed. *Use with great care.*

--- a/distro/wildfly10/src/main/resources/overlay/standalone/configuration/apiman.properties
+++ b/distro/wildfly10/src/main/resources/overlay/standalone/configuration/apiman.properties
@@ -124,9 +124,9 @@ apiman-gateway.connector-factory.tls.devMode=true
 # Uses JVM defaults depending if not explicitly provided.
 # See: https://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html
 # You may wish to consider global JVM settings by modifying java.security
-#apiman-gateway.connector-factory.tls.allowedProtocols=TLSv1.2,TLSv1.1
-#apiman-gateway.connector-factory.tls.disallowedProtocols=SSLv1,SSLv2
-#apiman-gateway.connector-factory.tls.allowedCiphers=TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+#apiman-gateway.connector-factory.tls.allowedProtocols=TLSv1.2\,TLSv1.1
+#apiman-gateway.connector-factory.tls.disallowedProtocols=SSLv1\,SSLv2
+#apiman-gateway.connector-factory.tls.allowedCiphers=TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA\,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
 #apiman-gateway.connector-factory.tls.disallowedCiphers=RC4
 
 # Whether certificate host checks should be bypassed. *Use with great care.*

--- a/distro/wildfly11/src/main/resources/overlay/standalone/configuration/apiman.properties
+++ b/distro/wildfly11/src/main/resources/overlay/standalone/configuration/apiman.properties
@@ -124,9 +124,9 @@ apiman-gateway.connector-factory.tls.devMode=true
 # Uses JVM defaults depending if not explicitly provided.
 # See: https://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html
 # You may wish to consider global JVM settings by modifying java.security
-#apiman-gateway.connector-factory.tls.allowedProtocols=TLSv1.2,TLSv1.1
-#apiman-gateway.connector-factory.tls.disallowedProtocols=SSLv1,SSLv2
-#apiman-gateway.connector-factory.tls.allowedCiphers=TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+#apiman-gateway.connector-factory.tls.allowedProtocols=TLSv1.2\,TLSv1.1
+#apiman-gateway.connector-factory.tls.disallowedProtocols=SSLv1\,SSLv2
+#apiman-gateway.connector-factory.tls.allowedCiphers=TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA\,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
 #apiman-gateway.connector-factory.tls.disallowedCiphers=RC4
 
 # Whether certificate host checks should be bypassed. *Use with great care.*


### PR DESCRIPTION
A comma  separated list work only if the comma is escaped. Because the communs-configuration library (version 1.10) is called with getString(), then that return only the first word.
With the value allowedProtocols=TLSv1.2,TLSv1.1, apiman load only "TLSv1.2".

To fix issues we can:
- Escaped comma,
- Move library  communs-configuration to 2.2 ( more complicated)
- Use getArrayString(), many refactoring because getString is use in generic code for String and List