### PR TITLE
#683: Don't invalidate the cache if ES goes down

### DIFF
--- a/gateway/engine/es/pom.xml
+++ b/gateway/engine/es/pom.xml
@@ -28,6 +28,10 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>apiman-gateway-engine-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>apiman-common-logging-core</artifactId>
+    </dependency>
 
     <!-- Third Party Dependencies -->
     <dependency>

--- a/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/ESMetrics.java
+++ b/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/ESMetrics.java
@@ -16,12 +16,8 @@
 
 package io.apiman.gateway.engine.es;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingDeque;
-
+import io.apiman.common.logging.DefaultDelegateFactory;
+import io.apiman.common.logging.IApimanLogger;
 import io.apiman.gateway.engine.IComponentRegistry;
 import io.apiman.gateway.engine.IMetrics;
 import io.apiman.gateway.engine.metrics.RequestMetric;
@@ -29,6 +25,12 @@ import io.searchbox.core.Bulk;
 import io.searchbox.core.Bulk.Builder;
 import io.searchbox.core.BulkResult;
 import io.searchbox.core.Index;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
 
 /**
  * An elasticsearch implementation of the {@link IMetrics} interface.
@@ -43,6 +45,8 @@ public class ESMetrics extends AbstractESComponent implements IMetrics {
     protected IComponentRegistry componentRegistry;
     private final BlockingQueue<RequestMetric> queue;
     private final int batchSize;
+
+    private IApimanLogger logger = new DefaultDelegateFactory().createLogger(PollCachingESRegistry.class);
 
     /**
      * Constructor.
@@ -125,12 +129,10 @@ public class ESMetrics extends AbstractESComponent implements IMetrics {
             
             BulkResult result = getClient().execute(builder.build());
             if (!result.isSucceeded()) {
-                System.err.println("Failed to add metric(s) to ES: " + result.getErrorMessage()); //$NON-NLS-1$
+                logger.warn("Failed to add metric(s) to ES"); //$NON-NLS-1$
             }
         } catch (Exception e) {
-            // TODO better logging of this unlikely error
-            System.err.println("Error adding metric to ES:"); //$NON-NLS-1$
-            e.printStackTrace();
+            logger.warn("Error adding metric to ES"); //$NON-NLS-1$
             return;
         }
     }

--- a/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/PollCachingESRegistry.java
+++ b/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/PollCachingESRegistry.java
@@ -15,18 +15,20 @@
  */
 package io.apiman.gateway.engine.es;
 
-import java.io.IOException;
-import java.util.Map;
-
+import io.apiman.common.logging.DefaultDelegateFactory;
+import io.apiman.common.logging.IApimanLogger;
 import io.apiman.gateway.engine.async.IAsyncResult;
 import io.apiman.gateway.engine.async.IAsyncResultHandler;
-import io.apiman.gateway.engine.beans.Client;
 import io.apiman.gateway.engine.beans.Api;
+import io.apiman.gateway.engine.beans.Client;
 import io.apiman.gateway.engine.es.beans.DataVersionBean;
 import io.searchbox.client.JestResult;
 import io.searchbox.client.JestResultHandler;
 import io.searchbox.core.Get;
 import io.searchbox.core.Index;
+
+import java.io.IOException;
+import java.util.Map;
 
 /**
  * Extends the {@link ESRegistry} to provide multi-node caching.  This caching solution
@@ -48,6 +50,8 @@ public class PollCachingESRegistry extends CachingESRegistry {
 
     private boolean polling = false;
     private String dataVersion = null;
+
+    private IApimanLogger logger = new DefaultDelegateFactory().createLogger(PollCachingESRegistry.class);
 
     /**
      * Constructor.
@@ -211,8 +215,8 @@ public class PollCachingESRegistry extends CachingESRegistry {
                 }
             }
         } catch (IOException e) {
-            // TODO need to use the gateway logger to log this!
-            e.printStackTrace();
+            logger.warn("Elasticsearch is not available, using cache");
+            invalidate = false;
         }
         if (invalidate) {
             invalidateCache();


### PR DESCRIPTION
This PR fixes https://github.com/apiman/apiman/issues/683

I am not sure about the logging, but it is better for the moment than printing every time the whole stacktrace.

Please let me know, what you think :)