### PR TITLE
Fix Tomcat logging

### DIFF
--- a/distro/tomcat8/pom.xml
+++ b/distro/tomcat8/pom.xml
@@ -42,12 +42,6 @@
       <artifactId>apiman-distro-es</artifactId>
       <type>war</type>
     </dependency>
-
-    <!-- tomcat default logging provider for slf4j -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/gateway/platforms/war/tomcat8/api/pom.xml
+++ b/gateway/platforms/war/tomcat8/api/pom.xml
@@ -67,7 +67,20 @@
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
       <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
     </dependency>
-    
+
+    <!-- Logging provider -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>apiman-common-logging-log4j2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jcl</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/gateway/platforms/war/tomcat8/api/src/main/resources/log4j2.xml
+++ b/gateway/platforms/war/tomcat8/api/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/gateway/platforms/war/tomcat8/gateway/pom.xml
+++ b/gateway/platforms/war/tomcat8/gateway/pom.xml
@@ -16,6 +16,20 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>apiman-gateway-platforms-war</artifactId>
     </dependency>
+
+    <!-- Logging provider -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>apiman-common-logging-log4j2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jcl</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/gateway/platforms/war/tomcat8/gateway/src/main/resources/log4j2.xml
+++ b/gateway/platforms/war/tomcat8/gateway/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/manager/api/war/tomcat8/pom.xml
+++ b/manager/api/war/tomcat8/pom.xml
@@ -111,14 +111,6 @@
 
     <!-- Other Libs -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <artifactId>slf4j-log4j12</artifactId>
-      <groupId>org.slf4j</groupId>
-    </dependency>
-    <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jaxrs</artifactId>
       <exclusions>
@@ -127,6 +119,20 @@
           <artifactId>jsr311-api</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <!-- Logging provider -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>apiman-common-logging-log4j2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jcl</artifactId>
     </dependency>
 
     <!-- Spec libs -->

--- a/manager/ui/war/tomcat8/pom.xml
+++ b/manager/ui/war/tomcat8/pom.xml
@@ -26,17 +26,19 @@
     </dependency>
     
     <!-- Other Libs -->
+
+    <!-- Logging provider -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>apiman-common-logging-log4j2</artifactId>
+    </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <artifactId>slf4j-log4j12</artifactId>
-      <groupId>org.slf4j</groupId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jcl</artifactId>
     </dependency>
   </dependencies>
 

--- a/manager/ui/war/tomcat8/src/main/resources/log4j2.xml
+++ b/manager/ui/war/tomcat8/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -812,11 +812,6 @@
         <version>${version.org.slf4j}</version>
       </dependency>
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-jdk14</artifactId>
-        <version>${version.org.slf4j}</version>
-      </dependency>
-      <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-core</artifactId>
         <version>${version.org.infinispan}</version>
@@ -973,6 +968,11 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
+        <version>${version.org.apache.logging.log4j}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-jcl</artifactId>
         <version>${version.org.apache.logging.log4j}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
This PR fixes the SLF4J binding errors and Log4J configuration issues with the Tomcat WARs.

## How
* Tomcat WARs now use the Log4J2 provider, via the project's common logging module.
* In addition, commons-logging is routed to Log4J2.