### PR TITLE
Little UI improvement: Hide delete button if not able to delete a plan

### DIFF
--- a/manager/ui/war/plugins/api-manager/html/plan/plan_entity.include
+++ b/manager/ui/war/plugins/api-manager/html/plan/plan_entity.include
@@ -19,8 +19,7 @@
 
 
                 <!-- Dropdown Cog -->
-                <ul class="plan-menu pull-right"
-                    style="list-style-type: none; padding-left: 10px; padding-top: 6px;">
+                <ul class="plan-menu pull-right" style="list-style-type: none; padding-left: 10px; padding-top: 6px;" ng-hide="canNotDelete()">
                   <li class="dropdown">
                     <a href="#"
                        style="text-decoration: none;"

--- a/manager/ui/war/plugins/api-manager/ts/plan/plan.ts
+++ b/manager/ui/war/plugins/api-manager/ts/plan/plan.ts
@@ -96,7 +96,11 @@ module Apiman {
             // ----- Delete --------------------->>>>
 
             // Add check for ability to delete, show/hide Delete option
-            $scope.canDelete = function() {};
+            $scope.canNotDelete = function () {
+               return ($scope.version && $scope.version.status === 'Locked') || ($scope.versions && $scope.versions.some(function (planItem) {
+                   return planItem.status === 'Locked';
+               }));
+            };
 
             // Call delete, open modal
             $scope.callDelete = function(size) {


### PR DESCRIPTION
It is only possible to delete an unlooked plan.

> Use this endpoint to delete a plan. Only an unlocked plan may be deleted.

So we added a little check if a plan version is locked and then hide the delete button.
As always thanks to @bekihm 