### PR TITLE
Fixes plugin logging in Tomcat distributions.

### DIFF
--- a/gateway/platforms/war/tomcat8/api/pom.xml
+++ b/gateway/platforms/war/tomcat8/api/pom.xml
@@ -70,6 +70,10 @@
 
     <!-- Logging provider -->
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>apiman-common-logging-log4j2</artifactId>
     </dependency>

--- a/gateway/platforms/war/tomcat8/gateway/pom.xml
+++ b/gateway/platforms/war/tomcat8/gateway/pom.xml
@@ -19,6 +19,10 @@
 
     <!-- Logging provider -->
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>apiman-common-logging-log4j2</artifactId>
     </dependency>

--- a/manager/api/war/tomcat8/pom.xml
+++ b/manager/api/war/tomcat8/pom.xml
@@ -123,6 +123,10 @@
 
     <!-- Logging provider -->
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>apiman-common-logging-log4j2</artifactId>
     </dependency>

--- a/manager/ui/war/tomcat8/pom.xml
+++ b/manager/ui/war/tomcat8/pom.xml
@@ -25,9 +25,11 @@
       <type>war</type>
     </dependency>
     
-    <!-- Other Libs -->
-
     <!-- Logging provider -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>apiman-common-logging-log4j2</artifactId>


### PR DESCRIPTION
Following on from https://github.com/apiman/apiman/pull/654, this PR adds the SLF4J API dependency to Tomcat distributions to ensure logs from plugins are also routed correctly.