### PR TITLE
Allow policies to suppress and permit headers

### DIFF
--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/IConnectorConfig.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/IConnectorConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.gateway.engine;
+
+import java.util.Set;
+
+/**
+ * Allows policies to mutate certain HTTP connector attributes.
+ *
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+public interface IConnectorConfig {
+    /**
+     * Suppress the named request header
+     *
+     * @param headerName the header name
+     */
+    void suppressRequestHeader(String headerName);
+
+    /**
+     * Suppress the named response header
+     *
+     * @param headerName the header name
+     */
+    void suppressResponseHeader(String headerName);
+
+    /**
+     * Permit a request header that may be suppressed.
+     *
+     * @param headerName the header name
+     */
+    void permitRequestHeader(String headerName);
+
+    /**
+     * Permit a response header that may be suppressed.
+     *
+     * @param headerName the header name
+     */
+    void permitResponseHeader(String headerName);
+
+    /**
+     * Unmodifiable request headers.
+     *
+     * @return the suppressed request headers
+     */
+    Set<String> getSuppressedRequestHeaders();
+
+    /**
+     * Unmodifiable response headers.
+     *
+     * @return the suppressed response headers
+     */
+    Set<String> getSuppressedResponseHeaders();
+
+
+}

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/IConnectorConfig.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/IConnectorConfig.java
@@ -53,14 +53,18 @@ public interface IConnectorConfig {
     void permitResponseHeader(String headerName);
 
     /**
-     * Unmodifiable request headers.
+     * <em>Unmodifiable</em> request headers.
+     *
+     * Use permit and suppress methods to mutate.
      *
      * @return the suppressed request headers
      */
     Set<String> getSuppressedRequestHeaders();
 
     /**
-     * Unmodifiable response headers.
+     * <em>Unmodifiable</em> response headers.
+     *
+     * Use permit and suppress methods to mutate.
      *
      * @return the suppressed response headers
      */

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/IConnectorFactory.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/IConnectorFactory.java
@@ -34,9 +34,20 @@ public interface IConnectorFactory {
      * @param api the managed API being invoked
      * @param requiredAuthType the required authorization type
      * @param hasDataPolicy if the policy chain contains a data policy
+     * @param connectorConfig the backend connector config. May be modified by policies.
      * @return a connector to the back-end API
      */
-    public IApiConnector createConnector(ApiRequest request, Api api,
-            RequiredAuthType requiredAuthType, boolean hasDataPolicy);
+    public IApiConnector createConnector(ApiRequest request,
+            Api api,
+            RequiredAuthType requiredAuthType,
+            boolean hasDataPolicy,
+            IConnectorConfig connectorConfig);
 
+    /**
+     * Creates a connector config
+     * @param request the inbound API request
+     * @param api the managed API being invoked
+     * @return connectorConfig the backend connector config. May be modified by policies.
+     */
+    public IConnectorConfig createConnectorConfig(ApiRequest request, Api api);
 }

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/AbstractConnectorConfig.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/AbstractConnectorConfig.java
@@ -34,21 +34,11 @@ import java.util.TreeSet;
  */
 public abstract class AbstractConnectorConfig implements IConnectorConfig {
 
-    Set<String> suppressedRequestHeaders;
-    boolean modifiedDefaultRequestHeaders = false;
+    protected Set<String> suppressedRequestHeaders;
+    private boolean modifiedDefaultRequestHeaders = false;
 
-    Set<String> suppressedResponseHeaders;
-    boolean modifiedDefaultResponseHeaders = false;
-
-// TODO: cache common request and response suppression maps. Some quick and dirty way of looking it up?
-//    static LRUMap<String, Set<String>> cache = new LRUMap<String, Set<String>>(1000) {
-//        private static final long serialVersionUID = -18620070710843930L;
-//
-//        @Override
-//        protected void handleRemovedElem(java.util.Map.Entry<String, Set<String>> eldest) {
-//            // Don't need to do anything.
-//        }
-//    };
+    protected Set<String> suppressedResponseHeaders;
+    private boolean modifiedDefaultResponseHeaders = false;
 
     /**
      * Suppressed request headers
@@ -63,7 +53,7 @@ public abstract class AbstractConnectorConfig implements IConnectorConfig {
     }
 
     /**
-     * Construct no suppressed request nor response headers.
+     * No suppressed request nor response headers.
      */
     public AbstractConnectorConfig() {
         this.suppressedRequestHeaders = Collections.emptySet();

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/AbstractConnectorConfig.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/AbstractConnectorConfig.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2018 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.gateway.engine.impl;
+
+import io.apiman.gateway.engine.IConnectorConfig;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Connector configuration with lazy initialisation of customised suppressions.
+ *
+ * Implementors should provide a static immutable default maps to {@link AbstractConnectorConfig}.
+ * This will be copied when needed into a mutable map (i.e. when the user adds/removes something).
+ *
+ * Future work could include caching common suppression maps, potentially.
+ *
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+public abstract class AbstractConnectorConfig implements IConnectorConfig {
+
+    Set<String> suppressedRequestHeaders;
+    boolean modifiedDefaultRequestHeaders = false;
+
+    Set<String> suppressedResponseHeaders;
+    boolean modifiedDefaultResponseHeaders = false;
+
+// TODO: cache common request and response suppression maps. Some quick and dirty way of looking it up?
+//    static LRUMap<String, Set<String>> cache = new LRUMap<String, Set<String>>(1000) {
+//        private static final long serialVersionUID = -18620070710843930L;
+//
+//        @Override
+//        protected void handleRemovedElem(java.util.Map.Entry<String, Set<String>> eldest) {
+//            // Don't need to do anything.
+//        }
+//    };
+
+    /**
+     * Suppressed request headers
+     * Suppressed response headers
+     *
+     * @param suppressedRequestHeaders request headers to suppress
+     * @param suppressedResponseHeaders response headers to suppress
+     */
+    public AbstractConnectorConfig(Set<String> suppressedRequestHeaders, Set<String> suppressedResponseHeaders) {
+        this.suppressedRequestHeaders = suppressedRequestHeaders;
+        this.suppressedResponseHeaders = suppressedResponseHeaders;
+    }
+
+    /**
+     * Construct no suppressed request nor response headers.
+     */
+    public AbstractConnectorConfig() {
+        this.suppressedRequestHeaders = Collections.emptySet();
+        this.suppressedResponseHeaders = Collections.emptySet();
+    }
+
+    @Override
+    public void suppressRequestHeader(String headerName) {
+        if (!suppressedRequestHeaders.contains(headerName)) {
+            copyRequestMap();
+            suppressedRequestHeaders.add(headerName);
+        }
+    }
+
+    @Override
+    public void suppressResponseHeader(String headerName) {
+        if (!suppressedResponseHeaders.contains(headerName)) {
+            copyResponseMap();
+            suppressedResponseHeaders.add(headerName);
+        }
+    }
+
+    @Override
+    public void permitRequestHeader(String headerName) {
+        if (suppressedRequestHeaders.contains(headerName)) {
+            copyRequestMap();
+            suppressedRequestHeaders.remove(headerName);
+        }
+    }
+
+    @Override
+    public void permitResponseHeader(String headerName) {
+        if (suppressedResponseHeaders.contains(headerName)) {
+            copyResponseMap();
+            suppressedResponseHeaders.remove(headerName);
+        }
+    }
+
+    @Override
+    public Set<String> getSuppressedRequestHeaders() {
+        return Collections.unmodifiableSet(suppressedRequestHeaders);
+    }
+
+    @Override
+    public Set<String> getSuppressedResponseHeaders() {
+        return Collections.unmodifiableSet(suppressedResponseHeaders);
+    }
+
+    private void copyRequestMap() {
+        if (!modifiedDefaultRequestHeaders) {
+            TreeSet<String> reqCopy = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+            reqCopy.addAll(suppressedRequestHeaders);
+            modifiedDefaultRequestHeaders = true;
+            this.suppressedRequestHeaders = reqCopy;
+        }
+    }
+
+    private void copyResponseMap() {
+        if (!modifiedDefaultResponseHeaders) {
+            TreeSet<String> resCopy = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+            resCopy.addAll(suppressedResponseHeaders);
+            modifiedDefaultResponseHeaders = true;
+            this.suppressedResponseHeaders = resCopy;
+        }
+    }
+}

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/ApiRequestExecutorImpl.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/ApiRequestExecutorImpl.java
@@ -21,6 +21,7 @@ import io.apiman.gateway.engine.IApiConnection;
 import io.apiman.gateway.engine.IApiConnectionResponse;
 import io.apiman.gateway.engine.IApiConnector;
 import io.apiman.gateway.engine.IApiRequestExecutor;
+import io.apiman.gateway.engine.IConnectorConfig;
 import io.apiman.gateway.engine.IConnectorFactory;
 import io.apiman.gateway.engine.IEngineResult;
 import io.apiman.gateway.engine.IMetrics;
@@ -244,9 +245,15 @@ public class ApiRequestExecutorImpl implements IApiRequestExecutor {
             requestChain = createRequestChain((ApiRequest req) -> {
                 IConnectorInterceptor connectorInterceptor = context.getConnectorInterceptor();
                 IApiConnector connector;
+                IConnectorConfig connectorConfig = connectorFactory.createConnectorConfig(request, api);
+                context.setConnectorConfiguration(connectorConfig);
+
                 if (connectorInterceptor == null) {
-                    connector = connectorFactory.createConnector(req, api,
-                            RequiredAuthType.parseType(api), hasDataPolicy);
+                    connector = connectorFactory.createConnector(req,
+                            api,
+                            RequiredAuthType.parseType(api),
+                            hasDataPolicy,
+                            connectorConfig);
                 } else {
                     connector = connectorInterceptor.createConnector();
                 }

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/policy/IPolicyContext.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/policy/IPolicyContext.java
@@ -17,6 +17,7 @@ package io.apiman.gateway.engine.policy;
 
 import io.apiman.common.logging.IApimanLogger;
 import io.apiman.gateway.engine.IComponent;
+import io.apiman.gateway.engine.IConnectorConfig;
 import io.apiman.gateway.engine.beans.exceptions.ComponentNotFoundException;
 import io.apiman.gateway.engine.beans.exceptions.InterceptorAlreadyRegisteredException;
 
@@ -79,4 +80,21 @@ public interface IPolicyContext {
      * @return A logger associated with the conversation.
      */
     IApimanLogger getLogger(Class<?> klazz);
+
+
+    /**
+     * Mutate connector attributes
+     * @return the connector configuration
+     */
+    IConnectorConfig getConnectorConfiguration();
+
+    /**
+     * Set the connector configuration.
+     *
+     * Most usecases should simply mutate the existing configuration via
+     * {@link #getConnectorConfiguration()}.
+     *
+     * @param config the configuration
+     */
+    void setConnectorConfiguration(IConnectorConfig config);
 }

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/policy/PolicyContextImpl.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/policy/PolicyContextImpl.java
@@ -20,6 +20,7 @@ import io.apiman.common.logging.IApimanLogger;
 import io.apiman.common.logging.IDelegateFactory;
 import io.apiman.gateway.engine.IComponent;
 import io.apiman.gateway.engine.IComponentRegistry;
+import io.apiman.gateway.engine.IConnectorConfig;
 import io.apiman.gateway.engine.beans.exceptions.ComponentNotFoundException;
 import io.apiman.gateway.engine.beans.exceptions.InterceptorAlreadyRegisteredException;
 
@@ -39,13 +40,15 @@ public class PolicyContextImpl implements IPolicyContext {
     // Using String instead of Class to avoid any accidental memory leak issues.
     private final static Map<String, IApimanLogger> loggers = new HashMap<>();
     private IConnectorInterceptor connectorInterceptor;
+    private IConnectorConfig connectorConfig;
 
     /**
      * Constructor.
      * @param componentRegistry the component registry
      * @param logFactory the log factory
      */
-    public PolicyContextImpl(IComponentRegistry componentRegistry, IDelegateFactory logFactory) {
+    public PolicyContextImpl(IComponentRegistry componentRegistry,
+            IDelegateFactory logFactory) {
         this.componentRegistry = componentRegistry;
         this.logFactory = logFactory;
     }
@@ -116,6 +119,16 @@ public class PolicyContextImpl implements IPolicyContext {
             loggers.put(klazz.getCanonicalName(), logger);
             return logger;
         }
+    }
+
+    @Override
+    public IConnectorConfig getConnectorConfiguration() {
+        return connectorConfig;
+    }
+
+    @Override
+    public void setConnectorConfiguration(IConnectorConfig connectorConfig) {
+        this.connectorConfig = connectorConfig;
     }
 
 }

--- a/gateway/engine/core/src/test/java/io/apiman/gateway/engine/impl/AbstractConnectorConfigTest.java
+++ b/gateway/engine/core/src/test/java/io/apiman/gateway/engine/impl/AbstractConnectorConfigTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.gateway.engine.impl;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+@SuppressWarnings("nls")
+public class AbstractConnectorConfigTest {
+
+    static final Set<String> REQUEST = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    static final Set<String> RESPONSE = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+
+    static {
+        REQUEST.add("Transfer-Encoding");
+        REQUEST.add("X-API-Key");
+        REQUEST.add("Host");
+
+        RESPONSE.add("Transfer-Encoding");
+        RESPONSE.add("Connection");
+    }
+
+    @Test
+    public void shouldContainInitialHeaders() {
+        AbstractConnectorConfig connector = new AbstractConnectorConfig(REQUEST, RESPONSE) {};
+        Assert.assertTrue(connector.getSuppressedResponseHeaders().containsAll(RESPONSE));
+    }
+
+    @Test
+    public void shouldEvaluateKeysCaseInsensitively() {
+        AbstractConnectorConfig connector = new AbstractConnectorConfig(REQUEST, RESPONSE) {};
+        Assert.assertTrue("Must compare case insensitively", connector.getSuppressedRequestHeaders().contains("x-api-key"));
+    }
+
+    @Test
+    public void addSuppressedRequestHeader() {
+        AbstractConnectorConfig connector = new AbstractConnectorConfig(REQUEST, RESPONSE) {};
+        connector.suppressRequestHeader("Seychelles");
+        Assert.assertTrue("Must contain suppressed header added by user", connector.getSuppressedRequestHeaders().contains("seychelles"));
+    }
+
+    @Test
+    public void permitRequestHeader() {
+        AbstractConnectorConfig connector = new AbstractConnectorConfig(REQUEST, RESPONSE) {};
+        connector.permitRequestHeader("Host");
+        Assert.assertFalse("Must unsuppress header", connector.getSuppressedRequestHeaders().contains("Host"));
+    }
+
+    @Test
+    public void addSuppressedResponseHeader() {
+        AbstractConnectorConfig connector = new AbstractConnectorConfig(REQUEST, RESPONSE) {};
+        connector.suppressResponseHeader("Aldabra");
+        Assert.assertTrue("Must contain suppressed header added by user", connector.getSuppressedResponseHeaders().contains("Aldabra"));
+    }
+
+    @Test
+    public void permitResponseHeader() {
+        AbstractConnectorConfig connector = new AbstractConnectorConfig(REQUEST, RESPONSE) {};
+        connector.permitResponseHeader("Host");
+        Assert.assertFalse("Must unsuppress header", connector.getSuppressedResponseHeaders().contains("Host"));
+    }
+
+}

--- a/gateway/engine/core/src/test/java/io/apiman/gateway/engine/impl/DefaultEngineFactoryTest.java
+++ b/gateway/engine/core/src/test/java/io/apiman/gateway/engine/impl/DefaultEngineFactoryTest.java
@@ -28,6 +28,7 @@ import io.apiman.gateway.engine.IApiConnector;
 import io.apiman.gateway.engine.IApiRequestExecutor;
 import io.apiman.gateway.engine.IApiRequestPathParser;
 import io.apiman.gateway.engine.IComponentRegistry;
+import io.apiman.gateway.engine.IConnectorConfig;
 import io.apiman.gateway.engine.IConnectorFactory;
 import io.apiman.gateway.engine.IEngine;
 import io.apiman.gateway.engine.IEngineResult;
@@ -114,7 +115,7 @@ public class DefaultEngineFactoryTest {
             protected IConnectorFactory createConnectorFactory(IPluginRegistry pluginRegistry) {
                 return new IConnectorFactory() {
                     @Override
-                    public IApiConnector createConnector(ApiRequest request, Api api, RequiredAuthType requiredAuthType, boolean hasDataPolicy) {
+                    public IApiConnector createConnector(ApiRequest request, Api api, RequiredAuthType requiredAuthType, boolean hasDataPolicy, IConnectorConfig connectorConfig) {
                         Assert.assertEquals("test", api.getEndpointType());
                         Assert.assertEquals("test:endpoint", api.getEndpoint());
                         IApiConnector connector = new IApiConnector() {
@@ -178,6 +179,11 @@ public class DefaultEngineFactoryTest {
 
                         };
                         return connector;
+                    }
+
+                    @Override
+                    public IConnectorConfig createConnectorConfig(ApiRequest request, Api api) {
+                        return new TestConnectorConfigImpl();
                     }
                 };
             }

--- a/gateway/engine/core/src/test/java/io/apiman/gateway/engine/impl/TestConnectorConfigImpl.java
+++ b/gateway/engine/core/src/test/java/io/apiman/gateway/engine/impl/TestConnectorConfigImpl.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.gateway.engine.impl;
+
+import io.apiman.gateway.engine.IConnectorConfig;
+
+import java.util.Set;
+import java.util.TreeSet;
+/**
+ * Test implementation of {@link IConnectorConfig}
+ *
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+@SuppressWarnings("nls")
+public class TestConnectorConfigImpl extends AbstractConnectorConfig {
+    static final Set<String> REQUEST = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    static final Set<String> RESPONSE = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+
+    static {
+        REQUEST.add("Transfer-Encoding");
+        REQUEST.add("X-API-Key");
+        REQUEST.add("Host");
+
+        RESPONSE.add("Transfer-Encoding");
+        RESPONSE.add("Connection");
+    }
+
+    public TestConnectorConfigImpl() {
+        super(REQUEST, RESPONSE);
+    }
+}

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/ConnectorConfigImpl.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/ConnectorConfigImpl.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.gateway.platforms.servlet.connectors;
+
+import io.apiman.gateway.engine.impl.AbstractConnectorConfig;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Servlet implementation of {@link AbstractConnectorConfig}.
+ *
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+@SuppressWarnings("nls")
+public class ConnectorConfigImpl extends AbstractConnectorConfig {
+
+    private static final Set<String> SUPPRESSED_REQUEST_HEADERS = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    private static final Set<String> SUPPRESSED_RESPONSE_HEADERS = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+
+    static {
+        SUPPRESSED_REQUEST_HEADERS.add("Transfer-Encoding");
+        SUPPRESSED_REQUEST_HEADERS.add("X-API-Key");
+        SUPPRESSED_REQUEST_HEADERS.add("Host");
+
+        SUPPRESSED_RESPONSE_HEADERS.add("OkHttp-Received-Millis");
+        SUPPRESSED_RESPONSE_HEADERS.add("OkHttp-Response-Source");
+        SUPPRESSED_RESPONSE_HEADERS.add("OkHttp-Selected-Protocol");
+        SUPPRESSED_RESPONSE_HEADERS.add("OkHttp-Sent-Millis");
+        SUPPRESSED_RESPONSE_HEADERS.add("Transfer-Encoding");
+        SUPPRESSED_RESPONSE_HEADERS.add("Connection");
+    }
+
+    public ConnectorConfigImpl() {
+        super(SUPPRESSED_REQUEST_HEADERS, SUPPRESSED_RESPONSE_HEADERS);
+    }
+}

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpConnectorFactory.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpConnectorFactory.java
@@ -17,10 +17,11 @@ package io.apiman.gateway.platforms.servlet.connectors;
 
 import io.apiman.common.config.options.HttpConnectorOptions;
 import io.apiman.common.config.options.TLSOptions;
-import io.apiman.gateway.engine.IConnectorFactory;
 import io.apiman.gateway.engine.IApiConnection;
 import io.apiman.gateway.engine.IApiConnectionResponse;
 import io.apiman.gateway.engine.IApiConnector;
+import io.apiman.gateway.engine.IConnectorConfig;
+import io.apiman.gateway.engine.IConnectorFactory;
 import io.apiman.gateway.engine.async.IAsyncResultHandler;
 import io.apiman.gateway.engine.auth.RequiredAuthType;
 import io.apiman.gateway.engine.beans.Api;
@@ -104,7 +105,8 @@ public class HttpConnectorFactory implements IConnectorFactory {
      */
     @Override
     public IApiConnector createConnector(ApiRequest request, final Api api,
-            final RequiredAuthType requiredAuthType, boolean hasDataPolicy) {
+            final RequiredAuthType requiredAuthType, boolean hasDataPolicy,
+            final IConnectorConfig connectorConfig) {
         return new IApiConnector() {
             /**
              * @see io.apiman.gateway.engine.IApiConnector#connect(io.apiman.gateway.engine.beans.ApiRequest, io.apiman.gateway.engine.async.IAsyncResultHandler)
@@ -114,7 +116,8 @@ public class HttpConnectorFactory implements IConnectorFactory {
                     IAsyncResultHandler<IApiConnectionResponse> handler) throws ConnectorException {
 
                 HttpApiConnection connection = new HttpApiConnection(okClient, request, api,
-                        requiredAuthType, getSslStrategy(requiredAuthType), hasDataPolicy, handler);
+                        requiredAuthType, getSslStrategy(requiredAuthType), hasDataPolicy,
+                        connectorConfig, handler);
                 return connection;
             }
         };
@@ -145,5 +148,10 @@ public class HttpConnectorFactory implements IConnectorFactory {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public IConnectorConfig createConnectorConfig(ApiRequest request, Api api) {
+        return new ConnectorConfigImpl();
     }
 }

--- a/gateway/platforms/servlet/src/test/java/io/apiman/gateway/platforms/servlet/auth/basic/BasicAuthTest.java
+++ b/gateway/platforms/servlet/src/test/java/io/apiman/gateway/platforms/servlet/auth/basic/BasicAuthTest.java
@@ -27,6 +27,7 @@ import io.apiman.gateway.engine.auth.RequiredAuthType;
 import io.apiman.gateway.engine.beans.Api;
 import io.apiman.gateway.engine.beans.ApiRequest;
 import io.apiman.gateway.engine.beans.exceptions.ConnectorException;
+import io.apiman.gateway.platforms.servlet.connectors.ConnectorConfigImpl;
 import io.apiman.gateway.platforms.servlet.connectors.HttpConnectorFactory;
 import io.apiman.test.common.mock.EchoServlet;
 
@@ -171,7 +172,7 @@ public class BasicAuthTest {
         api.setEndpoint("http://localhost:8008/echo");
 
         HttpConnectorFactory factory = new HttpConnectorFactory(globalConfig);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.BASIC, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.BASIC, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
                     @Override
@@ -199,7 +200,7 @@ public class BasicAuthTest {
         api.setEndpoint("https://localhost:8009/echo");
 
         HttpConnectorFactory factory = new HttpConnectorFactory(globalConfig);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.BASIC, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.BASIC, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
                     @Override
@@ -227,7 +228,7 @@ public class BasicAuthTest {
         api.setEndpoint("http://localhost:8008/echo");
 
         HttpConnectorFactory factory = new HttpConnectorFactory(globalConfig);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.BASIC, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.BASIC, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
                     @Override
@@ -255,7 +256,7 @@ public class BasicAuthTest {
         api.setEndpoint("http://localhost:8008/echo");
 
         HttpConnectorFactory factory = new HttpConnectorFactory(globalConfig);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.BASIC, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.BASIC, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
                     @Override
@@ -283,7 +284,7 @@ public class BasicAuthTest {
         api.setEndpoint("http://localhost:8008/echo");
 
         HttpConnectorFactory factory = new HttpConnectorFactory(globalConfig);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.BASIC, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.BASIC, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
                     @Override

--- a/gateway/platforms/servlet/src/test/java/io/apiman/gateway/platforms/servlet/auth/tls/BasicMutualAuthTest.java
+++ b/gateway/platforms/servlet/src/test/java/io/apiman/gateway/platforms/servlet/auth/tls/BasicMutualAuthTest.java
@@ -25,6 +25,7 @@ import io.apiman.gateway.engine.auth.RequiredAuthType;
 import io.apiman.gateway.engine.beans.Api;
 import io.apiman.gateway.engine.beans.ApiRequest;
 import io.apiman.gateway.engine.beans.exceptions.ConnectorException;
+import io.apiman.gateway.platforms.servlet.connectors.ConnectorConfigImpl;
 import io.apiman.gateway.platforms.servlet.connectors.HttpConnectorFactory;
 
 import java.io.FileInputStream;
@@ -174,7 +175,7 @@ public class BasicMutualAuthTest {
         config.put(TLSOptions.TLS_ALLOWSELFSIGNED, "false");
 
        HttpConnectorFactory factory = new HttpConnectorFactory(config);
-       IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false);
+       IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false, new ConnectorConfigImpl());
        IApiConnection connection = connector.connect(request,
                new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -207,7 +208,7 @@ public class BasicMutualAuthTest {
         config.put(TLSOptions.TLS_ALLOWSELFSIGNED, "false");
 
        HttpConnectorFactory factory = new HttpConnectorFactory(config);
-       IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false);
+       IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false, new ConnectorConfigImpl());
        IApiConnection connection = connector.connect(request,
                new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -242,7 +243,7 @@ public class BasicMutualAuthTest {
         config.put(TLSOptions.TLS_ALLOWSELFSIGNED, "false");
 
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -277,7 +278,7 @@ public class BasicMutualAuthTest {
         config.put(TLSOptions.TLS_ALLOWSELFSIGNED, "true");
 
        HttpConnectorFactory factory = new HttpConnectorFactory(config);
-       IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false);
+       IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false, new ConnectorConfigImpl());
        IApiConnection connection = connector.connect(request,
                new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -315,7 +316,7 @@ public class BasicMutualAuthTest {
         inStream.close();
 
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -359,7 +360,7 @@ public class BasicMutualAuthTest {
         inStream.close();
 
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -398,7 +399,7 @@ public class BasicMutualAuthTest {
         config.put(TLSOptions.TLS_KEYALIASES, "xxx");
 
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -421,7 +422,7 @@ public class BasicMutualAuthTest {
         config.put(TLSOptions.TLS_DEVMODE, "true");
 
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 

--- a/gateway/platforms/servlet/src/test/java/io/apiman/gateway/platforms/servlet/auth/tls/CAMutualAuthTest.java
+++ b/gateway/platforms/servlet/src/test/java/io/apiman/gateway/platforms/servlet/auth/tls/CAMutualAuthTest.java
@@ -25,6 +25,7 @@ import io.apiman.gateway.engine.auth.RequiredAuthType;
 import io.apiman.gateway.engine.beans.Api;
 import io.apiman.gateway.engine.beans.ApiRequest;
 import io.apiman.gateway.engine.beans.exceptions.ConnectorException;
+import io.apiman.gateway.platforms.servlet.connectors.ConnectorConfigImpl;
 import io.apiman.gateway.platforms.servlet.connectors.HttpConnectorFactory;
 
 import java.io.IOException;
@@ -157,7 +158,7 @@ public class CAMutualAuthTest {
         config.put(TLSOptions.TLS_ALLOWSELFSIGNED, "false");
 
        HttpConnectorFactory factory = new HttpConnectorFactory(config);
-       IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false);
+       IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false, new ConnectorConfigImpl());
        IApiConnection connection = connector.connect(request,
                new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -191,7 +192,7 @@ public class CAMutualAuthTest {
         config.put(TLSOptions.TLS_ALLOWSELFSIGNED, "false");
 
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.MTLS, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 

--- a/gateway/platforms/servlet/src/test/java/io/apiman/gateway/platforms/servlet/auth/tls/CipherAndProtocolSelectionTest.java
+++ b/gateway/platforms/servlet/src/test/java/io/apiman/gateway/platforms/servlet/auth/tls/CipherAndProtocolSelectionTest.java
@@ -25,6 +25,7 @@ import io.apiman.gateway.engine.auth.RequiredAuthType;
 import io.apiman.gateway.engine.beans.Api;
 import io.apiman.gateway.engine.beans.ApiRequest;
 import io.apiman.gateway.engine.beans.exceptions.ConnectorException;
+import io.apiman.gateway.platforms.servlet.connectors.ConnectorConfigImpl;
 import io.apiman.gateway.platforms.servlet.connectors.HttpConnectorFactory;
 
 import java.io.IOException;
@@ -166,7 +167,7 @@ public class CipherAndProtocolSelectionTest {
         server.start();
 
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -204,7 +205,7 @@ public class CipherAndProtocolSelectionTest {
 
 
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -238,7 +239,7 @@ public class CipherAndProtocolSelectionTest {
 
 
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -272,7 +273,7 @@ public class CipherAndProtocolSelectionTest {
 
 
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -306,7 +307,7 @@ public class CipherAndProtocolSelectionTest {
         server.start();
 
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -341,7 +342,7 @@ public class CipherAndProtocolSelectionTest {
         server.start();
 
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -377,7 +378,7 @@ public class CipherAndProtocolSelectionTest {
         final CountDownLatch latch = new CountDownLatch(1);
 
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 

--- a/gateway/platforms/servlet/src/test/java/io/apiman/gateway/platforms/servlet/auth/tls/StandardTLSTest.java
+++ b/gateway/platforms/servlet/src/test/java/io/apiman/gateway/platforms/servlet/auth/tls/StandardTLSTest.java
@@ -25,6 +25,7 @@ import io.apiman.gateway.engine.auth.RequiredAuthType;
 import io.apiman.gateway.engine.beans.Api;
 import io.apiman.gateway.engine.beans.ApiRequest;
 import io.apiman.gateway.engine.beans.exceptions.ConnectorException;
+import io.apiman.gateway.platforms.servlet.connectors.ConnectorConfigImpl;
 import io.apiman.gateway.platforms.servlet.connectors.HttpConnectorFactory;
 
 import java.io.IOException;
@@ -156,7 +157,7 @@ public class StandardTLSTest {
         config.put(TLSOptions.TLS_ALLOWSELFSIGNED, "false");
 
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -187,7 +188,7 @@ public class StandardTLSTest {
         config.put(TLSOptions.TLS_ALLOWSELFSIGNED, "false");
 
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -211,7 +212,7 @@ public class StandardTLSTest {
         config.put(TLSOptions.TLS_DEVMODE, "true");
 
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 
@@ -233,7 +234,7 @@ public class StandardTLSTest {
     @Test
     public void shouldFailWithNoSettings() {
         HttpConnectorFactory factory = new HttpConnectorFactory(config);
-        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false);
+        IApiConnector connector = factory.createConnector(request, api, RequiredAuthType.DEFAULT, false, new ConnectorConfigImpl());
         IApiConnection connection = connector.connect(request,
                 new IAsyncResultHandler<IApiConnectionResponse>() {
 

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/IRouteBuilder.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/IRouteBuilder.java
@@ -51,23 +51,25 @@ public interface IRouteBuilder {
 
         response.putHeader("X-API-Gateway-Error", "true");
 
-        if (error instanceof IStatusCode) {
-            response.setStatusCode(((IStatusCode)error).getStatusCode());
-            response.setStatusMessage(error.getMessage());
-        } else {
-            response.setStatusCode(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
-            response.setStatusMessage(error.getMessage() != null ? error.getMessage() : HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase());
-        }
-
         if (error != null) {
+            if (error instanceof IStatusCode) {
+                response.setStatusCode(((IStatusCode)error).getStatusCode());
+                response.setStatusMessage(error.getMessage());
+            } else {
+                response.setStatusCode(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+                response.setStatusMessage(error.getMessage() != null ? error.getMessage() : HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase());
+            }
+
             JsonObject errorResponse = new JsonObject()
                     .put("errorType", error.getClass().getSimpleName())
                     .put("message", error.getMessage());
 
             response.setChunked(true)
-                .putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
-                .end(errorResponse.toString(), "UTF-8");
+            .putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+            .end(errorResponse.toString(), "UTF-8");
         } else {
+            response.setStatusCode(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+            response.setStatusMessage(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase());
             response.end();
         }
     }

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/common/config/VertxEngineConfig.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/common/config/VertxEngineConfig.java
@@ -395,9 +395,7 @@ public class VertxEngineConfig implements IEngineConfig {
             // Not found via Class.forName() - try other mechanisms.
         }
 
-        System.err.println(Messages.getString("EngineConfig.FailedToLoadClass") + className);
-        System.exit(-1);
-        return null;
+        throw new IllegalStateException(Messages.getString("EngineConfig.FailedToLoadClass") + className);
     }
 
     protected String stringConfigWithDefault(String name, String defaultValue) {

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/ConnectorFactory.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/ConnectorFactory.java
@@ -20,6 +20,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import io.apiman.common.config.options.TLSOptions;
 import io.apiman.gateway.engine.IApiConnector;
+import io.apiman.gateway.engine.IConnectorConfig;
 import io.apiman.gateway.engine.IConnectorFactory;
 import io.apiman.gateway.engine.auth.RequiredAuthType;
 import io.apiman.gateway.engine.beans.Api;
@@ -84,7 +85,7 @@ public class ConnectorFactory implements IConnectorFactory {
 
     // In the future we can switch to different back-end implementations here!
     @Override
-    public IApiConnector createConnector(ApiRequest req, Api api, RequiredAuthType authType, boolean hasDataPolicy) {
+    public IApiConnector createConnector(ApiRequest req, Api api, RequiredAuthType authType, boolean hasDataPolicy, IConnectorConfig connectorConfig) {
         return (request, resultHandler) -> {
             // Apply options from config as our base case
             ApimanHttpConnectorOptions httpOptions = new ApimanHttpConnectorOptions(config)
@@ -97,7 +98,7 @@ public class ConnectorFactory implements IConnectorFactory {
             setAttributesFromApiEndpointProperties(api, httpOptions);
             // Get from cache
             HttpClient client = clientFromCache(httpOptions);
-            return new HttpConnector(vertx, client, request, api, httpOptions, resultHandler).connect();
+            return new HttpConnector(vertx, client, request, api, httpOptions, connectorConfig, resultHandler).connect();
          };
     }
 
@@ -136,5 +137,10 @@ public class ConnectorFactory implements IConnectorFactory {
         } catch (NumberFormatException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public IConnectorConfig createConnectorConfig(ApiRequest request, Api api) {
+        return new VertxConnectorConfig();
     }
 }

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/VertxConnectorConfig.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/VertxConnectorConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.gateway.platforms.vertx3.connector;
+
+import io.apiman.gateway.engine.impl.AbstractConnectorConfig;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Vert.x platform connector configuration.
+ *
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
+@SuppressWarnings("nls")
+public class VertxConnectorConfig extends AbstractConnectorConfig {
+
+    private static final Set<String> SUPPRESSED_REQUEST_HEADERS = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    private static final Set<String> SUPPRESSED_RESPONSE_HEADERS = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+
+    static {
+        SUPPRESSED_REQUEST_HEADERS.add("X-API-Key");
+        SUPPRESSED_REQUEST_HEADERS.add("Host");
+
+        SUPPRESSED_RESPONSE_HEADERS.add("Connection");
+    }
+
+    public VertxConnectorConfig() {
+        super(SUPPRESSED_REQUEST_HEADERS, SUPPRESSED_RESPONSE_HEADERS);
+    }
+}

--- a/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/connector/HttpConnectorDrainTest.java
+++ b/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/connector/HttpConnectorDrainTest.java
@@ -135,6 +135,7 @@ public class HttpConnectorDrainTest {
                 new ApimanHttpConnectorOptions()
                     .setHasDataPolicy(true)
                     .setUri(URI.create(api.getEndpoint())),
+                new VertxConnectorConfig(),
                 ignored -> {
                     // Immediately allow the dummy response to come back.
                     if (ignored.isError())

--- a/test/policies/src/main/java/io/apiman/test/policies/PolicyTesterConnectorConfig.java
+++ b/test/policies/src/main/java/io/apiman/test/policies/PolicyTesterConnectorConfig.java
@@ -21,6 +21,11 @@ import io.apiman.gateway.engine.impl.AbstractConnectorConfig;
 import java.util.Set;
 import java.util.TreeSet;
 
+/**
+ * Test connector config
+ *
+ * @author Marc Savy {@literal <marc@rhymewithgravy.com>}
+ */
 @SuppressWarnings("nls")
 public class PolicyTesterConnectorConfig extends AbstractConnectorConfig {
     static final Set<String> REQUEST = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);

--- a/test/policies/src/main/java/io/apiman/test/policies/PolicyTesterConnectorConfig.java
+++ b/test/policies/src/main/java/io/apiman/test/policies/PolicyTesterConnectorConfig.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.test.policies;
+
+import io.apiman.gateway.engine.impl.AbstractConnectorConfig;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+@SuppressWarnings("nls")
+public class PolicyTesterConnectorConfig extends AbstractConnectorConfig {
+    static final Set<String> REQUEST = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    static final Set<String> RESPONSE = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+
+    static {
+        REQUEST.add("Transfer-Encoding");
+        REQUEST.add("X-API-Key");
+        REQUEST.add("Host");
+
+        RESPONSE.add("Transfer-Encoding");
+        RESPONSE.add("Connection");
+    }
+
+    public PolicyTesterConnectorConfig() {
+        super(REQUEST, RESPONSE);
+    }
+}

--- a/test/policies/src/main/java/io/apiman/test/policies/PolicyTesterConnectorFactory.java
+++ b/test/policies/src/main/java/io/apiman/test/policies/PolicyTesterConnectorFactory.java
@@ -15,8 +15,9 @@
  */
 package io.apiman.test.policies;
 
-import io.apiman.gateway.engine.IConnectorFactory;
 import io.apiman.gateway.engine.IApiConnector;
+import io.apiman.gateway.engine.IConnectorConfig;
+import io.apiman.gateway.engine.IConnectorFactory;
 import io.apiman.gateway.engine.auth.RequiredAuthType;
 import io.apiman.gateway.engine.beans.Api;
 import io.apiman.gateway.engine.beans.ApiRequest;
@@ -32,8 +33,13 @@ public class PolicyTesterConnectorFactory implements IConnectorFactory {
      * @see io.apiman.gateway.engine.IConnectorFactory#createConnector(io.apiman.gateway.engine.beans.ApiRequest, io.apiman.gateway.engine.beans.Api)
      */
     @Override
-    public IApiConnector createConnector(ApiRequest request, Api api, RequiredAuthType authType, boolean hasDataPolicy) {
+    public IApiConnector createConnector(ApiRequest request, Api api, RequiredAuthType authType, boolean hasDataPolicy, IConnectorConfig connectorConfig) {
         return new PolicyTesterConnector(api);
+    }
+
+    @Override
+    public IConnectorConfig createConnectorConfig(ApiRequest request, Api api) {
+        return new PolicyTesterConnectorConfig();
     }
 
 }


### PR DESCRIPTION
Adds IConnectorConfig, which we can expand to allow twiddling of various connector configuration aspects by policies.