### PR TITLE
apiman-722 : BasicAuth, LDAPS - Fix Error "SERVER_DOWN, java.net.SocketException: Connection reset" in SSL.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
     - stage: build
       script: travis_retry mvn clean install -Dinvoker.skip -Dmaven.javadoc.skip=true -Dmvn.skip.test=true -DskipTests=true -T1C -B
     - stage: test
-      script: travis_retry mvn test install -Dinvoker.skip -Dmaven.javadoc.skip=true -B $ACTION -Djavax.net.debug=ssl:handshake
+      script: travis_retry mvn test install -Dinvoker.skip -Dmaven.javadoc.skip=true -B $ACTION
     - stage: deploy
       script:
         - mvn install -Pdocker -Dinvoker.skip -Dmaven.javadoc.skip=true -B

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
     - stage: build
       script: travis_retry mvn clean install -Dinvoker.skip -Dmaven.javadoc.skip=true -Dmvn.skip.test=true -DskipTests=true -T1C -B
     - stage: test
-      script: travis_retry mvn test install -Dinvoker.skip -Dmaven.javadoc.skip=true -B $ACTION
+      script: travis_retry mvn test install -Dinvoker.skip -Dmaven.javadoc.skip=true -B $ACTION -Djavax.net.debug=ssl:handshake
     - stage: deploy
       script:
         - mvn install -Pdocker -Dinvoker.skip -Dmaven.javadoc.skip=true -B

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/LDAPConnectionFactory.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/LDAPConnectionFactory.java
@@ -73,9 +73,15 @@ public class LDAPConnectionFactory {
     private static LDAPConnection getConnection(Map<LdapConfigBean, LDAPConnectionPool> map,
             SSLSocketFactory socketFactory, LdapConfigBean config) throws LDAPException {
         if (!map.containsKey(config)) {
-            LDAPConnection template = new LDAPConnection(config.getHost(), config.getPort());
-            if (socketFactory != null)
-                template.setSocketFactory(socketFactory);
+            LDAPConnection template;
+            if (socketFactory != null){
+                //LDAPS (with SSL)
+                template = new LDAPConnection(socketFactory);
+                template.connect(config.getHost(), config.getPort());
+            }else{
+                //LDAP
+                template= new LDAPConnection(config.getHost(), config.getPort());
+            }
             map.put(config, new LDAPConnectionPool(template, MAX_CONNECTIONS_PER_POOL));
         }
         return map.get(config).getConnection();

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/LDAPConnectionFactory.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/LDAPConnectionFactory.java
@@ -74,13 +74,13 @@ public class LDAPConnectionFactory {
             SSLSocketFactory socketFactory, LdapConfigBean config) throws LDAPException {
         if (!map.containsKey(config)) {
             LDAPConnection template;
-            if (socketFactory != null){
-                //LDAPS (with SSL)
+            if (socketFactory != null) {
+                // LDAPS (with SSL)
                 template = new LDAPConnection(socketFactory);
                 template.connect(config.getHost(), config.getPort());
-            }else{
-                //LDAP
-                template= new LDAPConnection(config.getHost(), config.getPort());
+            } else {
+                // LDAP
+                template = new LDAPConnection(config.getHost(), config.getPort());
             }
             map.put(config, new LDAPConnectionPool(template, MAX_CONNECTIONS_PER_POOL));
         }

--- a/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/BasicAuthLDAPSTest.java
+++ b/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/BasicAuthLDAPSTest.java
@@ -98,7 +98,7 @@ public class BasicAuthLDAPSTest extends AbstractLdapTestUnit {
         if (!targetDir.isDirectory()) {
             throw new Exception("Couldn't find maven target directory: " + targetDir);
         }
-        File partitionDir = new File(targetDir, "_ldap-partition");
+        File partitionDir = new File(targetDir, "_ldaps-partition");
         if (partitionDir.exists()) {
             FileUtils.deleteDirectory(partitionDir);
         }
@@ -120,7 +120,8 @@ public class BasicAuthLDAPSTest extends AbstractLdapTestUnit {
             ServerEntry entry = service.newEntry(dn);
             entry.add("objectClass", "top", "domain", "extensibleObject");
             entry.add("dc", "apiman");
-            entry.add("cn", "o=apiman");
+            entry.add("cn", "apiman");
+            entry.add("o", "apiman");
             service.getAdminSession().add(entry);
         }
 

--- a/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/BasicAuthLDAPSTest.java
+++ b/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/BasicAuthLDAPSTest.java
@@ -1,0 +1,361 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.gateway.engine.policies;
+
+import io.apiman.gateway.engine.beans.ApiRequest;
+import io.apiman.gateway.engine.beans.PolicyFailure;
+import io.apiman.gateway.engine.beans.PolicyFailureType;
+import io.apiman.gateway.engine.components.ILdapComponent;
+import io.apiman.gateway.engine.components.IPolicyFailureFactoryComponent;
+import io.apiman.gateway.engine.impl.DefaultLdapComponent;
+import io.apiman.gateway.engine.policies.config.BasicAuthenticationConfig;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.annotations.SaslMechanism;
+import org.apache.directory.server.core.integ.AbstractLdapTestUnit;
+import org.apache.directory.server.core.integ.FrameworkRunner;
+import org.apache.directory.server.core.partition.impl.btree.jdbm.JdbmPartition;
+import org.apache.directory.server.core.security.TlsKeyGenerator;
+import org.apache.directory.server.i18n.I18n;
+import org.apache.directory.server.ldap.handlers.bind.plain.PlainMechanismHandler;
+import org.apache.directory.server.ldap.handlers.extended.StartTlsHandler;
+import org.apache.directory.shared.ldap.constants.SupportedSaslMechanisms;
+import org.apache.directory.shared.ldap.entry.DefaultServerEntry;
+import org.apache.directory.shared.ldap.entry.ServerEntry;
+import org.apache.directory.shared.ldap.ldif.LdifEntry;
+import org.apache.directory.shared.ldap.ldif.LdifReader;
+import org.apache.directory.shared.ldap.name.DN;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import javax.naming.NamingException;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Fires up an ldaps server to do a better job testing the basic auth
+ * policy when configured for ldaps.
+ *
+ * @author jhauray
+ */
+@SuppressWarnings({ "nls", "javadoc" })
+@RunWith(FrameworkRunner.class)
+@CreateLdapServer(
+        transports = {
+                @CreateTransport(protocol = "LDAPS", port = 10636)
+        },
+        saslHost = "localhost",
+        saslMechanisms =
+                {
+                        @SaslMechanism(name = SupportedSaslMechanisms.PLAIN, implClass = PlainMechanismHandler.class),
+                },
+        extendedOpHandlers =
+                { StartTlsHandler.class }
+)
+public class BasicAuthLDAPSTest extends AbstractLdapTestUnit {
+
+    private static final String LDAP_SERVER = "localhost";
+    private static final String LDAP_KEYSTORE =  "ldaps_server.jks";
+    private static final String LDAP_KEYSTORE_PASSWD ="mustBeSecret";
+
+    private static JdbmPartition partition;
+
+    @Before
+    public void setUp() throws Exception {
+
+        if (partition != null) {
+            return;
+        }
+        File targetDir = new File("target");
+        if (!targetDir.isDirectory()) {
+            throw new Exception("Couldn't find maven target directory: " + targetDir);
+        }
+        File partitionDir = new File(targetDir, "_ldap-partition");
+        if (partitionDir.exists()) {
+            FileUtils.deleteDirectory(partitionDir);
+        }
+        partitionDir.mkdirs();
+
+        final File partitionDirectory = partitionDir;
+        partition = new JdbmPartition();
+        partition.setId("apiman");
+        partition.setPartitionDir(partitionDirectory);
+        partition.setSchemaManager(service.getSchemaManager());
+        partition.setSuffix("o=apiman");
+        service.addPartition(partition);
+
+        // Inject the foo root entry if it does not already exist
+        try {
+            service.getAdminSession().lookup(partition.getSuffixDn());
+        } catch (Exception lnnfe) {
+            DN dn = new DN("o=apiman");
+            ServerEntry entry = service.newEntry(dn);
+            entry.add("objectClass", "top", "domain", "extensibleObject");
+            entry.add("dc", "apiman");
+            entry.add("cn", "o=apiman");
+            service.getAdminSession().add(entry);
+        }
+
+        try {
+            injectLdifFiles("io/apiman/gateway/engine/policies/users.ldif");
+        } catch (Exception e) {
+            throw e;
+        }
+
+        //Init (delete if exist) key store for ldaps server
+        File goodKeyStoreFile = new File(targetDir, LDAP_KEYSTORE);
+        if ( goodKeyStoreFile.exists() ){goodKeyStoreFile.delete();}
+
+        //Get LDAP Root entry
+        ServerEntry entry = service.getAdminSession().lookup(partition.getSuffixDn());
+
+        //Add private KeyPair and a self-signed certificate corresponding to the entry
+        TlsKeyGenerator.addKeyPair( entry );
+        KeyPair keyPair = TlsKeyGenerator.getKeyPair( entry );
+        X509Certificate cert = TlsKeyGenerator.getCertificate( entry );
+
+        //Add generated certificate to the keystore
+        KeyStore goodKeyStore = KeyStore.getInstance( KeyStore.getDefaultType() );
+        goodKeyStore.load( null, null );
+        goodKeyStore.setCertificateEntry( "apacheds", cert );
+        goodKeyStore.setKeyEntry( "apacheds", keyPair.getPrivate(),
+                LDAP_KEYSTORE_PASSWD.toCharArray(),
+                new Certificate[]{ cert } );
+        goodKeyStore.store( new FileOutputStream( goodKeyStoreFile ), LDAP_KEYSTORE_PASSWD.toCharArray() );
+
+        //Load generated Keystore in ldaps server
+        ldapServer.setKeystoreFile(goodKeyStoreFile.getAbsolutePath());
+        ldapServer.setCertificatePassword(LDAP_KEYSTORE_PASSWD);
+        ldapServer.reloadSslContext();
+
+        //Load Keystore as Apiman current TrustStore
+        System.setProperty("javax.net.ssl.trustStore", goodKeyStoreFile.getAbsolutePath());
+        System.setProperty("javax.net.ssl.trustStorePassword", LDAP_KEYSTORE_PASSWD);
+
+    }
+
+    /**
+     * Test method for {@link BasicAuthenticationPolicy#apply(ServiceRequest, IPolicyContext, Object, IPolicyChain)}.
+     */
+    @Test
+    public void testApply() throws Exception {
+        // Test using a direct bind to the user account
+        //////////////////////////////////////////////////
+        String json = "{\r\n" +
+                "    \"realm\" : \"TestRealm\",\r\n" +
+                "    \"forwardIdentityHttpHeader\" : \"X-Authenticated-Identity\",\r\n" +
+                "    \"ldapIdentity\" : {\r\n" +
+                "        \"url\" : \"ldaps://" + LDAP_SERVER + ":" + ldapServer.getTransports()[0].getPort() + "\",\r\n" +
+                "        \"dnPattern\" : \"uid=${username},ou=system\"\r\n" +
+                "    }\r\n" +
+                "}";
+
+        doTest(json, null, null, PolicyFailureCodes.BASIC_AUTH_REQUIRED);
+        doTest(json, "admin", "invalid_password", PolicyFailureCodes.BASIC_AUTH_FAILED);
+        doTest(json, "admin", "secret", null);
+
+        // Test using a service account with user search
+        //////////////////////////////////////////////////
+        json = "{\r\n" +
+                "  \"realm\" : \"TestRealm\",\r\n" +
+                "  \"ldapIdentity\" : {\r\n" +
+                "    \"url\" : \"ldaps://" + LDAP_SERVER + ":" + ldapServer.getTransports()[0].getPort() + "\",\r\n" +
+                "    \"dnPattern\" : \"uid=${username},ou=system\",\r\n" +
+                "    \"bindAs\" : \"ServiceAccount\",\r\n" +
+                "    \"credentials\" : {\r\n" +
+                "      \"username\" : \"admin\",\r\n" +
+                "      \"password\" : \"secret\"\r\n" +
+                "    },\r\n" +
+                "    \"userSearch\" : {\r\n" +
+                "      \"baseDn\" : \"ou=people,o=apiman\",\r\n" +
+                "      \"expression\" : \"(uid=${username})\"\r\n" +
+                "    }\r\n" +
+                "  }\r\n" +
+                "}";
+
+        doTest(json, null, null, PolicyFailureCodes.BASIC_AUTH_REQUIRED);
+        doTest(json, "ewittman", "invalid_password", PolicyFailureCodes.BASIC_AUTH_FAILED);
+        doTest(json, "unknown_user", "password", PolicyFailureCodes.BASIC_AUTH_FAILED);
+        doTest(json, "ewittman", "ewittman", null);
+
+        // Test using a service account with user search
+        //////////////////////////////////////////////////
+        json = "{\r\n" +
+                "  \"realm\" : \"TestRealm\",\r\n" +
+                "  \"ldapIdentity\" : {\r\n" +
+                "    \"url\" : \"ldaps://" + LDAP_SERVER + ":" + ldapServer.getTransports()[0].getPort() + "\",\r\n" +
+                "    \"dnPattern\" : \"uid=${username},ou=system\",\r\n" +
+                "    \"bindAs\" : \"ServiceAccount\",\r\n" +
+                "    \"credentials\" : {\r\n" +
+                "      \"username\" : \"admin\",\r\n" +
+                "      \"password\" : \"secret\"\r\n" +
+                "    },\r\n" +
+                "    \"userSearch\" : {\r\n" +
+                "      \"baseDn\" : \"ou=people,o=apiman\",\r\n" +
+                "      \"expression\" : \"(uid=${username})\"\r\n" +
+                "    }\r\n" +
+                "  }\r\n" +
+                "}";
+        doTest(json, null, null, PolicyFailureCodes.BASIC_AUTH_REQUIRED);
+        doTest(json, "ewittman", "invalid_password", PolicyFailureCodes.BASIC_AUTH_FAILED);
+        doTest(json, "unknown_user", "password", PolicyFailureCodes.BASIC_AUTH_FAILED);
+        doTest(json, "ewittman", "ewittman", null);
+
+        // Test with the extraction of user roles
+        //////////////////////////////////////////////////
+        json = "{\r\n" +
+                "  \"realm\" : \"TestRealm\",\r\n" +
+                "  \"ldapIdentity\" : {\r\n" +
+                "    \"url\" : \"ldaps://" + LDAP_SERVER + ":" + ldapServer.getTransports()[0].getPort() + "\",\r\n" +
+                "    \"dnPattern\" : \"uid=${username},ou=system\",\r\n" +
+                "    \"bindAs\" : \"ServiceAccount\",\r\n" +
+                "    \"credentials\" : {\r\n" +
+                "      \"username\" : \"admin\",\r\n" +
+                "      \"password\" : \"secret\"\r\n" +
+                "    },\r\n" +
+                "    \"userSearch\" : {\r\n" +
+                "      \"baseDn\" : \"ou=people,o=apiman\",\r\n" +
+                "      \"expression\" : \"(uid=${username})\"\r\n" +
+                "    },\r\n" +
+                "    \"extractRoles\" : true,\r\n" +
+                "    \"membershipAttribute\" : \"title\",\r\n" +
+                "    \"rolenameAttribute\" : \"cn\"\r\n" +
+                "  }\r\n" +
+                "}";
+        Set<String> expectedRoles = new HashSet<>();
+        expectedRoles.add("user");
+        expectedRoles.add("admin");
+        doTest(json, "ewittman", "ewittman", null, expectedRoles);
+        doTest(json, "ewittman", "ewittmanx", PolicyFailureCodes.BASIC_AUTH_FAILED, expectedRoles);
+    }
+
+    private void doTest(String json, String username, String password, Integer expectedFailureCode) throws Exception {
+        doTest(json, username, password, expectedFailureCode, null);
+    }
+
+    // pass null if you expect success
+    private void doTest(String json, String username, String password, Integer expectedFailureCode,
+                        Set<String> expectedRoles) throws Exception {
+        BasicAuthenticationPolicy policy = new BasicAuthenticationPolicy();
+        BasicAuthenticationConfig config = policy.parseConfiguration(json);
+        ApiRequest request = new ApiRequest();
+        request.setType("GET");
+        request.setApiKey("12345");
+        request.setRemoteAddr("1.2.3.4");
+        request.setDestination("/");
+        IPolicyContext context = Mockito.mock(IPolicyContext.class);
+        final PolicyFailure failure = new PolicyFailure();
+        Mockito.when(context.getComponent(IPolicyFailureFactoryComponent.class)).thenReturn(new IPolicyFailureFactoryComponent() {
+            @Override
+            public PolicyFailure createFailure(PolicyFailureType type, int failureCode, String message) {
+                failure.setType(type);
+                failure.setFailureCode(failureCode);
+                failure.setMessage(message);
+                return failure;
+            }
+        });
+
+        // The LDAP stuff we're testing!
+        Mockito.when(context.getComponent(ILdapComponent.class)).thenReturn(new DefaultLdapComponent());
+
+        IPolicyChain<ApiRequest> chain = Mockito.mock(IPolicyChain.class);
+
+        if (username != null) {
+            request.getHeaders().put("Authorization", createBasicAuthorization(username, password));
+        }
+
+        if (expectedFailureCode == null) {
+            policy.apply(request, context, config, chain);
+            Mockito.verify(chain).doApply(request);
+        } else {
+            policy.apply(request, context, config, chain);
+            Mockito.verify(chain).doFailure(failure);
+            Assert.assertEquals(expectedFailureCode.intValue(), failure.getFailureCode());
+        }
+
+        if (expectedRoles != null && expectedFailureCode == null) {
+            Mockito.verify(context).setAttribute(AuthorizationPolicy.AUTHENTICATED_USER_ROLES, expectedRoles);
+        }
+    }
+
+    /**
+     * Creates the http Authorization string for the given credentials.
+     * @param username
+     * @param password
+     */
+    private String createBasicAuthorization(String username, String password) {
+        String creds = username + ":" + password;
+        StringBuilder builder = new StringBuilder();
+        builder.append("Basic ");
+        builder.append(Base64.encodeBase64String(creds.getBytes()));
+        return builder.toString();
+    }
+
+
+    public static void injectLdifFiles(String... ldifFiles) throws Exception {
+        if (ldifFiles != null && ldifFiles.length > 0) {
+            for (String ldifFile : ldifFiles) {
+                InputStream is = null;
+                try {
+                    is = BasicAuthLDAPSTest.class.getClassLoader().getResourceAsStream(ldifFile);
+                    if (is == null) {
+                        throw new FileNotFoundException("LDIF file '" + ldifFile + "' not found.");
+                    } else {
+                        try {
+                            LdifReader ldifReader = new LdifReader(is);
+                            for (LdifEntry entry : ldifReader) {
+                                injectEntry(entry);
+                            }
+                            ldifReader.close();
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                } finally {
+                    IOUtils.closeQuietly(is);
+                }
+            }
+        }
+    }
+
+    private static void injectEntry(LdifEntry entry) throws Exception {
+        if (entry.isChangeAdd()) {
+            service.getAdminSession().add(
+                    new DefaultServerEntry(service.getSchemaManager(), entry.getEntry()));
+        } else if (entry.isChangeModify()) {
+            service.getAdminSession().modify(entry.getDn(), entry.getModificationItems());
+        } else {
+            String message = I18n.err(I18n.ERR_117, entry.getChangeType());
+            throw new NamingException(message);
+        }
+    }
+
+}

--- a/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/BasicAuthLDAPSTest.java
+++ b/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/BasicAuthLDAPSTest.java
@@ -14,6 +14,7 @@
  */
 package io.apiman.gateway.engine.policies;
 
+import com.sun.javafx.binding.StringFormatter;
 import io.apiman.gateway.engine.beans.ApiRequest;
 import io.apiman.gateway.engine.beans.PolicyFailure;
 import io.apiman.gateway.engine.beans.PolicyFailureType;
@@ -144,13 +145,16 @@ public class BasicAuthLDAPSTest extends AbstractLdapTestUnit {
         X509Certificate cert = TlsKeyGenerator.getCertificate( entry );
 
         //Add generated certificate to the keystore
-        KeyStore goodKeyStore = KeyStore.getInstance( KeyStore.getDefaultType() );
+        KeyStore goodKeyStore = KeyStore.getInstance( "JKS" );
         goodKeyStore.load( null, null );
         goodKeyStore.setCertificateEntry( "apacheds", cert );
         goodKeyStore.setKeyEntry( "apacheds", keyPair.getPrivate(),
                 LDAP_KEYSTORE_PASSWD.toCharArray(),
                 new Certificate[]{ cert } );
-        goodKeyStore.store( new FileOutputStream( goodKeyStoreFile ), LDAP_KEYSTORE_PASSWD.toCharArray() );
+        goodKeyStore.store( new FileOutputStream( goodKeyStoreFile ), LDAP_KEYSTORE_PASSWD.toCharArray());
+
+        if ( !goodKeyStoreFile.exists() ) throw new Exception(String.format("Keystore [%s] doesn't exist.",
+                                            goodKeyStoreFile.getAbsolutePath()));
 
         //Load generated Keystore in ldaps server
         ldapServer.setKeystoreFile(goodKeyStoreFile.getAbsolutePath());
@@ -159,8 +163,11 @@ public class BasicAuthLDAPSTest extends AbstractLdapTestUnit {
 
         //Load Keystore as Apiman current TrustStore
         System.setProperty("javax.net.ssl.trustStore", goodKeyStoreFile.getAbsolutePath());
+        System.setProperty("javax.net.ssl.trustStoreType", "JKS");
         System.setProperty("javax.net.ssl.trustStorePassword", LDAP_KEYSTORE_PASSWD);
 
+        System.out.println(String.format("javax.net.ssl.trustStore : %s",System.getProperty("javax.net.ssl.trustStore")));
+        System.out.println(String.format("javax.net.ssl.trustStoreType : %s",System.getProperty("javax.net.ssl.trustStoreType")));
     }
 
     /**

--- a/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/BasicAuthLDAPSTest.java
+++ b/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/BasicAuthLDAPSTest.java
@@ -14,13 +14,11 @@
  */
 package io.apiman.gateway.engine.policies;
 
-import com.sun.javafx.binding.StringFormatter;
 import io.apiman.gateway.engine.beans.ApiRequest;
 import io.apiman.gateway.engine.beans.PolicyFailure;
 import io.apiman.gateway.engine.beans.PolicyFailureType;
 import io.apiman.gateway.engine.components.ILdapComponent;
 import io.apiman.gateway.engine.components.IPolicyFailureFactoryComponent;
-import io.apiman.gateway.engine.impl.DefaultLdapComponent;
 import io.apiman.gateway.engine.policies.config.BasicAuthenticationConfig;
 import io.apiman.gateway.engine.policies.util.DefaultLdapComponentReloaded;
 import io.apiman.gateway.engine.policy.IPolicyChain;
@@ -75,18 +73,18 @@ import java.util.Set;
                 @CreateTransport(protocol = "LDAPS", port = 10636)
         },
         saslHost = "localhost",
-        saslMechanisms =
-                {
-                        @SaslMechanism(name = SupportedSaslMechanisms.PLAIN, implClass = PlainMechanismHandler.class),
-                },
-        extendedOpHandlers =
-                { StartTlsHandler.class }
+        saslMechanisms = {
+                @SaslMechanism(name = SupportedSaslMechanisms.PLAIN, implClass = PlainMechanismHandler.class),
+        },
+        extendedOpHandlers = {
+                StartTlsHandler.class
+        }
 )
 public class BasicAuthLDAPSTest extends AbstractLdapTestUnit {
 
     private static final String LDAP_SERVER = "localhost";
     private static final String LDAP_KEYSTORE =  "ldaps_server.jks";
-    private static final String LDAP_KEYSTORE_PASSWD ="mustBeSecret";
+    private static final String LDAP_KEYSTORE_PASSWD = "mustBeSecret";
 
     private static JdbmPartition partition;
 
@@ -133,36 +131,36 @@ public class BasicAuthLDAPSTest extends AbstractLdapTestUnit {
             throw e;
         }
 
-        //Init (delete if exist) key store for ldaps server
+        // Init (delete if exist) key store for ldaps server
         File goodKeyStoreFile = new File(targetDir, LDAP_KEYSTORE);
-        if ( goodKeyStoreFile.exists() ){goodKeyStoreFile.delete();}
+        if (goodKeyStoreFile.exists()) goodKeyStoreFile.delete();
 
-        //Get LDAP Root entry
+        // Get LDAP Root entry
         ServerEntry entry = service.getAdminSession().lookup(partition.getSuffixDn());
 
-        //Add private KeyPair and a self-signed certificate corresponding to the entry
-        TlsKeyGenerator.addKeyPair( entry );
-        KeyPair keyPair = TlsKeyGenerator.getKeyPair( entry );
-        X509Certificate cert = TlsKeyGenerator.getCertificate( entry );
+        // Add private KeyPair and a self-signed certificate corresponding to the entry
+        TlsKeyGenerator.addKeyPair(entry);
+        KeyPair keyPair = TlsKeyGenerator.getKeyPair(entry);
+        X509Certificate cert = TlsKeyGenerator.getCertificate(entry);
 
-        //Add generated certificate to the keystore
-        KeyStore goodKeyStore = KeyStore.getInstance( "JKS" );
-        goodKeyStore.load( null, null );
-        goodKeyStore.setCertificateEntry( "apacheds", cert );
-        goodKeyStore.setKeyEntry( "apacheds", keyPair.getPrivate(),
-                LDAP_KEYSTORE_PASSWD.toCharArray(),
-                new Certificate[]{ cert } );
-        goodKeyStore.store( new FileOutputStream( goodKeyStoreFile ), LDAP_KEYSTORE_PASSWD.toCharArray());
+        // Add generated certificate to the keystore
+        KeyStore goodKeyStore = KeyStore.getInstance("JKS");
+        goodKeyStore.load(null,null);
+        goodKeyStore.setCertificateEntry("apacheds", cert);
+        goodKeyStore.setKeyEntry("apacheds", keyPair.getPrivate(),
+                                LDAP_KEYSTORE_PASSWD.toCharArray(),
+                                new Certificate[]{ cert });
+        goodKeyStore.store(new FileOutputStream(goodKeyStoreFile), LDAP_KEYSTORE_PASSWD.toCharArray());
 
-        if ( !goodKeyStoreFile.exists() ) throw new Exception(String.format("Keystore [%s] doesn't exist.",
-                                            goodKeyStoreFile.getAbsolutePath()));
+        if (!goodKeyStoreFile.exists()) throw new Exception(String.format("Keystore [%s] doesn't exist.",
+                                                            goodKeyStoreFile.getAbsolutePath()));
 
-        //Load generated Keystore in ldaps server
+        // Load generated Keystore in ldaps server
         ldapServer.setKeystoreFile(goodKeyStoreFile.getAbsolutePath());
         ldapServer.setCertificatePassword(LDAP_KEYSTORE_PASSWD);
         ldapServer.reloadSslContext();
 
-        //Load Keystore as Apiman current TrustStore
+        // Load Keystore as Apiman current TrustStore
         System.setProperty("javax.net.ssl.trustStore", goodKeyStoreFile.getAbsolutePath());
         System.setProperty("javax.net.ssl.trustStoreType", "JKS");
         System.setProperty("javax.net.ssl.trustStorePassword", LDAP_KEYSTORE_PASSWD);
@@ -290,7 +288,7 @@ public class BasicAuthLDAPSTest extends AbstractLdapTestUnit {
         });
 
         // The LDAP stuff we're testing!
-        //DefaultLdapComponentReloaded inherited class is used to load in sslcontext the new truststore defined in setUp()
+        // DefaultLdapComponentReloaded inherited class is used to load in sslcontext the new truststore defined in setUp()
         Mockito.when(context.getComponent(ILdapComponent.class)).thenReturn(new DefaultLdapComponentReloaded());
 
         IPolicyChain<ApiRequest> chain = Mockito.mock(IPolicyChain.class);

--- a/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/BasicAuthLDAPSTest.java
+++ b/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/BasicAuthLDAPSTest.java
@@ -22,6 +22,7 @@ import io.apiman.gateway.engine.components.ILdapComponent;
 import io.apiman.gateway.engine.components.IPolicyFailureFactoryComponent;
 import io.apiman.gateway.engine.impl.DefaultLdapComponent;
 import io.apiman.gateway.engine.policies.config.BasicAuthenticationConfig;
+import io.apiman.gateway.engine.policies.util.DefaultLdapComponentReloaded;
 import io.apiman.gateway.engine.policy.IPolicyChain;
 import io.apiman.gateway.engine.policy.IPolicyContext;
 import org.apache.commons.codec.binary.Base64;
@@ -165,9 +166,6 @@ public class BasicAuthLDAPSTest extends AbstractLdapTestUnit {
         System.setProperty("javax.net.ssl.trustStore", goodKeyStoreFile.getAbsolutePath());
         System.setProperty("javax.net.ssl.trustStoreType", "JKS");
         System.setProperty("javax.net.ssl.trustStorePassword", LDAP_KEYSTORE_PASSWD);
-
-        System.out.println(String.format("javax.net.ssl.trustStore : %s",System.getProperty("javax.net.ssl.trustStore")));
-        System.out.println(String.format("javax.net.ssl.trustStoreType : %s",System.getProperty("javax.net.ssl.trustStoreType")));
     }
 
     /**
@@ -292,7 +290,8 @@ public class BasicAuthLDAPSTest extends AbstractLdapTestUnit {
         });
 
         // The LDAP stuff we're testing!
-        Mockito.when(context.getComponent(ILdapComponent.class)).thenReturn(new DefaultLdapComponent());
+        //DefaultLdapComponentReloaded inherited class is used to load in sslcontext the new truststore defined in setUp()
+        Mockito.when(context.getComponent(ILdapComponent.class)).thenReturn(new DefaultLdapComponentReloaded());
 
         IPolicyChain<ApiRequest> chain = Mockito.mock(IPolicyChain.class);
 

--- a/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/util/DefaultLdapComponentReloaded.java
+++ b/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/util/DefaultLdapComponentReloaded.java
@@ -19,7 +19,7 @@ public class DefaultLdapComponentReloaded extends DefaultLdapComponent {
 
     public DefaultLdapComponentReloaded() throws GeneralSecurityException {
 
-        //Force reloading static SSLSocketFactory to accept truststore changes.
+        // Force reloading static SSLSocketFactory to accept truststore changes.
         TrustManagerFactory tmFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         tmFactory.init((KeyStore) null);
 

--- a/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/util/DefaultLdapComponentReloaded.java
+++ b/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/util/DefaultLdapComponentReloaded.java
@@ -1,0 +1,36 @@
+package io.apiman.gateway.engine.policies.util;
+
+import com.unboundid.util.ssl.SSLUtil;
+import io.apiman.gateway.engine.impl.DefaultLdapComponent;
+
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+
+/**
+ * For tests only
+ * Used to force reloading static SSLContext and SSLSocketFactory, without modifying DefaultLdapComponent
+ *
+ * @author jhauray
+ */
+public class DefaultLdapComponentReloaded extends DefaultLdapComponent {
+
+    public DefaultLdapComponentReloaded() throws GeneralSecurityException {
+
+        //Force reloading static SSLSocketFactory to accept truststore changes.
+        TrustManagerFactory tmFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmFactory.init((KeyStore) null);
+
+        X509TrustManager trustManager = null;
+        for (TrustManager tm : tmFactory.getTrustManagers()) {
+            if (tm instanceof X509TrustManager) {
+                trustManager = (X509TrustManager) tm;
+                break;
+            }
+        }
+
+        DEFAULT_SOCKET_FACTORY = new SSLUtil(trustManager).createSSLSocketFactory();
+    }
+}


### PR DESCRIPTION
I just fix method getConnection() in LDAPConnectionFactory + Add a unit test class : BasicAuthLDAPSTest.

The fix was successfully tested on a existing gateway, by adding a BasicAuth policy, connected by LDAPS on corporate LDAP directory.