### PR TITLE
Make TLS protocols configurable for vert.x (Client <-> Vert.x Server)

### DIFF
--- a/distro/vertx/src/main/resources/overlay/configs/conf-es.json
+++ b/distro/vertx/src/main/resources/overlay/configs/conf-es.json
@@ -244,17 +244,20 @@
     }
   },
 
-  // SSL configuration to the gateway's *front end* (i.e. client <-> gateway).
-  //  "ssl": {
-  //    "keystore": {
-  //      "path": "/the/keystore/path/here.jks",
-  //      "password": "password-here"
-  //    },
-  //    "truststore": {
-  //      "path": "/the/truststore/path/here.jks",
-  //      "password": "password-here"
-  //    }
-  //  },
+//   SSL configuration to the gateway's *front end* (i.e. client <-> gateway).
+//    "ssl": {
+//      "keystore": {
+//        "path": "/the/keystore/path/here.jks",
+//        "password": "password-here"
+//      },
+//      "truststore": {
+//        "path": "/the/truststore/path/here.jks",
+//        "password": "password-here"
+//      }
+//    },
+//    Allowed TLS/SSL protocols for Client <-> Gateway (Server)
+//    "allowedProtocols": "TLSv1.1, TLSv1.2"
+//    },
 
   // Gateway API Authentication. See documentation for further possibilities..
   "auth": {

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/Router2ResteasyRequestAdapter.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/Router2ResteasyRequestAdapter.java
@@ -20,19 +20,13 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpConnection;
-import io.vertx.core.http.HttpFrame;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServerFileUpload;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.http.HttpVersion;
-import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.http.*;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.RoutingContext;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 
 /**
@@ -84,6 +78,11 @@ public class Router2ResteasyRequestAdapter implements HttpServerRequest {
     public HttpServerRequest resume() {
         request.resume();
         return this;
+    }
+
+    @Override
+    public HttpServerRequest fetch(long l) {
+        return null;
     }
 
     @Override
@@ -143,6 +142,11 @@ public class Router2ResteasyRequestAdapter implements HttpServerRequest {
     }
 
     @Override
+    public SSLSession sslSession() {
+        return null;
+    }
+
+    @Override
     public boolean isSSL() {
         return request.isSSL();
     }
@@ -160,6 +164,11 @@ public class Router2ResteasyRequestAdapter implements HttpServerRequest {
     @Override
     public @Nullable String host() {
         return request.host();
+    }
+
+    @Override
+    public long bytesRead() {
+        return 0;
     }
 
     @Override
@@ -220,6 +229,11 @@ public class Router2ResteasyRequestAdapter implements HttpServerRequest {
     @Override
     public HttpConnection connection() {
         return request.connection();
+    }
+
+    @Override
+    public HttpServerRequest streamPriorityHandler(Handler<StreamPriority> handler) {
+        return null;
     }
 
     @Override

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/auth/KeycloakOAuthFactory.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/auth/KeycloakOAuthFactory.java
@@ -19,12 +19,15 @@ package io.apiman.gateway.platforms.vertx3.api.auth;
 import io.apiman.common.util.Basic;
 import io.apiman.gateway.platforms.vertx3.common.config.VertxEngineConfig;
 import io.apiman.gateway.platforms.vertx3.verticles.ApiVerticle;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.JksOptions;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.oauth2.AccessToken;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
 import io.vertx.ext.auth.oauth2.OAuth2FlowType;
@@ -40,7 +43,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.EnumUtils;
 
 /**
@@ -98,10 +100,10 @@ public class KeycloakOAuthFactory {
                 HttpClientOptions sslOptions = getHttpClientOptionsForKeycloak(authConfig);
 
                 OAuth2Auth oauth2 = KeycloakAuth.create(vertx, flowType, authConfig, sslOptions);
-                oauth2.getToken(params, tokenResult -> {
+                oauth2.authenticate(params, tokenResult -> {
                     if (tokenResult.succeeded()) {
                         log.debug("OAuth2 Keycloak exchange succeeded.");
-                        AccessToken token = tokenResult.result();
+                        AccessToken token = (AccessToken) tokenResult.result();
                         token.isAuthorised(role, res -> {
                             if (res.result()) {
                                 context.next();
@@ -145,6 +147,12 @@ public class KeycloakOAuthFactory {
             public AuthHandler addAuthorities(Set<String> authorities) {
                 return this;
             }
+
+            @Override
+            public void parseCredentials(RoutingContext routingContext, Handler<AsyncResult<JsonObject>> handler) {}
+
+            @Override
+            public void authorize(User user, Handler<AsyncResult<Void>> handler) {}
         };
     }
 
@@ -186,4 +194,5 @@ public class KeycloakOAuthFactory {
     private static OAuth2FlowType toEnum(String flowType) {
         return EnumUtils.getEnum(OAuth2FlowType.class, flowType.toUpperCase());
     }
+
 }

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/auth/NoneAuth.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/auth/NoneAuth.java
@@ -16,6 +16,10 @@
 
 package io.apiman.gateway.platforms.vertx3.api.auth;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.AuthHandler;
 
@@ -40,6 +44,16 @@ public class NoneAuth implements AuthHandler {
     @Override
     public AuthHandler addAuthorities(Set<String> authorities) {
         return this;
+    }
+
+    @Override
+    public void parseCredentials(RoutingContext routingContext, Handler<AsyncResult<JsonObject>> handler) {
+
+    }
+
+    @Override
+    public void authorize(User user, Handler<AsyncResult<Void>> handler) {
+
     }
 
     public static AuthHandler create() {

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/common/config/VertxEngineConfig.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/common/config/VertxEngineConfig.java
@@ -99,6 +99,7 @@ public class VertxEngineConfig implements IEngineConfig {
     private static final String SSL = "ssl";
     private static final String SSL_TRUSTSTORE = "truststore";
     private static final String SSL_KEYSTORE = "keystore";
+    private static final String SSL_TLS_ALLOWED_PROTOCOLS = "allowedProtocols";
     private static final String SSL_PATH = "path";
     private static final String VARIABLES = "variables";
 
@@ -300,6 +301,10 @@ public class VertxEngineConfig implements IEngineConfig {
 
     public String getTrustStorePassword() {
         return config.getJsonObject(SSL, new JsonObject()).getJsonObject(SSL_TRUSTSTORE, new JsonObject()).getString(API_PASSWORD);
+    }
+
+    public String[] getSslTlsAllowedProtocols() {
+        return config.getJsonObject(SSL, new JsonObject()).getString(SSL_TLS_ALLOWED_PROTOCOLS).split(",");
     }
 
     public JsonObject getAuth() {

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/logging/ApimanLog4j2LogDelegate.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/logging/ApimanLog4j2LogDelegate.java
@@ -22,6 +22,9 @@ public class ApimanLog4j2LogDelegate implements LogDelegate {
     }
 
     @Override
+    public boolean isWarnEnabled() { return logger.isWarnEnabled(); }
+
+    @Override
     public boolean isInfoEnabled() {
       return logger.isInfoEnabled();
     }

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/verticles/ApiVerticle.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/verticles/ApiVerticle.java
@@ -106,6 +106,7 @@ public class ApiVerticle extends ApimanVerticleWithEngine {
                         .setPath(apimanConfig.getTrustStore())
                         .setPassword(apimanConfig.getTrustStorePassword())
                     );
+            addAllowedSslTlsProtocols(httpOptions);
         } else {
             log.warn("API is running in plaintext mode. Enable SSL in config for production deployments.");
         }

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/verticles/ApimanVerticleBase.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/verticles/ApimanVerticleBase.java
@@ -20,6 +20,7 @@ import io.apiman.gateway.platforms.vertx3.common.config.VertxEngineConfig;
 import io.apiman.gateway.platforms.vertx3.common.verticles.VerticleType;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
@@ -62,5 +63,23 @@ public abstract class ApimanVerticleBase extends AbstractVerticle {
 
     protected Logger getLogger() {
         return log;
+    }
+
+    /**
+     * Adds allowed TLS versions to the verticle configuration if special TLS versions are configured
+     * @param httpsServerOptions
+     */
+    public void addAllowedSslTlsProtocols(HttpServerOptions httpsServerOptions) {
+        String[] allowedProtocols = apimanConfig.getSslTlsAllowedProtocols();
+
+        if (!allowedProtocols[0].isEmpty()) {
+            // remove unsecure protocols
+            httpsServerOptions.removeEnabledSecureTransportProtocol("TLSv1");
+            httpsServerOptions.removeEnabledSecureTransportProtocol("TLSv1.1");
+
+            for (String protocol : allowedProtocols) {
+                httpsServerOptions.addEnabledSecureTransportProtocol(protocol);
+            }
+        }
     }
 }

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/verticles/HttpsGatewayVerticle.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/verticles/HttpsGatewayVerticle.java
@@ -53,6 +53,7 @@ public class HttpsGatewayVerticle extends ApimanVerticleWithEngine {
                         .setPath(apimanConfig.getTrustStore())
                         .setPassword(apimanConfig.getTrustStorePassword())
                     );
+        addAllowedSslTlsProtocols(httpsServerOptions);
 
         if (JdkSSLEngineOptions.isAlpnAvailable()) {
             httpsServerOptions.setUseAlpn(true);

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
     <version.io.netty>4.1.8.Final</version.io.netty>
     <version.io.swagger>1.5.13</version.io.swagger>
     <version.xmlunit>1.6</version.xmlunit>
-    <version.io.vertx>3.4.2</version.io.vertx>
+    <version.io.vertx>3.7.0</version.io.vertx>
     <version.net.openhft>0.6</version.net.openhft>
     <version.com.ibm.icu4j>57.1</version.com.ibm.icu4j>
     <version.com.hazelcast>3.6.4</version.com.hazelcast>

--- a/test/common/src/main/java/io/apiman/test/common/echo/EchoServerVertx.java
+++ b/test/common/src/main/java/io/apiman/test/common/echo/EchoServerVertx.java
@@ -28,7 +28,6 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
-import io.vertx.core.http.HttpServerOptionsConverter;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
@@ -138,8 +137,7 @@ public class EchoServerVertx extends AbstractVerticle {
     }
 
     private HttpServerOptions getHttpServerOptions(String name) {
-        HttpServerOptions options = new HttpServerOptions();
-        HttpServerOptionsConverter.fromJson(config().getJsonObject(name, new JsonObject()), options);
+        HttpServerOptions options = new HttpServerOptions(config().getJsonObject(name, new JsonObject()));
         if (JdkSSLEngineOptions.isAlpnAvailable()) {
             options.setUseAlpn(true);
         }


### PR DESCRIPTION
We had the requirement that the the vert.x gateway (as server) defines the TLS protocol version for the connection between Client <-> Gateway.

This was not possible with the existing configuration.

I had to upgrade vert.x to get some methods to achieve this functionality and add a new flag to the configuration file. 
The other setting in `connector-factory` section is only for the connection Gateway <-> Unmanaged API. 

So this was not suitable for our case and for vert.x it is only a dummy setting. 
Vertx will only log: "Can't set allowed protocols on Vert.x gateway"

So I put the new setting in the `ssl` section of the config file.

I think we have to change the documentation also a bit for this, or the other conf.json files. I will do this if this gets merged.

And again I have to thank @bekihm for testing this.