### PR TITLE
Fix recreation of a plan - Elasticsearch Issue

### DIFF
--- a/manager/api/es/src/main/java/io/apiman/manager/api/es/EsStorage.java
+++ b/manager/api/es/src/main/java/io/apiman/manager/api/es/EsStorage.java
@@ -843,6 +843,7 @@ public class EsStorage implements IStorage, IStorageQuery {
                     .addIndex(getIndexName())
                     .addType("auditEntry")
                     .addType("planVersion")
+                    .addType("planPolicies")
                     .build();
 
             JestResult response = esClient.execute(deleteByQuery);


### PR DESCRIPTION
Hi together,

I encountered a little bug while making some tests:
If you create a plan, delelte the plan and recreate a plan with the same name you got an error in the UI:
```json
{"root_cause":[{"type":"version_conflict_engine_exception","reason":"[planPolicies][TestOrg:TestPlan:1.0]: version conflict, document already exists (current version [1])","index_uuid":"9RrVDUg2Sda7nj-Ufg4IqQ","shard":"3","index":"apiman_manager"}],"type":"version_conflict_engine_exception","reason":"[planPolicies][TestOrg:TestPlan:1.0]: version conflict, document already exists (current version [1])","index_uuid":"9RrVDUg2Sda7nj-Ufg4IqQ","shard":"3","index":"apiman_manager"}
```
The Plan is still created in the UI but the planVersion document is missing in ES.

**Steps to reproduce / Environment**

- Elasticsearch 5.6.14

1. Create a new Orginazation
2. Create a plan (do not look it)
3. Delete the plan
4. Recreate the plan again (same name of cource)

**Cause**
I looked into ES and after a plan creation there are three documents with _type

- auditEntry
- planVersion
- planPolicies

After deleting the plan there was still planPolicies in ES left.
See image:
![afterplandelete](https://user-images.githubusercontent.com/13332383/51979565-be1bea80-248d-11e9-873e-a48b23640c81.png)

**Fix**
The ES deletePlan Method only deletes the types planVersion and auditEntry.
So I added planPolicies to this list.

**Testing**
@bekihm and I tried to create some good tests for this but we didn't found a good way for this case after getting stuck in the Jetty REST tests.

@EricWittmann If you have a good idea then please let us know and tell us what do you think :)

Regards Florian