### PR TITLE
Make PluginClassLoader work on Windows

### DIFF
--- a/common/plugin/src/main/java/io/apiman/common/plugin/PluginClassLoader.java
+++ b/common/plugin/src/main/java/io/apiman/common/plugin/PluginClassLoader.java
@@ -129,6 +129,7 @@ public class PluginClassLoader extends ClassLoader {
                 output = new FileOutputStream(tmpFile);
                 IOUtils.copy(input, output);
                 output.flush();
+                IOUtils.closeQuietly(output);
                 tmpFile.renameTo(depFile);
             } catch (IOException e) {
                 throw e;
@@ -164,6 +165,7 @@ public class PluginClassLoader extends ClassLoader {
                 output = new FileOutputStream(tmpFile);
                 IOUtils.copy(input, output);
                 output.flush();
+                IOUtils.closeQuietly(output);
                 tmpFile.renameTo(resourceFile);
             } catch (IOException e) {
                 throw e;


### PR DESCRIPTION
When running on windows, the PluginClassLoader cannot rename files because it still has them open. Close the file before doing the rename.