### PR TITLE
Improve wildcard ("*") search in UI

### DIFF
--- a/manager/ui/war/plugins/api-manager/ts/consumer/consumer-apis.ts
+++ b/manager/ui/war/plugins/api-manager/ts/consumer/consumer-apis.ts
@@ -19,6 +19,8 @@ module Apiman {
                         var body:any = {};
                         body.filters = [];
                         body.filters.push( {"name": "name", "value": "*" + params.q + "*", "operator": "like"});
+                        body.page = 1;
+                        body.pageSize = 0x7fffffff; // Java Interger.MAX_VALUE
                         var searchStr = angular.toJson(body);
                         
                         ApimanSvcs.save({ entityType: 'search', secondaryType: 'apis' }, searchStr, function(reply) {

--- a/manager/ui/war/plugins/api-manager/ts/consumer/consumer-apis.ts
+++ b/manager/ui/war/plugins/api-manager/ts/consumer/consumer-apis.ts
@@ -20,7 +20,7 @@ module Apiman {
                         body.filters = [];
                         body.filters.push( {"name": "name", "value": "*" + params.q + "*", "operator": "like"});
                         body.page = 1;
-                        body.pageSize = 0x7fffffff; // Java Interger.MAX_VALUE
+                        body.pageSize = 10000; // ES index.max_result_window
                         var searchStr = angular.toJson(body);
                         
                         ApimanSvcs.save({ entityType: 'search', secondaryType: 'apis' }, searchStr, function(reply) {

--- a/manager/ui/war/plugins/api-manager/ts/consumer/consumer-orgs.ts
+++ b/manager/ui/war/plugins/api-manager/ts/consumer/consumer-orgs.ts
@@ -19,6 +19,8 @@ module Apiman {
                         var body:any = {};
                         body.filters = [];
                         body.filters.push( {"name": "name", "value": "*" + params.q + "*", "operator": "like"});
+                        body.page = 1;
+                        body.pageSize = 0x7fffffff; // Java Interger.MAX_VALUE
                         var searchStr = angular.toJson(body);
                         ApimanSvcs.save({ entityType: 'search', secondaryType: 'organizations' }, searchStr, function(result) { 
                             resolve(result.beans);

--- a/manager/ui/war/plugins/api-manager/ts/consumer/consumer-orgs.ts
+++ b/manager/ui/war/plugins/api-manager/ts/consumer/consumer-orgs.ts
@@ -20,7 +20,7 @@ module Apiman {
                         body.filters = [];
                         body.filters.push( {"name": "name", "value": "*" + params.q + "*", "operator": "like"});
                         body.page = 1;
-                        body.pageSize = 0x7fffffff; // Java Interger.MAX_VALUE
+                        body.pageSize = 10000; // ES index.max_result_window
                         var searchStr = angular.toJson(body);
                         ApimanSvcs.save({ entityType: 'search', secondaryType: 'organizations' }, searchStr, function(result) { 
                             resolve(result.beans);

--- a/manager/ui/war/plugins/api-manager/ts/modals.ts
+++ b/manager/ui/war/plugins/api-manager/ts/modals.ts
@@ -126,6 +126,8 @@ module ApimanModals {
                             'value': '%' + $scope.searchText + '%',
                             'operator': 'like'
                         });
+                        body.page = 1;
+                        body.pageSize = 0x7fffffff; // Java Interger.MAX_VALUE
 
                         var searchStr = angular.toJson(body);
 

--- a/manager/ui/war/plugins/api-manager/ts/modals.ts
+++ b/manager/ui/war/plugins/api-manager/ts/modals.ts
@@ -127,7 +127,7 @@ module ApimanModals {
                             'operator': 'like'
                         });
                         body.page = 1;
-                        body.pageSize = 0x7fffffff; // Java Interger.MAX_VALUE
+                        body.pageSize = 10000; // ES index.max_result_window
 
                         var searchStr = angular.toJson(body);
 

--- a/manager/ui/war/plugins/api-manager/ts/org/org-new-member.ts
+++ b/manager/ui/war/plugins/api-manager/ts/org/org-new-member.ts
@@ -44,7 +44,7 @@ module Apiman {
                     return;
                 }
 
-                let pageSize = 0x7fffffff; // Java Interger.MAX_VALUE
+                let pageSize = 10000; // ES index.max_result_window
                 var queryBean = {
                     filters: [{
                         name: 'username',

--- a/manager/ui/war/plugins/api-manager/ts/org/org-new-member.ts
+++ b/manager/ui/war/plugins/api-manager/ts/org/org-new-member.ts
@@ -44,6 +44,7 @@ module Apiman {
                     return;
                 }
 
+                let pageSize = 0x7fffffff; // Java Interger.MAX_VALUE
                 var queryBean = {
                     filters: [{
                         name: 'username',
@@ -56,9 +57,9 @@ module Apiman {
                     },
                     paging: {
                         page: 1,
-                        pageSize: 50
+                        pageSize: pageSize
                     }
-                }
+                };
 
                 $log.debug('Query: {0}', queryBean);
 


### PR DESCRIPTION
Apiman allows to find all entries such as all APIs, Orgs, User per wildcard.
But the results are wrong because there is a paging. So the return is limeted to 20 or 50 entries. 
So I make a suggestion to change this because otherwise this is a bit confusing.

I created two screenshots that you can see what I mean:

Before:
![before](https://user-images.githubusercontent.com/13332383/41287845-652c75f2-6e44-11e8-815e-4890f2f8a34d.png)

After:
![after](https://user-images.githubusercontent.com/13332383/41287844-65161636-6e44-11e8-8fa1-953db88c1316.png)

Please let me know what you think :)
