### PR TITLE
Fixes #736 -changed field mapping for "data" and added migration method

### DIFF
--- a/common/es/src/main/resources-filtered/io/apiman/common/es/util/apiman_manager-settings.json
+++ b/common/es/src/main/resources-filtered/io/apiman/common/es/util/apiman_manager-settings.json
@@ -89,7 +89,7 @@
                 "entityVersion" : { "type" : "string", "index" : "not_analyzed" },
                 "who" : { "type" : "string", "index" : "not_analyzed" },
                 "what" : { "type" : "string", "index" : "not_analyzed" },
-                "data" : { "type" : "string", "index" : "not_analyzed" }
+                "data" : { "type" : "text" }
             }
         },
         "plan" : {

--- a/manager/api/es/src/main/resources/io/apiman/manager/api/es/index-settings.json
+++ b/manager/api/es/src/main/resources/io/apiman/manager/api/es/index-settings.json
@@ -89,7 +89,7 @@
                 "entityVersion" : { "type" : "string", "index" : "not_analyzed" },
                 "who" : { "type" : "string", "index" : "not_analyzed" },
                 "what" : { "type" : "string", "index" : "not_analyzed" },
-                "data" : { "type" : "string", "index" : "not_analyzed" }
+                "data" : { "type" : "text" }
             }
         },
         "plan" : {


### PR DESCRIPTION
Here we go:

The problem was that mapping type "string" is not supported anymore in elasticseach. It is replaced with keyword and text. String will be changed automatically if you create an index with old mapping definitions.

In our case the field "data" was mapped with keyword, that can only store 32KB.

I changed it to text. So new installations does not have this problem anymore.

The migration process is a bit more complex for old installations:

1. Check if the old mapping applies
2. If yes, create a tmp index with new mapping
3. Reindex apiman_manger to tmp
4. Delete old apiman_manger index
5. Reindex tmp to apiman_manager
6. Delete tmp

Everything is made asynchronous so the UI does not freeze.

It is hard to test, because you need an existing elasticsearch with this kind of documents. Also you can not use the document count because the reindex api does not copy documents pending for deletion.

@bekihm and I tested this on our own setups and everything worked fine.

So let me know what you think :)