### PR TITLE
Fix cache with different query params

### DIFF
--- a/common/config/src/main/java/io/apiman/common/config/options/AbstractOptions.java
+++ b/common/config/src/main/java/io/apiman/common/config/options/AbstractOptions.java
@@ -16,6 +16,7 @@
 package io.apiman.common.config.options;
 
 import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -99,6 +100,9 @@ public abstract class AbstractOptions {
      * @return the submap
      */
     public static Map<String, String> getSubmap(Map<String, String> mapIn, String subkey) {
+        if (mapIn == null || mapIn.isEmpty()) {
+            return Collections.emptyMap();
+        }
         // Get map sub-element.
         return mapIn.entrySet().stream()
                 .filter(entry -> entry.getKey().toLowerCase().startsWith(subkey.toLowerCase()))

--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/CachingPolicy.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/CachingPolicy.java
@@ -19,6 +19,8 @@ import static java.util.Optional.ofNullable;
 
 import java.io.IOException;
 
+import org.apache.commons.codec.digest.Md5Crypt;
+
 import io.apiman.gateway.engine.async.IAsyncResult;
 import io.apiman.gateway.engine.async.IAsyncResultHandler;
 import io.apiman.gateway.engine.beans.ApiRequest;


### PR DESCRIPTION
The buildCacheID method ignored the query params.
I added a md5 of query params.

Maybe it's better to make a hash of rawrequest to cache POST/ PUT/PATCH verb.