### PR TITLE
Fix YAML API definitions not showing (#738)

### DIFF
--- a/manager/ui/war/plugins/api-manager/html/consumer/consumer-api.html
+++ b/manager/ui/war/plugins/api-manager/html/consumer/consumer-api.html
@@ -50,7 +50,7 @@
               No versions of this API have been published.  You will not be able to
               consume this API until it has been published by its owner!
             </div>
-            <div ng-show="version.definitionType == 'SwaggerJSON' && hasSwagger">
+            <div ng-show="(version.definitionType == 'SwaggerJSON' || version.definitionType == 'SwaggerYAML') && hasSwagger">
               <div class="vspacer-10" />
               <a href="{{ pluginName }}/browse/orgs/{{params.org}}/{{params.api}}/{{params.version}}/def">
                 <i class="fa fa-fw fa-sitemap"></i>

--- a/manager/ui/war/plugins/api-manager/ts/catalog/api-catalog.ts
+++ b/manager/ui/war/plugins/api-manager/ts/catalog/api-catalog.ts
@@ -257,7 +257,7 @@ module Apiman {
                     if ($scope.api.routeDefinitionUrl != null) definitionUrl = $scope.api.routeDefinitionUrl;
                     var definitionType = $scope.api.definitionType;
 
-                    if (definitionType == 'SwaggerJSON' && hasSwagger) {
+                    if ((definitionType == 'SwaggerJSON' || definitionType == 'SwaggerYAML') && hasSwagger) {
                         var authHeader = Configuration.getAuthorizationHeader();
 
                         $scope.definitionStatus = 'loading';

--- a/manager/ui/war/plugins/api-manager/ts/consumer/consumer-api.ts
+++ b/manager/ui/war/plugins/api-manager/ts/consumer/consumer-api.ts
@@ -145,7 +145,7 @@ module Apiman {
                     hasSwagger = true;
                 } catch (e) {}
 
-                if ($scope.version.definitionType == 'SwaggerJSON' && hasSwagger) {
+                if (($scope.version.definitionType == 'SwaggerJSON' || $scope.version.definitionType == 'SwaggerYAML') && hasSwagger) {
                     var url = ApiDefinitionSvcs.getApiDefinitionUrl($scope.params.org, $scope.params.api, $scope.params.version);
                     Logger.debug("!!!!! Using definition URL: {0}", url);
 


### PR DESCRIPTION
Fixes Issue apiman#738. It enables the showing of Swagger YAML API definitions in the ui