### PR TITLE
fix-ui: Show selected tags in API Catalog

### DIFF
--- a/manager/ui/war/plugins/api-manager/html/catalog/api-catalog.html
+++ b/manager/ui/war/plugins/api-manager/html/catalog/api-catalog.html
@@ -59,14 +59,14 @@
                          style="width: 250px; margin: 0 10px; box-shadow: none; font-size: small; border-color: #bababa; display: inline-table;"
                          apiman-i18n-key="choose-a-tag"
                          title="Choose a tag">
-                <ui-select-match apiman-i18n-key="filter-by-tags" placeholder="Filter by tags...">{{$item}}</ui-select-match>
-                <ui-select-choices repeat="tag in tags | filter:$select.search | orderBy: tag"
-                                   style="margin: 0 -1px auto -1px; width: 101%;">
+                <span apiman-i18n-key="filter-by-tags"></span>
+                <ui-select-match placeholder="Filter by tags...">{{$item}}</ui-select-match>
+                <ui-select-choices repeat="tag in tags | filter:$select.search | orderBy: tag">
                   {{tag}}
                 </ui-select-choices>
               </ui-select>
-              <button ng-show="selected.tags.length > 0" class="btn btn-default btn-xs"
-                      style="box-shadow: none; height: 28px; margin: -1px 10px 0 -14px; border-left: none;"
+              <button ng-show="selected.tags.length > 0" class="btn btn-default"
+                      style="box-shadow: none; height: 29px; margin: -2px 10px 0 -14px; border-left: none;"
                       ng-click="clear()"><i class="fa fa-fw fa-close"></i></button>
 
               <!-- Filter: API Type -->


### PR DESCRIPTION
This is a little UI fix for the API Catalog. 
If you use the filter for tags it gets annoying if the selected tags are not shown.

## Before
![before](https://user-images.githubusercontent.com/13332383/44778498-67785080-ab7d-11e8-82a5-68f7b9e512ae.png)

## After
![after](https://user-images.githubusercontent.com/13332383/44778499-67785080-ab7d-11e8-9307-bf3a4cca49ef.png)
