### PR TITLE
Make Caching policy more RFC7234 compliant w.r.t. query string

### DIFF
--- a/distro/data/src/main/resources/data/all-policyDefs.json
+++ b/distro/data/src/main/resources/data/all-policyDefs.json
@@ -99,7 +99,7 @@
       "templates" : [
         {
           "language" : null,
-          "template" : "API responses will be cached for @{ttl} seconds."
+          "template" : "API responses will be cached for @{ttl} seconds. @if{includeQueryInKey == true}The query string will be included for the cache key.@end{}@if{includeQueryInKey == false}The query string will be ignored for the cache key.@end{}"
         }
       ]
     },

--- a/gateway/engine/beans/src/test/java/io/apiman/gateway/engine/beans/util/QueryMapTest.java
+++ b/gateway/engine/beans/src/test/java/io/apiman/gateway/engine/beans/util/QueryMapTest.java
@@ -16,33 +16,35 @@
 
 package io.apiman.gateway.engine.beans.util;
 
-import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Marc Savy {@literal <msavy@redhat.com>}
  */
 @SuppressWarnings("nls")
 public class QueryMapTest {
-
     @Test
-    @Ignore
-    public void simpleQuery() {
+    public void emptyQuery() {
         QueryMap qm = new QueryMap();
-        qm.add("q", "search").add("Q", "search again").add("x", "otherthing");
-        Assert.assertEquals("q=search&Q=search+again&x=otherthing", qm.toQueryString());
+        assertEquals("", qm.toQueryString());
     }
 
     @Test
-    @Ignore
+    public void simpleQuery() {
+        QueryMap qm = new QueryMap();
+        qm.add("q", "search").add("Q", "search again").add("x", "otherthing");
+        assertEquals("q=search&Q=search+again&x=otherthing", qm.toQueryString());
+    }
+
+    @Test
     public void complexQuery() {
         QueryMap qm = new QueryMap();
         qm.add("the query param", "the meaning of life: 42, according to Douglas Adams' Hitchiker's Guide to the Galaxy")
           .add("Q", "A & B & C & D * E @ F $ G % G ^ I & J ( K");
 
-        Assert.assertEquals("the+query+param=the+meaning+of+life%3A+42%2C+according+to+Douglas+Adams%27+Hitchiker%27s+Guide+to+the+Galaxy&"
+        assertEquals("the+query+param=the+meaning+of+life%3A+42%2C+according+to+Douglas+Adams%27+Hitchiker%27s+Guide+to+the+Galaxy&"
                 + "Q=A+%26+B+%26+C+%26+D+*+E+%40+F+%24+G+%25+G+%5E+I+%26+J+%28+K", qm.toQueryString());
     }
-
 }

--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/CachingPolicy.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/CachingPolicy.java
@@ -92,6 +92,8 @@ public class CachingPolicy extends AbstractMappedDataPolicy<CachingConfig> imple
                                     context.setConnectorInterceptor(new CacheConnectorInterceptor(cacheEntry));
                                     context.setAttribute(SHOULD_CACHE_ATTR, Boolean.FALSE);
                                     context.setAttribute(CACHED_RESPONSE, cacheEntry.getHead());
+                                } else {
+                                    context.setAttribute(SHOULD_CACHE_ATTR, Boolean.TRUE);
                                 }
                                 chain.doApply(request);
                             }
@@ -131,7 +133,7 @@ public class CachingPolicy extends AbstractMappedDataPolicy<CachingConfig> imple
 
         // Possibly cache the response for future posterity.
         // Check the response code against list in config (empty/null list means cache all).
-        final boolean shouldCache = (context.getAttribute(SHOULD_CACHE_ATTR, Boolean.TRUE) &&
+        final boolean shouldCache = (context.getAttribute(SHOULD_CACHE_ATTR, Boolean.FALSE) &&
                 ofNullable(policyConfiguration.getStatusCodes())
                     .map(statusCodes -> statusCodes.isEmpty() || statusCodes.contains(String.valueOf(response.getCode())))
                     .orElse(true));

--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/CachingPolicy.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/CachingPolicy.java
@@ -57,7 +57,7 @@ public class CachingPolicy extends AbstractMappedDataPolicy<CachingConfig> imple
     }
 
     /**
-     * @see io.apiman.gateway.engine.policy.AbstractPolicy#getConfigurationClass()
+     * @see io.apiman.gateway.engine.policies.AbstractMappedPolicy#getConfigurationClass()
      */
     @Override
     protected Class<CachingConfig> getConfigurationClass() {
@@ -77,7 +77,7 @@ public class CachingPolicy extends AbstractMappedDataPolicy<CachingConfig> imple
         if (config.getTtl() > 0) {
             // Check to see if there is a cache entry for this request.  If so, we need to
             // short-circuit the connector factory by providing a connector interceptor
-            String cacheId = buildCacheID(request);
+            String cacheId = buildCacheID(request, config);
             context.setAttribute(CACHE_ID_ATTR, cacheId);
             ICacheStoreComponent cache = context.getComponent(ICacheStoreComponent.class);
             cache.getBinary(cacheId, ApiResponse.class,
@@ -174,17 +174,27 @@ public class CachingPolicy extends AbstractMappedDataPolicy<CachingConfig> imple
      * verb and the destination. In the case where there's no API key the ID
      * will contain ApiOrgId + ApiId + ApiVersion
      */
-    private static String buildCacheID(ApiRequest request) {
-        StringBuilder req = new StringBuilder();
+    private static String buildCacheID(ApiRequest request, CachingConfig config) {
+        StringBuilder cacheId = new StringBuilder();
         if (request.getContract() != null) {
-            req.append(request.getApiKey());
+            cacheId.append(request.getApiKey());
         } else {
-            req.append(request.getApiOrgId()).append(KEY_SEPARATOR).append(request.getApiId())
+            cacheId.append(request.getApiOrgId()).append(KEY_SEPARATOR).append(request.getApiId())
                     .append(KEY_SEPARATOR).append(request.getApiVersion());
         }
-        req.append(KEY_SEPARATOR).append(request.getType()).append(KEY_SEPARATOR)
+        cacheId.append(KEY_SEPARATOR).append(request.getType()).append(KEY_SEPARATOR)
                 .append(request.getDestination());
-        return req.toString();
+
+        // According to RFC7234 (https://tools.ietf.org/html/rfc7234#section-2),
+        // 'The primary cache key consists of the request method and target URI.'
+        // For historical reasons, this is not the behaviour of this policy, which instead
+        // uses only the path part of the URI, not the query string.
+        // The behaviour mentioned in the RFC can be enabled using a configuration option.
+        if (config.isIncludeQueryInKey() && !request.getQueryParams().isEmpty()) {
+            cacheId.append("?").append(request.getQueryParams().toQueryString());
+        }
+
+        return cacheId.toString();
     }
 
 }

--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/config/CachingConfig.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/config/CachingConfig.java
@@ -27,6 +27,7 @@ public class CachingConfig {
 
     private long ttl; // in seconds
     private List<String> statusCodes = new ArrayList<>();
+    private boolean includeQueryInKey = false;
 
     /**
      * Constructor.
@@ -60,5 +61,21 @@ public class CachingConfig {
      */
     public void setStatusCodes(List<String> statusCodes) {
         this.statusCodes = statusCodes;
+    }
+
+    /**
+     * Whether to include query parameters in the cache key.
+     * @return {@code true} if query parameters should be included, otherwise, {@code false}
+     */
+    public boolean isIncludeQueryInKey() {
+        return includeQueryInKey;
+    }
+
+    /**
+     * Whether to include query parameters in the cache key.
+     * @param includeQueryInKey whether to include query parameters
+     */
+    public void setIncludeQueryInKey(boolean includeQueryInKey) {
+        this.includeQueryInKey = includeQueryInKey;
     }
 }

--- a/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/CachingPolicyTest.java
+++ b/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/CachingPolicyTest.java
@@ -23,8 +23,9 @@ import io.apiman.test.policies.PolicyTestRequestType;
 import io.apiman.test.policies.PolicyTestResponse;
 import io.apiman.test.policies.TestingPolicy;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * Unit test.
@@ -44,47 +45,47 @@ public class CachingPolicyTest extends ApimanPolicyTest {
 
         PolicyTestResponse response = send(request);
         EchoResponse echo = response.entity(EchoResponse.class);
-        Assert.assertNotNull(echo);
+        assertNotNull(echo);
         Long counterValue = echo.getCounter();
-        Assert.assertNotNull(counterValue);
-        Assert.assertEquals("application/json", response.header("Content-Type"));
+        assertNotNull(counterValue);
+        assertEquals("application/json", response.header("Content-Type"));
 
         // Now send the request again - we should get the *same* counter value!
         response = send(request);
         echo = response.entity(EchoResponse.class);
-        Assert.assertNotNull(echo);
+        assertNotNull(echo);
         Long counterValue2 = echo.getCounter();
-        Assert.assertNotNull(counterValue2);
-        Assert.assertEquals(counterValue, counterValue2);
-        Assert.assertEquals("application/json", response.header("Content-Type"));
+        assertNotNull(counterValue2);
+        assertEquals(counterValue, counterValue2);
+        assertEquals("application/json", response.header("Content-Type"));
 
         // One more time, just to be sure
         response = send(request);
         echo = response.entity(EchoResponse.class);
-        Assert.assertNotNull(echo);
+        assertNotNull(echo);
         Long counterValue3 = echo.getCounter();
-        Assert.assertNotNull(counterValue3);
-        Assert.assertEquals(counterValue, counterValue3);
-        Assert.assertEquals("application/json", response.header("Content-Type"));
+        assertNotNull(counterValue3);
+        assertEquals(counterValue, counterValue3);
+        assertEquals("application/json", response.header("Content-Type"));
 
         // Now wait for 3s and make sure the cache entry expired
         Thread.sleep(3000);
         response = send(request);
         echo = response.entity(EchoResponse.class);
-        Assert.assertNotNull(echo);
+        assertNotNull(echo);
         Long counterValue4 = echo.getCounter();
-        Assert.assertNotNull(counterValue4);
-        Assert.assertNotEquals(counterValue, counterValue4);
-        Assert.assertEquals("application/json", response.header("Content-Type"));
+        assertNotNull(counterValue4);
+        assertNotEquals(counterValue, counterValue4);
+        assertEquals("application/json", response.header("Content-Type"));
 
         // And again - should be re-cached
         response = send(request);
         echo = response.entity(EchoResponse.class);
-        Assert.assertNotNull(echo);
+        assertNotNull(echo);
         Long counterValue5 = echo.getCounter();
-        Assert.assertNotNull(counterValue5);
-        Assert.assertEquals(counterValue4, counterValue5);
-        Assert.assertEquals("application/json", response.header("Content-Type"));
+        assertNotNull(counterValue5);
+        assertEquals(counterValue4, counterValue5);
+        assertEquals("application/json", response.header("Content-Type"));
     }
 
     /**
@@ -102,27 +103,30 @@ public class CachingPolicyTest extends ApimanPolicyTest {
 
         PolicyTestResponse response = send(PolicyTestRequest.build(PolicyTestRequestType.GET, originalUri));
         EchoResponse echo = response.entity(EchoResponse.class);
-        Assert.assertNotNull(echo);
+        assertNotNull(echo);
         Long counterValue = echo.getCounter();
-        Assert.assertNotNull(counterValue);
-        Assert.assertEquals("application/json", response.header("Content-Type"));
+        assertNotNull(counterValue);
+        assertEquals("application/json", response.header("Content-Type"));
+        assertEquals(200, response.code());
 
         // Request with a different query string - expect an uncached response
         response = send(PolicyTestRequest.build(PolicyTestRequestType.GET, "/some/cached-resource?foo=different"));
         echo = response.entity(EchoResponse.class);
-        Assert.assertNotNull(echo);
+        assertNotNull(echo);
         Long counterValue2 = echo.getCounter();
-        Assert.assertNotNull(counterValue2);
-        Assert.assertNotEquals(counterValue, counterValue2);
-        Assert.assertEquals("application/json", response.header("Content-Type"));
+        assertNotNull(counterValue2);
+        assertNotEquals(counterValue, counterValue2);
+        assertEquals("application/json", response.header("Content-Type"));
+        assertEquals(200, response.code());
 
         // Request the original URI (including query string) - expect a cached response
         response = send(PolicyTestRequest.build(PolicyTestRequestType.GET, originalUri));
         echo = response.entity(EchoResponse.class);
-        Assert.assertNotNull(echo);
+        assertNotNull(echo);
         Long counterValue3 = echo.getCounter();
-        Assert.assertNotNull(counterValue3);
-        Assert.assertEquals(counterValue, counterValue3);
-        Assert.assertEquals("application/json", response.header("Content-Type"));
+        assertNotNull(counterValue3);
+        assertEquals(counterValue, counterValue3);
+        assertEquals("application/json", response.header("Content-Type"));
+        assertEquals(200, response.code());
     }
 }


### PR DESCRIPTION
## What is this?
* An alternative to #652, with a configuration option to maintain backwards compatibility.
* This enables the CachingPolicy to optionally include query string in its cache key, per RFC7234.

## Why?

According to RFC7234 (https://tools.ietf.org/html/rfc7234#section-2),
> 'The primary cache key consists of the request method and target URI.'

For historical reasons, this is not the behaviour of this policy, which instead uses only the path part of the URI, not the query string. The behaviour mentioned in the RFC can be enabled using a configuration option, `includeQueryInKey`, whose default is `false`.

Appropriate test coverage is added to verify the behaviour with the configuration [en|dis]abled. Also reenables ignored unit tests for QueryMap and adds another test case for an empty map.

## Implementation considerations

We should consider whether to default the behaviour to `true` as it currently violates the principle of least surprise (see #652).