### PR TITLE
Adds Redis store implementations for cache, shared state and rate limiter

### DIFF
--- a/gateway/engine/es/pom.xml
+++ b/gateway/engine/es/pom.xml
@@ -32,6 +32,10 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>apiman-common-logging-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>apiman-gateway-engine-storage-common</artifactId>
+    </dependency>
 
     <!-- Third Party Dependencies -->
     <dependency>

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheStoreComponent.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheStoreComponent.java
@@ -15,26 +15,36 @@
  */
 package io.apiman.gateway.engine.hazelcast;
 
+import io.apiman.gateway.engine.DependsOnComponents;
 import io.apiman.gateway.engine.IRequiresInitialization;
+import io.apiman.gateway.engine.components.IBufferFactoryComponent;
 import io.apiman.gateway.engine.hazelcast.common.HazelcastBackingStoreProvider;
-import io.apiman.gateway.engine.storage.component.AbstractSharedStateComponent;
+import io.apiman.gateway.engine.hazelcast.common.HazelcastInstanceManager;
+import io.apiman.gateway.engine.storage.component.AbstractCacheStoreComponent;
 
 import java.util.Map;
 
 /**
- * Shared state component backed by a Hazelcast Map. This allows the shared state
- * to be easily clusterable.
+ * A Hazelcast implementation of a cache store.
  *
  * @author Pete Cornish
  */
-public class HazelcastSharedStateComponent extends AbstractSharedStateComponent implements IRequiresInitialization {
+@DependsOnComponents({IBufferFactoryComponent.class})
+public class HazelcastCacheStoreComponent extends AbstractCacheStoreComponent implements IRequiresInitialization {
     private final Map<String, String> componentConfig;
 
     /**
      * Constructor.
      */
-    public HazelcastSharedStateComponent(Map<String, String> componentConfig) {
-        super(new HazelcastBackingStoreProvider());
+    public HazelcastCacheStoreComponent(Map<String, String> componentConfig) {
+        this(HazelcastInstanceManager.DEFAULT_MANAGER, componentConfig);
+    }
+
+    /**
+     * Constructor.
+     */
+    public HazelcastCacheStoreComponent(HazelcastInstanceManager instanceManager, Map<String, String> componentConfig) {
+        super(new HazelcastBackingStoreProvider(instanceManager));
         this.componentConfig = componentConfig;
     }
 

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/common/HazelcastBackingStoreProvider.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/common/HazelcastBackingStoreProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.hazelcast.common;
+
+import io.apiman.gateway.engine.storage.store.IBackingStoreProvider;
+import io.apiman.gateway.engine.storage.store.MapBackingStore;
+
+/**
+ * Store provider for components backed by a Hazelcast Map.
+ *
+ * @author Pete Cornish
+ */
+public class HazelcastBackingStoreProvider implements IBackingStoreProvider<MapBackingStore> {
+    public static final String CONFIG_EAGER_INIT = "eager-init";
+
+    private final HazelcastInstanceManager instanceManager;
+
+    /**
+     * Constructor.
+     */
+    public HazelcastBackingStoreProvider() {
+        this(HazelcastInstanceManager.DEFAULT_MANAGER);
+    }
+
+    /**
+     * Constructor.
+     */
+    public HazelcastBackingStoreProvider(HazelcastInstanceManager instanceManager) {
+        this.instanceManager = instanceManager;
+    }
+
+    /**
+     * Returns an instance of the store for the store name.
+     *
+     * @return the store
+     */
+    @Override
+    public MapBackingStore get(String storeName) {
+        return new MapBackingStore(instanceManager.getHazelcastMap(storeName));
+    }
+}

--- a/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/common/HazelcastInstanceManager.java
+++ b/gateway/engine/hazelcast/src/main/java/io/apiman/gateway/engine/hazelcast/common/HazelcastInstanceManager.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.hazelcast.common;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Manages Hazelcast instances to reduce the amount of initialisation work on each I/O operation.
+ *
+ * @author Pete Cornish
+ */
+public final class HazelcastInstanceManager {
+    public static final HazelcastInstanceManager DEFAULT_MANAGER = new HazelcastInstanceManager();
+
+    private final Object mutex = new Object();
+    private final Map<String, Map<String, ?>> stores = Collections.synchronizedMap(new HashMap<>());
+    private Config overrideConfig;
+    private HazelcastInstance hazelcastInstance;
+
+    /**
+     * Generally, you don't want to initialise your own manager - instead, use the {@link #DEFAULT_MANAGER}.
+     */
+    public HazelcastInstanceManager() {
+    }
+
+    /**
+     * Override the default Hazelcast configuration discovery strategy.
+     */
+    public void setOverrideConfig(Config overrideConfig) {
+        this.overrideConfig = overrideConfig;
+    }
+
+    /**
+     * @param storeName a name to associate with the instance
+     * @return a new or existing Hazelcast instance for the given store name
+     */
+    @SuppressWarnings("unchecked")
+    public <T> Map<String, T> getHazelcastMap(String storeName) {
+        Map<String, ?> hzMap = stores.get(storeName);
+        if (null == hzMap) {
+            synchronized (mutex) {
+                if (null == hazelcastInstance) {
+                    hazelcastInstance = Hazelcast.newHazelcastInstance(overrideConfig);
+                }
+                if (null == stores.get(storeName)) {
+                    hzMap = hazelcastInstance.getMap(storeName);
+                    stores.put(storeName, hzMap);
+                }
+            }
+        }
+        return (Map<String, T>) hzMap;
+    }
+
+    /**
+     * Shut down the Hazelcast instance and clear stores references.
+     */
+    public void reset() {
+        if (null != hazelcastInstance) {
+            synchronized (mutex) {
+                if (null == hazelcastInstance) {
+                    hazelcastInstance.shutdown();
+                    hazelcastInstance = null;
+                }
+            }
+        }
+        if (!stores.isEmpty()) {
+            synchronized (mutex) {
+                stores.clear();
+            }
+        }
+    }
+}

--- a/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheStoreComponentTest.java
+++ b/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastCacheStoreComponentTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.hazelcast;
+
+import com.hazelcast.config.Config;
+import io.apiman.gateway.engine.hazelcast.common.HazelcastInstanceManager;
+import io.apiman.gateway.engine.hazelcast.model.Example;
+import io.apiman.gateway.engine.hazelcast.support.HazelcastConfigUtil;
+import io.apiman.gateway.engine.impl.ByteBufferFactoryComponent;
+import io.apiman.gateway.engine.io.ByteBuffer;
+import io.apiman.gateway.engine.io.ISignalReadStream;
+import io.apiman.gateway.engine.io.ISignalWriteStream;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Tests for {@link HazelcastCacheStoreComponent}.
+ *
+ * @author Pete Cornish
+ */
+public class HazelcastCacheStoreComponentTest {
+    private HazelcastCacheStoreComponent component;
+
+    @Before
+    public void setUp() {
+        final Config config = HazelcastConfigUtil.buildConfigWithDisabledNetwork();
+        HazelcastInstanceManager.DEFAULT_MANAGER.setOverrideConfig(config);
+
+        component = new HazelcastCacheStoreComponent(emptyMap());
+        component.setBufferFactory(new ByteBufferFactoryComponent());
+    }
+
+    @Test
+    public void putAndGetFromCluster() throws Exception {
+        final String cacheKey = "cacheKeySimple";
+        final Example cacheValue = new Example("cacheValue");
+
+        component.put(cacheKey, cacheValue, 120);
+        component.get(cacheKey, Example.class, result -> {
+            assertFalse("Result should be retrieved successfully from initial member", result.isError());
+            assertEquals(cacheValue, result.getResult());
+        });
+    }
+
+    @Test
+    public void putAndGetBinaryFromCluster() throws Exception {
+        final String cacheKey = "cacheKeyBinary";
+        final String cacheHead = "cacheHead";
+        final String cacheBody = "cacheBody";
+
+        final ISignalWriteStream writeStream = component.putBinary(cacheKey, cacheHead, 120);
+        writeStream.write(new ByteBuffer(cacheBody));
+        writeStream.end();
+
+        component.getBinary(cacheKey, String.class, result -> {
+            assertFalse("Result should be retrieved successfully from initial member", result.isError());
+
+            final ISignalReadStream<String> readStream = result.getResult();
+            readStream.bodyHandler(bodyResult -> assertEquals(cacheBody, new String(bodyResult.getBytes())));
+            readStream.endHandler(endResult -> { /* no op */});
+            readStream.transmit();
+
+            assertEquals(cacheHead, readStream.getHead());
+        });
+    }
+}

--- a/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastRateLimiterComponentTest.java
+++ b/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastRateLimiterComponentTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.hazelcast;
+
+import com.hazelcast.config.Config;
+import io.apiman.gateway.engine.hazelcast.common.HazelcastInstanceManager;
+import io.apiman.gateway.engine.hazelcast.support.HazelcastConfigUtil;
+import io.apiman.gateway.engine.rates.RateBucketPeriod;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link HazelcastRateLimiterComponent}.
+ *
+ * @author Pete Cornish
+ */
+public class HazelcastRateLimiterComponentTest {
+    private HazelcastRateLimiterComponent component;
+
+    @Before
+    public void setUp() throws Exception {
+        final Config config = HazelcastConfigUtil.buildConfigWithDisabledNetwork();
+        HazelcastInstanceManager.DEFAULT_MANAGER.setOverrideConfig(config);
+
+        component = new HazelcastRateLimiterComponent(emptyMap());
+    }
+
+    @Test
+    public void updateBucket_LimitNotReached() throws Exception {
+        component.accept("bucketId", RateBucketPeriod.Hour, 10, 1, result -> {
+            assertFalse("The bucket should be updated successfully", result.isError());
+            assertEquals("The remaining count should be correct", 9, result.getResult().getRemaining());
+            assertTrue(result.getResult().isAccepted());
+        });
+    }
+
+    @Test
+    public void updateBucket_LimitReached() throws Exception {
+        component.accept("bucketId", RateBucketPeriod.Hour, 10, 10, result -> {
+            assertFalse("The bucket should be updated successfully", result.isError());
+        });
+
+        // should now be at limit
+        component.accept("bucketId", RateBucketPeriod.Hour, 10, 1, result -> {
+            assertFalse("The bucket should be updated successfully", result.isError());
+            assertEquals("The remaining count should be correct", -1, result.getResult().getRemaining());
+            assertFalse(result.getResult().isAccepted());
+        });
+    }
+}

--- a/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastSharedStateComponentTest.java
+++ b/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/HazelcastSharedStateComponentTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.hazelcast;
+
+import com.hazelcast.config.Config;
+import io.apiman.gateway.engine.hazelcast.common.HazelcastInstanceManager;
+import io.apiman.gateway.engine.hazelcast.support.HazelcastConfigUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link HazelcastSharedStateComponent}.
+
+ * @author Pete Cornish
+ */
+public class HazelcastSharedStateComponentTest {
+    private HazelcastSharedStateComponent component;
+
+    @Before
+    public void setUp() throws Exception {
+        final Config config = HazelcastConfigUtil.buildConfigWithDisabledNetwork();
+        HazelcastInstanceManager.DEFAULT_MANAGER.setOverrideConfig(config);
+
+        component = new HazelcastSharedStateComponent(emptyMap());
+    }
+
+    @Test
+    public void getSetAndClearProperty() throws Exception {
+        final String namespace = "namespace";
+        final String propertyName = "propertyName";
+        final String propertyValue = "propertyValue";
+
+        component.setProperty(namespace, propertyName, propertyValue, result -> {
+            assertFalse("The property should be set successfully", result.isError());
+        });
+
+        component.getProperty(namespace, propertyName, "defaultValue", result -> {
+            assertFalse("The property should be fetched successfully", result.isError());
+            assertEquals(propertyValue, result.getResult());
+        });
+
+        component.clearProperty(namespace, propertyName, result -> {
+            assertFalse("The property should be cleared successfully", result.isError());
+        });
+
+        // retrieve the default for a non-existent property
+        component.getProperty(namespace, propertyName, "defaultValue", result -> {
+            assertFalse("The default property value should be returned", result.isError());
+            assertEquals("defaultValue", result.getResult());
+        });
+    }
+}

--- a/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/model/Example.java
+++ b/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/model/Example.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.hazelcast.model;
+
+import java.util.Objects;
+
+/**
+ * @author Pete Cornish
+ */
+public class Example {
+    private String data;
+
+    public Example() {
+    }
+
+    public Example(String data) {
+        this.data = data;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Example)) return false;
+        Example example = (Example) o;
+        return Objects.equals(data, example.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data);
+    }
+}

--- a/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/support/HazelcastConfigUtil.java
+++ b/gateway/engine/hazelcast/src/test/java/io/apiman/gateway/engine/hazelcast/support/HazelcastConfigUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.hazelcast.support;
+
+import com.hazelcast.config.*;
+
+/**
+ * @author Pete Cornish
+ */
+public final class HazelcastConfigUtil {
+    private HazelcastConfigUtil() {
+    }
+
+    /**
+     * @return a Hazelcast configuration with network options disabled.
+     */
+    public static Config buildConfigWithDisabledNetwork() {
+        return new Config() {{
+            getNetworkConfig().setJoin(new JoinConfig() {{
+                setMulticastConfig(new MulticastConfig() {{
+                    setEnabled(false);
+                }});
+                setTcpIpConfig(new TcpIpConfig() {{
+                    setEnabled(false);
+                }});
+                setAwsConfig(new AwsConfig() {{
+                    setEnabled(false);
+                }});
+            }});
+        }};
+    }
+}

--- a/gateway/engine/ispn/src/main/java/io/apiman/gateway/engine/ispn/InfinispanBackingStore.java
+++ b/gateway/engine/ispn/src/main/java/io/apiman/gateway/engine/ispn/InfinispanBackingStore.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.ispn;
+
+import io.apiman.gateway.engine.storage.store.IBackingStore;
+import org.infinispan.Cache;
+
+/**
+ * Store provider for components backed by an Infinispan cache.
+ */
+public class InfinispanBackingStore implements IBackingStore {
+    private final Cache<Object, Object> cache;
+
+    public InfinispanBackingStore(Cache<Object, Object> cache) {
+        this.cache = cache;
+    }
+
+    @Override
+    public void put(String key, Object value) {
+        cache.put(key, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T get(String key, Class<T> type) {
+        return (T) cache.get(key);
+    }
+
+    @Override
+    public void remove(String key) {
+        cache.remove(key);
+    }
+
+    @Override
+    public boolean containsKey(String key) {
+        return cache.containsKey(key);
+    }
+}

--- a/gateway/engine/ispn/src/main/java/io/apiman/gateway/engine/ispn/InfinispanBackingStoreProvider.java
+++ b/gateway/engine/ispn/src/main/java/io/apiman/gateway/engine/ispn/InfinispanBackingStoreProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.ispn;
+
+import io.apiman.gateway.engine.storage.store.IBackingStoreProvider;
+
+import java.util.Map;
+
+/**
+ * Store provider for components backed by an Infinispan cache.
+ *
+ * @author Pete Cornish
+ */
+public class InfinispanBackingStoreProvider extends AbstractInfinispanComponent
+        implements IBackingStoreProvider<InfinispanBackingStore> {
+
+    /**
+     * Constructor.
+     *
+     * @param config                the config
+     * @param defaultCacheContainer
+     * @param defaultCache
+     */
+    public InfinispanBackingStoreProvider(Map<String, String> config,
+                                          String defaultCacheContainer,
+                                          String defaultCache) {
+        super(config, defaultCacheContainer, defaultCache);
+    }
+
+    @Override
+    public InfinispanBackingStore get(String storeName) {
+        return new InfinispanBackingStore(getCache());
+    }
+}

--- a/gateway/engine/ispn/src/main/java/io/apiman/gateway/engine/ispn/InfinispanRateLimiterComponent.java
+++ b/gateway/engine/ispn/src/main/java/io/apiman/gateway/engine/ispn/InfinispanRateLimiterComponent.java
@@ -15,12 +15,7 @@
  */
 package io.apiman.gateway.engine.ispn;
 
-import io.apiman.gateway.engine.async.AsyncResultImpl;
-import io.apiman.gateway.engine.async.IAsyncResultHandler;
-import io.apiman.gateway.engine.components.IRateLimiterComponent;
-import io.apiman.gateway.engine.components.rate.RateLimitResponse;
-import io.apiman.gateway.engine.rates.RateBucketPeriod;
-import io.apiman.gateway.engine.rates.RateLimiterBucket;
+import io.apiman.gateway.engine.storage.component.AbstractRateLimiterComponent;
 
 import java.util.Collections;
 import java.util.Map;
@@ -31,56 +26,23 @@ import java.util.Map;
  *
  * @author eric.wittmann@redhat.com
  */
-public class InfinispanRateLimiterComponent extends AbstractInfinispanComponent implements IRateLimiterComponent {
+public class InfinispanRateLimiterComponent extends AbstractRateLimiterComponent {
 
     private static final String DEFAULT_CACHE_CONTAINER = "java:jboss/infinispan/apiman"; //$NON-NLS-1$
-    private static final String DEFAULT_CACHE = "rate-limiter"; //$NON-NLS-1$
-
-    private Object mutex = new Object();
 
     /**
      * Constructor.
      */
     public InfinispanRateLimiterComponent() {
-        this(Collections.EMPTY_MAP);
+        this(Collections.emptyMap());
     }
 
     /**
      * Constructor.
+     *
      * @param config the config
      */
     public InfinispanRateLimiterComponent(Map<String, String> config) {
-        super(config, DEFAULT_CACHE_CONTAINER, DEFAULT_CACHE);
-    }
-
-    /**
-     * @see io.apiman.gateway.engine.components.IRateLimiterComponent#accept(java.lang.String, io.apiman.gateway.engine.rates.RateBucketPeriod, long, long, io.apiman.gateway.engine.async.IAsyncResultHandler)
-     */
-    @Override
-    public void accept(final String bucketId, final RateBucketPeriod period, final long limit,
-            final long increment, final IAsyncResultHandler<RateLimitResponse> handler) {
-        RateLimiterBucket bucket;
-        synchronized (mutex) {
-            bucket = (RateLimiterBucket) getCache().get(bucketId);
-            if (bucket == null) {
-                bucket = new RateLimiterBucket();
-                getCache().put(bucketId, bucket);
-            }
-            bucket.resetIfNecessary(period);
-
-            RateLimitResponse response = new RateLimitResponse();
-            if (bucket.getCount() > limit) {
-                response.setAccepted(false);
-            } else {
-                response.setAccepted(bucket.getCount() < limit);
-                bucket.setCount(bucket.getCount() + increment);
-                bucket.setLast(System.currentTimeMillis());
-            }
-            int reset = (int) (bucket.getResetMillis(period) / 1000L);
-            response.setReset(reset);
-            response.setRemaining(limit - bucket.getCount());
-            handler.handle(AsyncResultImpl.<RateLimitResponse>create(response));
-            getCache().put(bucketId, bucket);
-        }
+        super(new InfinispanBackingStoreProvider(config, DEFAULT_CACHE_CONTAINER, STORE_NAME));
     }
 }

--- a/gateway/engine/pom.xml
+++ b/gateway/engine/pom.xml
@@ -22,6 +22,8 @@
     <module>osgi</module>
     <module>policies</module>
     <module>prometheus</module>
+    <module>redis</module>
+    <module>storage-common</module>
     <module>vertx-eb-inmemory</module>
     <module>vertx-polling</module>
     <module>vertx-shareddata</module>

--- a/gateway/engine/redis/examples/redisson-config-example.json
+++ b/gateway/engine/redis/examples/redisson-config-example.json
@@ -1,0 +1,41 @@
+{
+  "clusterServersConfig": {
+    "idleConnectionTimeout": 10000,
+    "pingTimeout": 1000,
+    "connectTimeout": 10000,
+    "timeout": 3000,
+    "retryAttempts": 3,
+    "retryInterval": 1500,
+    "failedSlaveReconnectionInterval": 3000,
+    "failedSlaveCheckInterval": 60000,
+    "password": null,
+    "subscriptionsPerConnection": 5,
+    "clientName": null,
+    "loadBalancer": {
+      "class": "org.redisson.connection.balancer.RoundRobinLoadBalancer"
+    },
+    "subscriptionConnectionMinimumIdleSize": 1,
+    "subscriptionConnectionPoolSize": 50,
+    "slaveConnectionMinimumIdleSize": 32,
+    "slaveConnectionPoolSize": 64,
+    "masterConnectionMinimumIdleSize": 32,
+    "masterConnectionPoolSize": 64,
+    "readMode": "SLAVE",
+    "subscriptionMode": "SLAVE",
+    "nodeAddresses": [
+      "redis://127.0.0.1:7004",
+      "redis://127.0.0.1:7001",
+      "redis://127.0.0.1:7000"
+    ],
+    "scanInterval": 1000,
+    "pingConnectionInterval": 0,
+    "keepAlive": false,
+    "tcpNoDelay": false
+  },
+  "threads": 0,
+  "nettyThreads": 0,
+  "codec": {
+    "class": "org.redisson.codec.JsonJacksonCodec"
+  },
+  "transportMode": "NIO"
+}

--- a/gateway/engine/redis/pom.xml
+++ b/gateway/engine/redis/pom.xml
@@ -6,9 +6,9 @@
     <artifactId>apiman-gateway-engine</artifactId>
     <version>1.5.2-SNAPSHOT</version>
   </parent>
-  <artifactId>apiman-gateway-engine-hazelcast</artifactId>
+  <artifactId>apiman-gateway-engine-redis</artifactId>
   <packaging>bundle</packaging>
-  <name>apiman-gateway-engine-hazelcast</name>
+  <name>apiman-gateway-engine-redis</name>
 
   <dependencies>
     <!-- Project Dependencies -->
@@ -31,28 +31,39 @@
 
     <!-- Third Party Dependencies -->
     <dependency>
-      <groupId>com.hazelcast</groupId>
-      <artifactId>hazelcast</artifactId>
-      <!--
-        Important: Hazelcast should be added to the container's classpath (e.g. 'lib'),
-        not packaged within the engine deployable (e.g. WAR), otherwise odd classloading
-        issues can occur.
-       -->
-      <scope>provided</scope>
+      <groupId>org.redisson</groupId>
+      <artifactId>redisson</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
 
     <!-- Test only -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/gateway/engine/redis/src/main/java/io/apiman/gateway/engine/redis/RedisCacheStoreComponent.java
+++ b/gateway/engine/redis/src/main/java/io/apiman/gateway/engine/redis/RedisCacheStoreComponent.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.redis;
+
+import io.apiman.gateway.engine.DependsOnComponents;
+import io.apiman.gateway.engine.components.IBufferFactoryComponent;
+import io.apiman.gateway.engine.redis.common.RedisBackingStoreProvider;
+import io.apiman.gateway.engine.redis.common.RedisClientManager;
+import io.apiman.gateway.engine.storage.component.AbstractCacheStoreComponent;
+
+import java.util.Map;
+
+/**
+ * A Redis implementation of a cache store.
+ *
+ * @author Pete Cornish
+ */
+@DependsOnComponents({IBufferFactoryComponent.class})
+public class RedisCacheStoreComponent extends AbstractCacheStoreComponent {
+    /**
+     * Constructor.
+     */
+    public RedisCacheStoreComponent(Map<String, String> componentConfig) {
+        this(RedisClientManager.DEFAULT_MANAGER, componentConfig);
+    }
+
+    /**
+     * Constructor.
+     */
+    public RedisCacheStoreComponent(RedisClientManager poolManager, Map<String, String> componentConfig) {
+        super(new RedisBackingStoreProvider(poolManager, componentConfig));
+    }
+}

--- a/gateway/engine/redis/src/main/java/io/apiman/gateway/engine/redis/RedisRateLimiterComponent.java
+++ b/gateway/engine/redis/src/main/java/io/apiman/gateway/engine/redis/RedisRateLimiterComponent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.redis;
+
+import io.apiman.gateway.engine.redis.common.RedisBackingStoreProvider;
+import io.apiman.gateway.engine.storage.component.AbstractRateLimiterComponent;
+
+import java.util.Map;
+
+/**
+ * Rate limiter component backed by Redis.
+ *
+ * @author Pete Cornish
+ */
+public class RedisRateLimiterComponent extends AbstractRateLimiterComponent {
+    /**
+     * Constructor.
+     */
+    public RedisRateLimiterComponent(Map<String, String> componentConfig) {
+        super(new RedisBackingStoreProvider(componentConfig));
+    }
+}

--- a/gateway/engine/redis/src/main/java/io/apiman/gateway/engine/redis/RedisSharedStateComponent.java
+++ b/gateway/engine/redis/src/main/java/io/apiman/gateway/engine/redis/RedisSharedStateComponent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.redis;
+
+import io.apiman.gateway.engine.redis.common.RedisBackingStoreProvider;
+import io.apiman.gateway.engine.storage.component.AbstractSharedStateComponent;
+
+import java.util.Map;
+
+/**
+ * Shared state component backed by Redis.
+ *
+ * @author Pete Cornish
+ */
+public class RedisSharedStateComponent extends AbstractSharedStateComponent {
+    /**
+     * Constructor.
+     */
+    public RedisSharedStateComponent(Map<String, String> componentConfig) {
+        super(new RedisBackingStoreProvider(componentConfig));
+    }
+}

--- a/gateway/engine/redis/src/main/java/io/apiman/gateway/engine/redis/common/RedisBackingStore.java
+++ b/gateway/engine/redis/src/main/java/io/apiman/gateway/engine/redis/common/RedisBackingStore.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.redis.common;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apiman.gateway.engine.storage.store.IBackingStore;
+import io.apiman.gateway.engine.storage.util.BackingStoreUtil;
+import org.redisson.api.RMap;
+import org.redisson.api.RedissonClient;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static io.apiman.gateway.engine.storage.util.BackingStoreUtil.JSON_MAPPER;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+/**
+ * Provides a Redis backing store, whose keys are namespaced with a prefix.
+ * This is implemented using a {@link RedissonClient}.
+ */
+public class RedisBackingStore implements IBackingStore {
+    private final RedissonClient client;
+    private final String prefix;
+
+    public RedisBackingStore(RedissonClient client, String prefix) {
+        this.client = client;
+        this.prefix = prefix;
+    }
+
+    /**
+     * Pass an {@link RMap} to the function and return its result.
+     *
+     * @param func the function to apply using the {@link RMap}
+     * @return the result
+     */
+    private <T> T onMap(Function<RMap<String, String>, T> func) {
+        final RMap<String, String> map = client.getMap(prefix);
+        return func.apply(map);
+    }
+
+    /**
+     * Pass an {@link RMap} to the consumer.
+     *
+     * @param consumer the consumer of the {@link RMap}
+     */
+    private void withMap(Consumer<RMap<String, String>> consumer) {
+        final RMap<String, String> map = client.getMap(prefix);
+        consumer.accept(map);
+    }
+
+    @Override
+    public void put(String key, Object value) {
+        withMap(map -> {
+            try {
+                final String raw;
+                if (isNull(value)) {
+                    raw = null;
+                } else if (value.getClass().isPrimitive() || value instanceof String) {
+                    raw = value.toString();
+                } else {
+                    raw = JSON_MAPPER.writeValueAsString(value);
+                }
+                map.put(key, raw);
+
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(String.format("Error setting value for key '%s'", key), e);
+            }
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T get(String key, Class<T> type) {
+        return onMap(map -> {
+            try {
+                final String raw = map.get(key);
+                if (isNull(raw)) {
+                    return null;
+                } else if (type.isPrimitive() || type.isAssignableFrom(String.class)) {
+                    return (T) BackingStoreUtil.readPrimitive(type, raw);
+                } else {
+                    return JSON_MAPPER.readValue(raw, type);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(String.format("Error reading value for key '%s'", key), e);
+            }
+        });
+    }
+
+    @Override
+    public void remove(String key) {
+        withMap(map -> {
+            try {
+                map.remove(key);
+            } catch (Exception e) {
+                throw new RuntimeException(String.format("Error removing value for key '%s'", key), e);
+            }
+        });
+    }
+
+    @Override
+    public boolean containsKey(String key) {
+        return onMap(map -> nonNull(map.get(key)));
+    }
+}

--- a/gateway/engine/redis/src/main/java/io/apiman/gateway/engine/redis/common/RedisBackingStoreProvider.java
+++ b/gateway/engine/redis/src/main/java/io/apiman/gateway/engine/redis/common/RedisBackingStoreProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.redis.common;
+
+import io.apiman.gateway.engine.storage.store.IBackingStoreProvider;
+import org.apache.commons.lang3.StringUtils;
+
+import java.nio.file.Paths;
+import java.util.Map;
+
+/**
+ * Store provider for components backed by Redis.
+ *
+ * @author Pete Cornish
+ */
+public class RedisBackingStoreProvider implements IBackingStoreProvider<RedisBackingStore> {
+    public static final String CONFIG_FILE = "config.file";
+
+    private final RedisClientManager clientManager;
+
+    /**
+     * Constructor.
+     */
+    public RedisBackingStoreProvider(Map<String, String> componentConfig) {
+        this(RedisClientManager.DEFAULT_MANAGER, componentConfig);
+    }
+
+    /**
+     * Constructor.
+     */
+    public RedisBackingStoreProvider(RedisClientManager clientManager, Map<String, String> componentConfig) {
+        this.clientManager = clientManager;
+        final String configFilePath = componentConfig.get(CONFIG_FILE);
+        if (StringUtils.isNotBlank(configFilePath)) {
+            clientManager.setConfigFile(Paths.get(configFilePath));
+        }
+    }
+
+    /**
+     * Returns a namespaced instance of the store for the store name.
+     *
+     * @return the Map
+     */
+    @Override
+    public RedisBackingStore get(String storeName) {
+        return clientManager.getRedis(storeName);
+    }
+}

--- a/gateway/engine/redis/src/main/java/io/apiman/gateway/engine/redis/common/RedisClientManager.java
+++ b/gateway/engine/redis/src/main/java/io/apiman/gateway/engine/redis/common/RedisClientManager.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.redis.common;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.Codec;
+import org.redisson.client.codec.StringCodec;
+import org.redisson.config.Config;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+/**
+ * Manages Redis clients to reduce the amount of initialisation work on each I/O operation.
+ *
+ * @author Pete Cornish
+ */
+public final class RedisClientManager {
+    public static final RedisClientManager DEFAULT_MANAGER = new RedisClientManager();
+
+    private final Object mutex = new Object();
+    private Config overrideConfig;
+    private File configFile;
+    private RedissonClient client;
+
+    /**
+     * Generally, you don't want to initialise your own manager - instead, use the {@link #DEFAULT_MANAGER}.
+     */
+    public RedisClientManager() {
+    }
+
+    /**
+     * Override the default Redis configuration discovery strategy.
+     */
+    public void setConfigFile(Path configFilePath) {
+        this.configFile = configFilePath.toFile();
+    }
+
+    /**
+     * Override the default Redis configuration discovery strategy.
+     */
+    public void setOverrideConfig(Config overrideConfig) {
+        this.overrideConfig = overrideConfig;
+    }
+
+    /**
+     * @param storeName a name to associate with the instance
+     * @return a new or existing Redis client for the given store name
+     */
+    public RedisBackingStore getRedis(String storeName) {
+        if (isNull(client)) {
+            synchronized (mutex) {
+                if (isNull(client)) { // double-guard
+                    final Config config;
+                    if (nonNull(overrideConfig)) {
+                        config = overrideConfig;
+                    } else if (nonNull(configFile)) {
+                        config = loadConfigFromFile();
+                    } else {
+                        throw new IllegalStateException("No Redisson configuration provided");
+                    }
+                    config.setCodec(new StringCodec());
+                    client = Redisson.create(config);
+                }
+            }
+        }
+        return new RedisBackingStore(client, storeName);
+    }
+
+    private Config loadConfigFromFile() {
+        if (configFile.exists()) {
+            try {
+                return Config.fromJSON(configFile);
+            } catch (IOException e) {
+                throw new RuntimeException(String.format("Error reading Redisson configuration file: %s", configFile), e);
+            }
+        } else {
+            throw new RuntimeException(String.format("Redisson configuration file: '%s' does not exist", configFile));
+        }
+    }
+
+    /**
+     * Shut down the Redis client.
+     */
+    public void reset() {
+        if (nonNull(client)) {
+            synchronized (mutex) {
+                if (nonNull(client)) { // double-guard
+                    client.shutdown();
+                    client = null;
+                }
+            }
+        }
+    }
+}

--- a/gateway/engine/redis/src/test/java/io/apiman/gateway/engine/redis/RedisCacheStoreComponentTest.java
+++ b/gateway/engine/redis/src/test/java/io/apiman/gateway/engine/redis/RedisCacheStoreComponentTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.redis;
+
+import io.apiman.gateway.engine.impl.ByteBufferFactoryComponent;
+import io.apiman.gateway.engine.io.ByteBuffer;
+import io.apiman.gateway.engine.io.ISignalReadStream;
+import io.apiman.gateway.engine.io.ISignalWriteStream;
+import io.apiman.gateway.engine.redis.common.RedisClientManager;
+import io.apiman.gateway.engine.redis.model.Example;
+import io.apiman.gateway.engine.redis.support.TestRedisUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.GenericContainer;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Tests for {@link RedisCacheStoreComponent}.
+ *
+ * @author Pete Cornish
+ */
+public class RedisCacheStoreComponentTest {
+    @Rule
+    public GenericContainer redis = TestRedisUtil.buildRedisContainer();
+
+    private RedisCacheStoreComponent component;
+
+    @Before
+    public void setUp() {
+        RedisClientManager.DEFAULT_MANAGER.reset();
+        RedisClientManager.DEFAULT_MANAGER.setOverrideConfig(TestRedisUtil.buildComponentConfig(redis));
+        component = new RedisCacheStoreComponent(emptyMap());
+        component.setBufferFactory(new ByteBufferFactoryComponent());
+    }
+
+    @Test
+    public void putAndGet() throws Exception {
+        final String cacheKey = "cacheKeySimple";
+        final Example cacheValue = new Example("cacheValue");
+
+        component.put(cacheKey, cacheValue, 120);
+        component.get(cacheKey, Example.class, result -> {
+            assertFalse("Result should be retrieved successfully", result.isError());
+            assertEquals(cacheValue, result.getResult());
+        });
+    }
+
+    @Test
+    public void putAndGetBinary() throws Exception {
+        final String cacheKey = "cacheKeyBinary";
+        final String cacheHead = "cacheHead";
+        final String cacheBody = "cacheBody";
+
+        final ISignalWriteStream writeStream = component.putBinary(cacheKey, cacheHead, 120);
+        writeStream.write(new ByteBuffer(cacheBody));
+        writeStream.end();
+
+        component.getBinary(cacheKey, String.class, result -> {
+            assertFalse("Result should be retrieved successfully", result.isError());
+
+            final ISignalReadStream<String> readStream = result.getResult();
+            readStream.bodyHandler(bodyResult -> assertEquals(cacheBody, new String(bodyResult.getBytes())));
+            readStream.endHandler(endResult -> { /* no op */ });
+            readStream.transmit();
+
+            assertEquals(cacheHead, readStream.getHead());
+        });
+    }
+}

--- a/gateway/engine/redis/src/test/java/io/apiman/gateway/engine/redis/RedisRateLimiterComponentTest.java
+++ b/gateway/engine/redis/src/test/java/io/apiman/gateway/engine/redis/RedisRateLimiterComponentTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.redis;
+
+import io.apiman.gateway.engine.rates.RateBucketPeriod;
+import io.apiman.gateway.engine.redis.common.RedisClientManager;
+import io.apiman.gateway.engine.redis.support.TestRedisUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.GenericContainer;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link RedisRateLimiterComponent}.
+ *
+ * @author Pete Cornish
+ */
+public class RedisRateLimiterComponentTest {
+    @Rule
+    public GenericContainer redis = TestRedisUtil.buildRedisContainer();
+
+    private RedisRateLimiterComponent component;
+
+    @Before
+    public void setUp() {
+        RedisClientManager.DEFAULT_MANAGER.reset();
+        RedisClientManager.DEFAULT_MANAGER.setOverrideConfig(TestRedisUtil.buildComponentConfig(redis));
+        component = new RedisRateLimiterComponent(emptyMap());
+    }
+
+    @Test
+    public void updateBucket_LimitNotReached() {
+        component.accept("bucketId", RateBucketPeriod.Hour, 10, 1, result -> {
+            assertFalse("The bucket should be updated successfully", result.isError());
+            assertEquals("The remaining count should be correct", 9, result.getResult().getRemaining());
+            assertTrue(result.getResult().isAccepted());
+        });
+    }
+
+    @Test
+    public void updateBucket_LimitReached() {
+        component.accept("bucketId", RateBucketPeriod.Hour, 10, 10, result -> {
+            assertFalse("The bucket should be updated successfully", result.isError());
+        });
+
+        // should now be at limit
+        component.accept("bucketId", RateBucketPeriod.Hour, 10, 1, result -> {
+            assertFalse("The bucket should be updated successfully", result.isError());
+            assertEquals("The remaining count should be correct", -1, result.getResult().getRemaining());
+            assertFalse(result.getResult().isAccepted());
+        });
+    }
+}

--- a/gateway/engine/redis/src/test/java/io/apiman/gateway/engine/redis/RedisSharedStateComponentTest.java
+++ b/gateway/engine/redis/src/test/java/io/apiman/gateway/engine/redis/RedisSharedStateComponentTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.redis;
+
+import io.apiman.gateway.engine.redis.common.RedisClientManager;
+import io.apiman.gateway.engine.redis.support.TestRedisUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.GenericContainer;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Tests for {@link RedisSharedStateComponent}.
+ *
+ * @author Pete Cornish
+ */
+public class RedisSharedStateComponentTest {
+    @Rule
+    public GenericContainer redis = TestRedisUtil.buildRedisContainer();
+
+    private RedisSharedStateComponent component;
+
+    @Before
+    public void setUp() {
+        RedisClientManager.DEFAULT_MANAGER.reset();
+        RedisClientManager.DEFAULT_MANAGER.setOverrideConfig(TestRedisUtil.buildComponentConfig(redis));
+        component = new RedisSharedStateComponent(emptyMap());
+    }
+
+    @Test
+    public void getSetAndClearProperty() {
+        final String namespace = "namespace";
+        final String propertyName = "propertyName";
+        final String propertyValue = "propertyValue";
+
+        component.setProperty(namespace, propertyName, propertyValue, result -> {
+            if (null != result.getError()) {
+                result.getError().printStackTrace();
+            }
+            assertFalse("The property should be set successfully", result.isError());
+        });
+
+        component.getProperty(namespace, propertyName, "defaultValue", result -> {
+            if (null != result.getError()) {
+                result.getError().printStackTrace();
+            }
+            assertFalse("The property should be fetched successfully", result.isError());
+            assertEquals(propertyValue, result.getResult());
+        });
+
+        component.clearProperty(namespace, propertyName, result -> {
+            if (null != result.getError()) {
+                result.getError().printStackTrace();
+            }
+            assertFalse("The property should be cleared successfully", result.isError());
+        });
+
+        // retrieve the default for a non-existent property
+        component.getProperty(namespace, propertyName, "defaultValue", result -> {
+            if (null != result.getError()) {
+                result.getError().printStackTrace();
+            }
+            assertFalse("The default property value should be returned", result.isError());
+            assertEquals("defaultValue", result.getResult());
+        });
+    }
+}

--- a/gateway/engine/redis/src/test/java/io/apiman/gateway/engine/redis/model/Example.java
+++ b/gateway/engine/redis/src/test/java/io/apiman/gateway/engine/redis/model/Example.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.redis.model;
+
+import java.util.Objects;
+
+/**
+ * @author Pete Cornish
+ */
+public class Example {
+    private String data;
+
+    public Example() {
+    }
+
+    public Example(String data) {
+        this.data = data;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Example)) return false;
+        Example example = (Example) o;
+        return Objects.equals(data, example.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data);
+    }
+}

--- a/gateway/engine/redis/src/test/java/io/apiman/gateway/engine/redis/support/TestRedisUtil.java
+++ b/gateway/engine/redis/src/test/java/io/apiman/gateway/engine/redis/support/TestRedisUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.redis.support;
+
+import org.redisson.config.Config;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public final class TestRedisUtil {
+    private TestRedisUtil() {
+    }
+
+    public static GenericContainer buildRedisContainer() {
+        return new GenericContainer("redis:3.0.6")
+                .withExposedPorts(6379)
+                .waitingFor(Wait.forListeningPort());
+    }
+
+    public static Config buildComponentConfig(GenericContainer redis) {
+        final String address = "redis://" + redis.getContainerIpAddress() + ":" + redis.getMappedPort(6379);
+        final Config config = new Config();
+        config.useSingleServer().setAddress(address);
+        return config;
+    }
+}

--- a/gateway/engine/redis/src/test/resources/log4j.properties
+++ b/gateway/engine/redis/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %m%n
+
+# Root logger option
+log4j.rootLogger=INFO, stdout

--- a/gateway/engine/storage-common/pom.xml
+++ b/gateway/engine/storage-common/pom.xml
@@ -6,47 +6,31 @@
     <artifactId>apiman-gateway-engine</artifactId>
     <version>1.5.2-SNAPSHOT</version>
   </parent>
-  <artifactId>apiman-gateway-engine-ispn</artifactId>
+  <artifactId>apiman-gateway-engine-storage-common</artifactId>
   <packaging>bundle</packaging>
-  <name>apiman-gateway-engine-ispn</name>
+  <name>apiman-gateway-engine-storage-common</name>
 
   <dependencies>
     <!-- Project Dependencies -->
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>apiman-common-util</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>apiman-gateway-engine-beans</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>apiman-gateway-engine-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>apiman-gateway-engine-storage-common</artifactId>
     </dependency>
 
     <!-- Third Party Dependencies -->
-    <dependency>
-      <groupId>org.infinispan</groupId>
-      <artifactId>infinispan-core</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.infinispan</groupId>
-      <artifactId>infinispan-commons</artifactId>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/component/AbstractRateLimiterComponent.java
+++ b/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/component/AbstractRateLimiterComponent.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.storage.component;
+
+import io.apiman.gateway.engine.async.AsyncResultImpl;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.components.IRateLimiterComponent;
+import io.apiman.gateway.engine.components.rate.RateLimitResponse;
+import io.apiman.gateway.engine.rates.RateBucketPeriod;
+import io.apiman.gateway.engine.rates.RateLimiterBucket;
+import io.apiman.gateway.engine.storage.store.IBackingStoreProvider;
+
+/**
+ * Rate limiter component backed by a store.
+ *
+ * @author Pete Cornish
+ */
+public abstract class AbstractRateLimiterComponent extends AbstractStorageComponent implements IRateLimiterComponent {
+    protected static final String STORE_NAME = "rate-limiter"; //$NON-NLS-1$
+
+    private final Object mutex = new Object();
+
+    /**
+     * Constructor.
+     */
+    public AbstractRateLimiterComponent(IBackingStoreProvider storeProvider) {
+        super(storeProvider, STORE_NAME);
+    }
+
+    /**
+     * @see IRateLimiterComponent#accept(String, RateBucketPeriod, long, long, IAsyncResultHandler)
+     */
+    @Override
+    public void accept(final String bucketId, final RateBucketPeriod period, final long limit,
+                       final long increment, final IAsyncResultHandler<RateLimitResponse> handler) {
+        RateLimiterBucket bucket;
+        synchronized (mutex) {
+            bucket = getStore().get(bucketId, RateLimiterBucket.class);
+            if (bucket == null) {
+                bucket = new RateLimiterBucket();
+                getStore().put(bucketId, bucket);
+            }
+            bucket.resetIfNecessary(period);
+
+            RateLimitResponse response = new RateLimitResponse();
+            if (bucket.getCount() > limit) {
+                response.setAccepted(false);
+            } else {
+                response.setAccepted(bucket.getCount() < limit);
+                bucket.setCount(bucket.getCount() + increment);
+                bucket.setLast(System.currentTimeMillis());
+            }
+            int reset = (int) (bucket.getResetMillis(period) / 1000L);
+            response.setReset(reset);
+            response.setRemaining(limit - bucket.getCount());
+            handler.handle(AsyncResultImpl.create(response));
+            getStore().put(bucketId, bucket);
+        }
+    }
+}

--- a/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/component/AbstractSharedStateComponent.java
+++ b/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/component/AbstractSharedStateComponent.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.storage.component;
+
+import io.apiman.gateway.engine.async.AsyncResultImpl;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.components.ISharedStateComponent;
+import io.apiman.gateway.engine.storage.store.IBackingStoreProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.Objects.isNull;
+
+/**
+ * Shared state component backed by a store.
+ *
+ * @author Pete Cornish
+ */
+public abstract class AbstractSharedStateComponent extends AbstractStorageComponent implements ISharedStateComponent {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSharedStateComponent.class);
+    private static final String STORE_NAME = "shared-state"; //$NON-NLS-1$
+
+    /**
+     * Constructor.
+     */
+    public AbstractSharedStateComponent(IBackingStoreProvider storeProvider) {
+        super(storeProvider, STORE_NAME);
+    }
+
+    /**
+     * @see ISharedStateComponent#getProperty(String, String, Object, IAsyncResultHandler)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> void getProperty(String namespace, String propertyName, T defaultValue, IAsyncResultHandler<T> handler) {
+        if (isNull(defaultValue)) {
+            handler.handle(AsyncResultImpl.create(new Exception("Null defaultValue is not allowed.")));
+            return;
+        }
+        final String namespacedKey = buildNamespacedKey(namespace, propertyName);
+        if (getStore().containsKey(namespacedKey)) {
+            try {
+                final Class<T> valueClass = (Class<T>) defaultValue.getClass();
+                final T rval = getStore().get(namespacedKey, valueClass);
+                handler.handle(AsyncResultImpl.create(rval));
+
+            } catch (Exception e) {
+                LOGGER.error("Error reading from shared state with namespace: {} and key: {}",
+                        namespace, propertyName, e);
+
+                handler.handle(AsyncResultImpl.create(e));
+            }
+
+        } else {
+            handler.handle(AsyncResultImpl.create(defaultValue));
+        }
+    }
+
+    /**
+     * @see ISharedStateComponent#setProperty(String, String, Object, IAsyncResultHandler)
+     */
+    @Override
+    public <T> void setProperty(String namespace, String propertyName, T value, IAsyncResultHandler<Void> handler) {
+        final String namespacedKey = buildNamespacedKey(namespace, propertyName);
+        try {
+            getStore().put(namespacedKey, value);
+            handler.handle(AsyncResultImpl.create((Void) null));
+
+        } catch (Exception e) {
+            LOGGER.error("Error writing to shared state with namespace: {} and key: {}",
+                    namespace, propertyName, e);
+
+            handler.handle(AsyncResultImpl.create(e));
+        }
+    }
+
+    /**
+     * @see ISharedStateComponent#clearProperty(String, String, IAsyncResultHandler)
+     */
+    @Override
+    public <T> void clearProperty(String namespace, String propertyName, IAsyncResultHandler<Void> handler) {
+        final String namespacedKey = buildNamespacedKey(namespace, propertyName);
+        try {
+            getStore().remove(namespacedKey);
+            handler.handle(AsyncResultImpl.create((Void) null));
+
+        } catch (Exception e) {
+            LOGGER.error("Error removing entry from shared state with namespace: {} and key: {}",
+                    namespace, propertyName, e);
+
+            handler.handle(AsyncResultImpl.create(e));
+        }
+    }
+}

--- a/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/component/AbstractStorageComponent.java
+++ b/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/component/AbstractStorageComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Pete Cornish
+ * Copyright 2018 Pete Cornish
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,54 +13,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.apiman.gateway.engine.hazelcast;
+package io.apiman.gateway.engine.storage.component;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.core.Hazelcast;
-import com.hazelcast.core.HazelcastInstance;
-
-import java.util.Map;
+import io.apiman.gateway.engine.storage.store.IBackingStore;
+import io.apiman.gateway.engine.storage.store.IBackingStoreProvider;
 
 /**
- * Common base class for components backed by a Hazelcast Map.
+ * Common base class for components backed by a store.
  *
  * @author Pete Cornish
  */
-abstract class AbstractHazelcastComponent {
+abstract public class AbstractStorageComponent {
+    private final IBackingStoreProvider storeProvider;
     private final String storeName;
-    private final HazelcastInstance hazelcastInstance;
 
     /**
      * Constructor.
      */
-    public AbstractHazelcastComponent(String storeName) {
-        this(storeName, new Config());
-    }
+    public AbstractStorageComponent(IBackingStoreProvider storeProvider,
+                                    String storeName) {
 
-    /**
-     * Constructor.
-     *
-     * @param config the config
-     */
-    public AbstractHazelcastComponent(String storeName, Config config) {
+        this.storeProvider = storeProvider;
         this.storeName = storeName;
-        hazelcastInstance = Hazelcast.newHazelcastInstance(config);
     }
 
     /**
-     * Returns an instance of the shared state.
+     * Returns an instance of the store.
      *
-     * @param <T> the value type
-     * @return the shared state
+     * @return the Map
      */
-    protected <T> Map<String, T> getSharedState() {
-        return hazelcastInstance.getMap(storeName);
+    public IBackingStore getStore() {
+        return storeProvider.get(storeName);
     }
 
     /**
      * Builds a key derived from the namespace.
      *
-     * @param namespace the namespace
+     * @param namespace    the namespace
      * @param propertyName the property name
      * @return the namespaced key
      */

--- a/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/model/CacheEntry.java
+++ b/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/model/CacheEntry.java
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.apiman.gateway.engine.es;
+package io.apiman.gateway.engine.storage.model;
 
+
+import java.io.Serializable;
 
 /**
- * This is what gets stored in the ES cache.
- *
- * @author eric.wittmann@redhat.com
+ * A cache entry whose head and data are represented as strings.
  */
-public class ESCacheEntry {
-
+public class CacheEntry implements Serializable {
     private String head;
     private String data;
     private long expiresOn;
@@ -30,7 +29,7 @@ public class ESCacheEntry {
     /**
      * Constructor.
      */
-    public ESCacheEntry() {
+    public CacheEntry() {
     }
 
     /**
@@ -74,5 +73,4 @@ public class ESCacheEntry {
     public void setHead(String head) {
         this.head = head;
     }
-
 }

--- a/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/store/IBackingStore.java
+++ b/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/store/IBackingStore.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.storage.store;
+
+/**
+ * Common operations for backing stores.
+ */
+public interface IBackingStore {
+    /**
+     * Insert an item into the store.
+     *
+     * @param key   the item's key
+     * @param value the item's value
+     */
+    void put(String key, Object value);
+
+    /**
+     * Fetch an item from the store.
+     *
+     * @param key  the item's key
+     * @param type the item's class
+     * @param <T>  the item's type
+     * @return the item, or {@code null}
+     */
+    <T> T get(String key, Class<T> type);
+
+    /**
+     * Remove an item from the store.
+     *
+     * @param key the item's key
+     */
+    void remove(String key);
+
+    /**
+     * Determine whether the store contains an item.
+     *
+     * @param key the item's key
+     * @return {@code true} if the item is in the store, otherwise {@code false}
+     */
+    boolean containsKey(String key);
+}

--- a/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/store/IBackingStoreProvider.java
+++ b/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/store/IBackingStoreProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.storage.store;
+
+/**
+ * Provider of backing stores.
+ */
+public interface IBackingStoreProvider<T extends IBackingStore> {
+    /**
+     * Provide a backing store for the given name.
+     *
+     * @param storeName the name of the store, e.g. 'cache'
+     * @return the backing store
+     */
+    T get(String storeName);
+}

--- a/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/store/MapBackingStore.java
+++ b/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/store/MapBackingStore.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.storage.store;
+
+import java.util.Map;
+
+/**
+ * A backing store that uses a {@link Map}.
+ */
+public class MapBackingStore implements IBackingStore {
+    private final Map<String, Object> map;
+
+    public MapBackingStore(Map<String, Object> map) {
+        this.map = map;
+    }
+
+    @Override
+    public void put(String key, Object value) {
+        map.put(key, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T get(String key, Class<T> type) {
+        return (T) map.get(key);
+    }
+
+    @Override
+    public void remove(String key) {
+        map.remove(key);
+    }
+
+    @Override
+    public boolean containsKey(String key) {
+        return map.containsKey(key);
+    }
+}

--- a/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/util/BackingStoreUtil.java
+++ b/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/util/BackingStoreUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.storage.util;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Utility methods for backing stores.
+ */
+public final class BackingStoreUtil {
+    public static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+    static {
+        JSON_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    private BackingStoreUtil() {
+    }
+
+    /**
+     * Parses the String value as a primitive or a String, depending on its type.
+     * @param clazz the destination type
+     * @param value the value to parse
+     * @return the parsed value
+     * @throws Exception
+     */
+    public static Object readPrimitive(Class<?> clazz, String value) throws Exception {
+        if (clazz == String.class) {
+            return value;
+        } else if (clazz == Long.class) {
+            return Long.parseLong(value);
+        } else if (clazz == Integer.class) {
+            return Integer.parseInt(value);
+        } else if (clazz == Double.class) {
+            return Double.parseDouble(value);
+        } else if (clazz == Boolean.class) {
+            return Boolean.parseBoolean(value);
+        } else if (clazz == Byte.class) {
+            return Byte.parseByte(value);
+        } else if (clazz == Short.class) {
+            return Short.parseShort(value);
+        } else if (clazz == Float.class) {
+            return Float.parseFloat(value);
+        } else {
+            throw new Exception("Unsupported primitive: " + clazz); //$NON-NLS-1$
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,7 @@
     <version.org.osgi>4.2.0</version.org.osgi>
     <version.org.picketbox>4.9.6.Final</version.org.picketbox>
     <version.org.slf4j>1.7.21</version.org.slf4j>
+    <version.org.testcontainers>1.10.2</version.org.testcontainers>
     <version.io.netty>4.1.8.Final</version.io.netty>
     <version.io.swagger>1.5.13</version.io.swagger>
     <version.xmlunit>1.6</version.xmlunit>
@@ -174,6 +175,7 @@
     <version.javax.json.javax.json-api>1.0</version.javax.json.javax.json-api>
     <version.pl.allegro.tech.embedded-elastic>2.5.0</version.pl.allegro.tech.embedded-elastic>
     <version.org.skyscreamer.jsonassert>1.5.0</version.org.skyscreamer.jsonassert>
+    <version.org.redisson>3.9.1</version.org.redisson>
   </properties>
 
   <dependencyManagement>
@@ -488,6 +490,16 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>apiman-gateway-engine-osgi</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>apiman-gateway-engine-redis</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>apiman-gateway-engine-storage-common</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
@@ -1014,6 +1026,11 @@
         <artifactId>disruptor</artifactId>
         <version>${version.com.lmax}</version>
       </dependency>
+      <dependency>
+        <groupId>org.redisson</groupId>
+        <artifactId>redisson</artifactId>
+        <version>${version.org.redisson}</version>
+      </dependency>
       <!-- Spec Libraries -->
       <dependency>
         <groupId>javax.json</groupId>
@@ -1164,6 +1181,11 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
         <version>${version.org.mockito}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${version.org.testcontainers}</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
This PR is a superset of #640. We should rebase this after PR640 is merged.

### Background
Adds Redis store implementations for cache, shared state and rate limiter.

### This PR
Adds Redis store implementations, modelled on the Infinispan and Hazelcast ones.

### Implementation notes
@msavy @EricWittmann per description of #640, there is a lot of commonality between elements of the ES, ISPN, Hazelcast and now Redis stores. 

This PR factors out the commonality into a shared/common module under engine.