### PR TITLE
build(.travis): Use OpenJDK8 instead of OracleJDK 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ stages:
     if: "branch = master AND type != pull_request"
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 notifications:
   irc:


### PR DESCRIPTION
Fixes CI breakage.