### PR TITLE
Fix InMemoryRateLimiter

### DIFF
--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/InMemoryRateLimiterComponent.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/InMemoryRateLimiterComponent.java
@@ -33,7 +33,7 @@ import java.util.Map;
  */
 public class InMemoryRateLimiterComponent implements IRateLimiterComponent {
 
-    private Map<String, RateLimiterBucket> buckets = new HashMap<>();
+    private static Map<String, RateLimiterBucket> buckets = new HashMap<>();
 
     /**
      * Constructor.


### PR DESCRIPTION
We have detected a bug in the InMemoryRateLimter while using it with vertx.

Because vertx creates multiple threads we have in each thread a different buckets Map containing different entries for the same bucketId.

You can see this here, that the same request is handled by two different threads and this results in a wrong remaining limit:
```
2019-03-27T13:33:13.631314600Z [DEBUG] 2019-03-27 13:33:13.630 [vert.x-eventloop-thread-2] HttpConnector - Connecting to petstore.swagger.io | ssl?: true port: 443 verb: GET path: /v2
...
2019-03-27T13:34:04.557650800Z [DEBUG] 2019-03-27 13:34:04.557 [vert.x-eventloop-thread-3] HttpConnector - Connecting to petstore.swagger.io | ssl?: true port: 443 verb: POST path: /v2
```

If we make the the Hashmap static we can avoid this problem.
@EricWittmann Do you have an idea to test this. We are not sure if we can easyily test this with the existing Mockito tests.

And of course thanks @bekihm for helping me to resolve this bug :)

