### PR TITLE
Fix how vertx public endpoint is assembled in UI

### DIFF
--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/ApiResourceImpl.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/ApiResourceImpl.java
@@ -16,7 +16,6 @@
 
 package io.apiman.gateway.platforms.vertx3.api;
 
-import io.apiman.common.util.SimpleStringUtils;
 import io.apiman.gateway.api.rest.contract.IApiResource;
 import io.apiman.gateway.api.rest.contract.exceptions.NotAuthorizedException;
 import io.apiman.gateway.engine.IEngine;
@@ -27,6 +26,7 @@ import io.apiman.gateway.engine.beans.ApiEndpoint;
 import io.apiman.gateway.engine.beans.exceptions.PublishingException;
 import io.apiman.gateway.engine.beans.exceptions.RegistrationException;
 import io.apiman.gateway.platforms.vertx3.common.config.VertxEngineConfig;
+import org.apache.commons.lang3.StringUtils;
 
 import java.net.URI;
 
@@ -95,15 +95,33 @@ public class ApiResourceImpl extends AbstractResource implements IApiResource {
            }
         }
 
-        String endpoint = scheme + "://" + host;
-        if (port != 443 && port != 80)
-            endpoint += ":" + port + "/";
-        endpoint += path;
-        endpoint += SimpleStringUtils.join("/", organizationId, apiId, version);
-
+        String endpoint = buildEndpoint(organizationId, apiId, version, scheme, host, port, path);
         ApiEndpoint endpointObj = new ApiEndpoint();
         endpointObj.setEndpoint(endpoint);
         return endpointObj;
+    }
+
+    private String buildEndpoint(String organizationId, String apiId, String version, String scheme, String host, int port, String path) {
+        StringBuilder endpoint = new StringBuilder();
+        endpoint.append(scheme);
+        endpoint.append("://");
+        endpoint.append(host);
+
+        if (port != 443 && port != 80) {
+            endpoint.append(":");
+            endpoint.append(port);
+        }
+
+        if (path.isEmpty()) {
+            endpoint.append("/");
+        } else {
+            endpoint.append(path);
+            if (!StringUtils.endsWith(path, "/"))
+                endpoint.append("/");
+        }
+
+        endpoint.append(String.join("/", organizationId, apiId, version));
+        return endpoint.toString();
     }
 
     @Override

--- a/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/api/ApiRessourceImplTest.java
+++ b/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/api/ApiRessourceImplTest.java
@@ -1,0 +1,123 @@
+package io.apiman.gateway.platforms.vertx3.api;
+
+import io.apiman.gateway.engine.*;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.beans.ApiEndpoint;
+import io.apiman.gateway.engine.beans.ApiRequest;
+import io.apiman.gateway.platforms.vertx3.common.config.VertxEngineConfig;
+import io.vertx.core.json.JsonObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ApiRessourceImplTest {
+
+    private static String config = "{\n" +
+            "  \"publicEndpoint\": \"https://gateway.acme-corp.com\",\n" +
+            "\n" +
+            "  \"verticles\": {\n" +
+            "    \"https\": {\n" +
+            "      \"port\": \"80\",\n" +
+            "      \"count\": \"auto\"\n" +
+            "    }\n" +
+            "  },\n" +
+            "\n" +
+            "  \"preferSecure\": true\n" +
+            "}";
+
+    private JsonObject apimanConfig = new JsonObject(config);
+    private ApiResourceImpl apiResource = new ApiResourceImpl(new VertxEngineConfig(apimanConfig), new DummyEngine());
+    private ApiEndpoint endpoint;
+
+    @Test
+    public void testGetApiEndpoint(){
+        String matchingEndpoint = "https://gateway.acme-corp.com/TestOrg/TestAPI/1.0";
+
+        // Test correct user input
+        endpoint = apiResource.getApiEndpoint("TestOrg", "TestAPI", "1.0");
+        Assert.assertEquals(matchingEndpoint, endpoint.getEndpoint());
+
+
+        // Test with trailing slash
+        apimanConfig.put("publicEndpoint", "https://gateway.acme-corp.com/");
+        apiResource = new ApiResourceImpl(new VertxEngineConfig(apimanConfig), new DummyEngine());
+        endpoint = apiResource.getApiEndpoint("TestOrg", "TestAPI", "1.0");
+        Assert.assertEquals(matchingEndpoint, endpoint.getEndpoint());
+
+
+        // Test with path
+        matchingEndpoint = "https://gateway.acme-corp.com/TestPath/TestOrg/TestAPI/1.0";
+
+        apimanConfig.put("publicEndpoint", "https://gateway.acme-corp.com/TestPath");
+        apiResource = new ApiResourceImpl(new VertxEngineConfig(apimanConfig), new DummyEngine());
+        endpoint = apiResource.getApiEndpoint("TestOrg", "TestAPI", "1.0");
+        Assert.assertEquals(matchingEndpoint, endpoint.getEndpoint());
+
+        // Test with path and trailing slash
+        apimanConfig.put("publicEndpoint", "https://gateway.acme-corp.com/TestPath/");
+        apiResource = new ApiResourceImpl(new VertxEngineConfig(apimanConfig), new DummyEngine());
+        endpoint = apiResource.getApiEndpoint("TestOrg", "TestAPI", "1.0");
+        Assert.assertEquals(matchingEndpoint, endpoint.getEndpoint());
+
+
+        // Test with other port in config
+        matchingEndpoint = "https://gateway.acme-corp.com:4444/TestOrg/TestAPI/1.0";
+
+        apimanConfig = new JsonObject(config);
+        apimanConfig.getJsonObject("verticles").getJsonObject("https").put("port", "4444");
+        apiResource = new ApiResourceImpl(new VertxEngineConfig(apimanConfig), new DummyEngine());
+        endpoint = apiResource.getApiEndpoint("TestOrg", "TestAPI", "1.0");
+        Assert.assertEquals(matchingEndpoint, endpoint.getEndpoint());
+
+
+        // Test with other port in config and path
+        matchingEndpoint = "https://gateway.acme-corp.com:4444/TestPath/TestOrg/TestAPI/1.0";
+
+        apimanConfig.put("publicEndpoint", "https://gateway.acme-corp.com/TestPath");
+        apiResource = new ApiResourceImpl(new VertxEngineConfig(apimanConfig), new DummyEngine());
+        endpoint = apiResource.getApiEndpoint("TestOrg", "TestAPI", "1.0");
+        Assert.assertEquals(matchingEndpoint, endpoint.getEndpoint());
+
+        // Test with other port in config, path and trailing slash
+        apimanConfig.put("publicEndpoint", "https://gateway.acme-corp.com/TestPath/");
+        apiResource = new ApiResourceImpl(new VertxEngineConfig(apimanConfig), new DummyEngine());
+        endpoint = apiResource.getApiEndpoint("TestOrg", "TestAPI", "1.0");
+        Assert.assertEquals(matchingEndpoint, endpoint.getEndpoint());
+
+
+        // Test with other port in publicEndpoint, path and trailing slash
+        matchingEndpoint = "https://gateway.acme-corp.com:5555/TestPath/TestOrg/TestAPI/1.0";
+
+        apimanConfig.put("publicEndpoint", "https://gateway.acme-corp.com:5555/TestPath/");
+        apiResource = new ApiResourceImpl(new VertxEngineConfig(apimanConfig), new DummyEngine());
+        endpoint = apiResource.getApiEndpoint("TestOrg", "TestAPI", "1.0");
+        Assert.assertEquals(matchingEndpoint, endpoint.getEndpoint());
+    }
+
+
+    public class DummyEngine implements IEngine {
+        @Override
+        public String getVersion() {
+            return null;
+        }
+
+        @Override
+        public IApiRequestExecutor executor(ApiRequest request, IAsyncResultHandler<IEngineResult> resultHandler) {
+            return null;
+        }
+
+        @Override
+        public IRegistry getRegistry() {
+            return null;
+        }
+
+        @Override
+        public IPluginRegistry getPluginRegistry() {
+            return null;
+        }
+
+        @Override
+        public IApiRequestPathParser getApiRequestPathParser() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Hi togehter,

we have encountered a small issue with the vertx json config:
The problem is how the endpoint was builded if you set a special endpoint and use port 443 or 80, but not specify this port in the endpoint sring:

**Example**:
```json
// You can force a particular endpoint to be reported here (e.g.
  // if you have some clustered setup with exotic DNS setup)
  "endpoint": "https://gateway.e2e.ch",

  // Verticle configuration
  // Port - The port a given verticle listens on (where relevant)
  // Count - Number of given verticle type launched
  "verticles": {
    "http": {
      "port": 8082,
      "count": 1
    },
    "https": {
      "port": 443,
      "count": 0
    },
    "api": {
      "port": 8081,
      "count": 1
    }
  },
```

**Result:**
This ended up in the UI with a missing slash after the host under "Endpoint"
* <https://gateway.e2e.chOrg/API/Version>
Instead of:
* <https://gateway.e2e.ch/Org/API/Version>

We refactored the assembly of the endpoint a little bit to make it more robust and also added some simple test cases.

Please let us know what you think :)

Regards
Florian

P.S. Thanks again to @bekihm for reviewing and testing this with me.