### PR TITLE
Small fix for redirect in Tomcat (with Keycloak)

### DIFF
--- a/manager/ui/war/tomcat8/src/main/webapp/WEB-INF/web.xml
+++ b/manager/ui/war/tomcat8/src/main/webapp/WEB-INF/web.xml
@@ -88,10 +88,25 @@
       <web-resource-name>apimanui-3</web-resource-name>
       <url-pattern>/rest/*</url-pattern>
     </web-resource-collection>
+    <web-resource-collection>
+      <web-resource-name>apimanui-4</web-resource-name>
+      <url-pattern>/api-manager/*</url-pattern>
+    </web-resource-collection>
     <auth-constraint>
       <role-name>apiuser</role-name>
     </auth-constraint>
   </security-constraint>
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>apimanui-css</web-resource-name>
+      <url-pattern>/api-manager/dist/deps.css</url-pattern>
+    </web-resource-collection>
+    <web-resource-collection>
+      <web-resource-name>apimanui-css</web-resource-name>
+      <url-pattern>/api-manager/login/resources/css/login.css</url-pattern>
+    </web-resource-collection>
+  </security-constraint>
+
   <login-config>
     <auth-method>FORM</auth-method>
     <form-login-config>

--- a/manager/ui/war/tomcat8/src/main/webapp/login.html
+++ b/manager/ui/war/tomcat8/src/main/webapp/login.html
@@ -5,6 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
             <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <title>Log in to apiman</title>
+    <base href="/apimanui/"/>
     <link rel="icon" href="favicon.ico" />
     <link href="dist/deps.css" rel="stylesheet" />
     <link href="login/resources/css/login.css" rel="stylesheet" />


### PR DESCRIPTION
If the session was not valid there was no redirect to the login page of Tomcat 8.
With this small fix we are able to do a redirect and have a whitelisting of the login CSS files.

This works also if you use keycloak as login provider instead of tomcat. Otherwise also the keycloak login page was not loaded correctly.

Thanks @bekihm for finding this out and help me with the debugging of this :)

@msavy and @EricWittmann Please let us know what you think of this. 
