### PR TITLE
Fix null pointer exception in caching resources policy

### DIFF
--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/CachingResourcesPolicy.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/CachingResourcesPolicy.java
@@ -167,6 +167,10 @@ public class CachingResourcesPolicy extends AbstractMappedDataPolicy<CachingReso
     @Override
     protected IReadWriteStream<ApiResponse> responseDataHandler(final ApiResponse response,
                                                                 IPolicyContext context, CachingResourcesConfig policyConfiguration) {
+        if (response == null) {
+            // if the response is empty because of a policy failure before we end here and return null
+            return null;
+        }
 
         List<CachingResourcesSettingsEntry> possibleMatchingCachingEntries = context.getAttribute(CACHE_POSSIBLE_MATCHING_ENTRIES, new ArrayList<CachingResourcesSettingsEntry>());
         boolean isAMatch = false;
@@ -243,5 +247,4 @@ public class CachingResourcesPolicy extends AbstractMappedDataPolicy<CachingReso
 
         return cacheId.toString();
     }
-
 }


### PR DESCRIPTION
Hello @EricWittmann,
@volkflo has discovered some case in the caching resources policy where a NullPointerExection is thrown.
We now provide a PR for the case that the response is null. This can hapen if another previous chained policy delivers no response like the rate limiting policy.

Thanks to @volkflo for fixing it.