### PR TITLE
fix: vertx cert error because of typo

### DIFF
--- a/common/config/src/main/java/io/apiman/common/config/options/TLSOptions.java
+++ b/common/config/src/main/java/io/apiman/common/config/options/TLSOptions.java
@@ -29,7 +29,7 @@ public class TLSOptions extends AbstractOptions {
     public static final String TLS_TRUSTSTORE = PREFIX + "trustStore";
     public static final String TLS_TRUSTSTOREPASSWORD = PREFIX + "trustStorePassword";
     public static final String TLS_KEYSTORE = PREFIX + "keyStore";
-    public static final String TLS_KEYSTOREPASSWORD = PREFIX + "keystorePassword";
+    public static final String TLS_KEYSTOREPASSWORD = PREFIX + "keyStorePassword";
     public static final String TLS_KEYALIASES = PREFIX + "keyAliases";
     public static final String TLS_KEYPASSWORD = PREFIX + "keyPassword";
     public static final String TLS_ALLOWEDPROTOCOLS = PREFIX + "allowedProtocols";


### PR DESCRIPTION
You are not able to connect the vertx gateway with an API that is secured over https.
You are running into the following error:
```
[DEBUG] 2018-08-28 14:15:22.010 [vert.x-eventloop-thread-3] HttpConnector - Connecting to XXX | ssl?: true port: 8,443 verb: GET path: /SalesForce/SalesForce/REST/Services
[ERROR] 2018-08-28 14:15:22.027 [vert.x-eventloop-thread-3] ContextImpl - Unhandled exception
io.vertx.core.VertxException: java.security.UnrecoverableKeyException: Password must not be null
at io.vertx.core.net.impl.SSLHelper.createContext(SSLHelper.java:304) ~[apiman-gateway.jar:?]
at io.vertx.core.net.impl.SSLHelper.getContext(SSLHelper.java:446) ~[apiman-gateway.jar:?]
at io.vertx.core.net.impl.SSLHelper.validate(SSLHelper.java:466) ~[apiman-gateway.jar:?]
at io.vertx.core.http.impl.ConnectionManager$ConnQueue.createNewConnection(ConnectionManager.java:294) ~[apiman-gateway.jar:?]
at io.vertx.core.http.impl.ConnectionManager$ConnQueue.getConnection(ConnectionManager.java:241) ~[apiman-gateway.jar:?]
at io.vertx.core.http.impl.ConnectionManager.getConnectionForRequest(ConnectionManager.java:177) ~[apiman-gateway.jar:?]
at io.vertx.core.http.impl.HttpClientImpl.getConnectionForRequest(HttpClientImpl.java:915) ~[apiman-gateway.jar:?]
at io.vertx.core.http.impl.HttpClientRequestImpl.connect(HttpClientRequestImpl.java:745) ~[apiman-gateway.jar:?]
at io.vertx.core.http.impl.HttpClientRequestImpl.write(HttpClientRequestImpl.java:867) ~[apiman-gateway.jar:?]
at io.vertx.core.http.impl.HttpClientRequestImpl.end(HttpClientRequestImpl.java:352) ~[apiman-gateway.jar:?]
at io.apiman.gateway.platforms.vertx3.connector.HttpConnector.end(HttpConnector.java:269) ~[apiman-gateway.jar:?]
at io.apiman.gateway.engine.impl.ApiRequestExecutorImpl.lambda$null$2(ApiRequestExecutorImpl.java:278) ~[apiman-gateway.jar:?]
at io.apiman.gateway.engine.io.AbstractStream.handleEnd(AbstractStream.java:116) ~[apiman-gateway.jar:?]
at io.apiman.gateway.engine.policy.Chain.end(Chain.java:220) ~[apiman-gateway.jar:?]
at io.apiman.gateway.engine.impl.ApiRequestExecutorImpl$3.end(ApiRequestExecutorImpl.java:750) ~[apiman-gateway.jar:?]
at io.apiman.gateway.platforms.vertx3.http.HttpPolicyAdapter.lambda$null$4(HttpPolicyAdapter.java:105) ~[apiman-gateway.jar:?]
at io.vertx.core.http.impl.HttpServerRequestImpl.handleEnd(HttpServerRequestImpl.java:406) ~[apiman-gateway.jar:?]
at io.vertx.core.http.impl.ServerConnection.handleEnd(ServerConnection.java:297) ~[apiman-gateway.jar:?]
at io.vertx.core.http.impl.ServerConnection.processMessage(ServerConnection.java:441) ~[apiman-gateway.jar:?]
at io.vertx.core.http.impl.ServerConnection.handleMessage(ServerConnection.java:131) ~[apiman-gateway.jar:?]
at io.vertx.core.http.impl.HttpServerImpl$ServerHandler.doMessageReceived(HttpServerImpl.java:673) ~[apiman-gateway.jar:?]
at io.vertx.core.http.impl.HttpServerImpl$ServerHandler.doMessageReceived(HttpServerImpl.java:580) ~[apiman-gateway.jar:?]
at io.vertx.core.http.impl.VertxHttpHandler.lambda$channelRead$0(VertxHttpHandler.java:71) ~[apiman-gateway.jar:?]
at io.vertx.core.impl.ContextImpl.lambda$wrapTask$2(ContextImpl.java:335) ~[apiman-gateway.jar:?]
at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:193) ~[apiman-gateway.jar:?]
at io.vertx.core.http.impl.VertxHttpHandler.channelRead(VertxHttpHandler.java:71) ~[apiman-gateway.jar:?]
at io.vertx.core.net.impl.VertxHandler.channelRead(VertxHandler.java:122) ~[apiman-gateway.jar:?]
at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363) ~[apiman-gateway.jar:?]
at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:349) ~[apiman-gateway.jar:?]
at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:341) ~[apiman-gateway.jar:?]
at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:86) ~[apiman-gateway.jar:?]
at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363) ~[apiman-gateway.jar:?]
at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:349) ~[apiman-gateway.jar:?]
at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:341) ~[apiman-gateway.jar:?]
at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:293) ~[apiman-gateway.jar:?]
at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:267) ~[apiman-gateway.jar:?]
at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363) ~[apiman-gateway.jar:?]
at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:349) ~[apiman-gateway.jar:?]
at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:341) ~[apiman-gateway.jar:?]
at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1228) ~[apiman-gateway.jar:?]
at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1039) ~[apiman-gateway.jar:?]
at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:411) ~[apiman-gateway.jar:?]
at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:248) ~[apiman-gateway.jar:?]
at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363) ~[apiman-gateway.jar:?]
at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:349) ~[apiman-gateway.jar:?]
at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:341) ~[apiman-gateway.jar:?]
at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1334) ~[apiman-gateway.jar:?]
at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363) ~[apiman-gateway.jar:?]
at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:349) ~[apiman-gateway.jar:?]
at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:926) ~[apiman-gateway.jar:?]
at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:129) ~[apiman-gateway.jar:?]
at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:642) ~[apiman-gateway.jar:?]
at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:565) ~[apiman-gateway.jar:?]
at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:479) ~[apiman-gateway.jar:?]
at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:441) ~[apiman-gateway.jar:?]
at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:858) ~[apiman-gateway.jar:?]
at java.lang.Thread.run(Thread.java:748) [?:1.8.0_161]
Caused by: java.security.UnrecoverableKeyException: Password must not be null
at sun.security.provider.JavaKeyStore.engineGetKey(JavaKeyStore.java:132) ~[?:1.8.0_161]
at sun.security.provider.JavaKeyStore$JKS.engineGetKey(JavaKeyStore.java:56) ~[?:1.8.0_161]
at sun.security.provider.KeyStoreDelegator.engineGetKey(KeyStoreDelegator.java:96) ~[?:1.8.0_161]
at sun.security.provider.JavaKeyStore$DualFormatJKS.engineGetKey(JavaKeyStore.java:70) ~[?:1.8.0_161]
at java.security.KeyStore.getKey(KeyStore.java:1023) ~[?:1.8.0_161]
at io.vertx.core.net.impl.KeyStoreHelper.<init>(KeyStoreHelper.java:158) ~[apiman-gateway.jar:?]
at io.vertx.core.net.impl.KeyStoreHelper.create(KeyStoreHelper.java:80) ~[apiman-gateway.jar:?]
at io.vertx.core.net.KeyCertOptions.getKeyManagerFactory(KeyCertOptions.java:47) ~[apiman-gateway.jar:?]
at io.vertx.core.net.impl.SSLHelper.getKeyMgrFactory(SSLHelper.java:309) ~[apiman-gateway.jar:?]
at io.vertx.core.net.impl.SSLHelper.createContext(SSLHelper.java:254) ~[apiman-gateway.jar:?]
````

This is because of a simple typo. So the keystore password was never set.