### PR TITLE
Fix resource loading because special characters in directory name

### DIFF
--- a/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/ApiToFileRegistry.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/ApiToFileRegistry.java
@@ -79,8 +79,8 @@ public class ApiToFileRegistry extends InMemoryRegistry {
         try {
             file = File.createTempFile("apiman", "fs");
             file.deleteOnExit();
-            System.setProperty("CONFIG_FILE_PATH", "file:///" + file.getAbsolutePath());
-            System.out.println("Setting CONFIG_FILE_PATH file:///" + file.getAbsolutePath());
+            System.setProperty("CONFIG_FILE_PATH", file.toURI().toString());
+            System.out.println("Setting CONFIG_FILE_PATH file:///" + file.toURI().toString());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/Vertx3GatewayFileRegistryServer.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/Vertx3GatewayFileRegistryServer.java
@@ -15,6 +15,7 @@
  */
 package io.apiman.gateway.test.junit.vertx3;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.apiman.gateway.engine.vertx.polling.URILoadingRegistry;
 import io.apiman.gateway.platforms.vertx3.verticles.ApiVerticle;
 import io.apiman.gateway.platforms.vertx3.verticles.InitVerticle;
@@ -26,14 +27,9 @@ import io.vertx.core.VertxOptions;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.json.JsonObject;
 
-import java.io.File;
-import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Files;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
-import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * A Vert.x 3 version of the gateway test server
@@ -67,8 +63,9 @@ public class Vertx3GatewayFileRegistryServer implements IGatewayTestServer {
 
     @Override
     public void configure(JsonNode nodeConfig) {
-        vertxConf = loadJsonObjectFromResources(nodeConfig, "config");
-        apiToFilePushEmulatorConfig = loadJsonObjectFromResources(nodeConfig, "configPushEmulator");
+        Vertx3GatewayHelper helper = new Vertx3GatewayHelper();
+        vertxConf = helper.loadJsonObjectFromResources(nodeConfig, "config");
+        apiToFilePushEmulatorConfig = helper.loadJsonObjectFromResources(nodeConfig, "configPushEmulator");
 
         apiToFileVx = Vertx.vertx(new VertxOptions()
                 .setBlockedThreadCheckInterval(99999));
@@ -87,18 +84,6 @@ public class Vertx3GatewayFileRegistryServer implements IGatewayTestServer {
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
-    }
-
-    private JsonObject loadJsonObjectFromResources(JsonNode nodeConfig, String name) {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fPath = nodeConfig.get(name).asText();
-        File file = new File(classLoader.getResource(fPath).getFile());
-        try {
-            conf = new String(Files.readAllBytes(file.toPath()));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return new JsonObject(conf);
     }
 
     @Override

--- a/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/Vertx3GatewayHelper.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/Vertx3GatewayHelper.java
@@ -1,0 +1,42 @@
+package io.apiman.gateway.test.junit.vertx3;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.vertx.core.json.JsonObject;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+public final class Vertx3GatewayHelper {
+
+
+    /**
+     * Constructor
+     */
+    public Vertx3GatewayHelper() {}
+
+    /**
+     * Loads the vertx3 config from a resource
+     *
+     * @param config the config to be read
+     * @param name the element of the config to be read
+     * @return the vertx3 config as jsonObject
+     */
+    protected JsonObject loadJsonObjectFromResources(JsonNode config, String name){
+        ClassLoader classLoader = getClass().getClassLoader();
+        String configPath = config.get(name).asText();
+        String conf;
+        String fPath;
+        File file;
+        try {
+            fPath = URLDecoder.decode(classLoader.getResource(configPath).getFile(), StandardCharsets.UTF_8.name());
+            file = new File(fPath);
+            conf = new String(Files.readAllBytes(file.toPath()));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return new JsonObject(conf);
+    }
+}

--- a/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/Vertx3GatewayTestServer.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/Vertx3GatewayTestServer.java
@@ -15,6 +15,7 @@
  */
 package io.apiman.gateway.test.junit.vertx3;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.apiman.common.util.ReflectionUtils;
 import io.apiman.gateway.platforms.vertx3.common.config.VertxEngineConfig;
 import io.apiman.gateway.platforms.vertx3.verticles.InitVerticle;
@@ -25,13 +26,8 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.json.JsonObject;
 
-import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.nio.file.Files;
 import java.util.concurrent.CountDownLatch;
-
-import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * A Vert.x 3 version of the gateway test server
@@ -46,7 +42,6 @@ public class Vertx3GatewayTestServer implements IGatewayTestServer {
     protected static final int ECHO_PORT = 7654;
 
     private EchoServer echoServer = new EchoServer(ECHO_PORT);
-    private String conf;
     private CountDownLatch startLatch;
     private CountDownLatch stopLatch;
     private Resetter resetter;
@@ -60,16 +55,7 @@ public class Vertx3GatewayTestServer implements IGatewayTestServer {
 
     @Override
     public void configure(JsonNode config) {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fPath = config.get("config").asText();
-        File file = new File(classLoader.getResource(fPath).getFile());
-
-        try {
-            conf = new String(Files.readAllBytes(file.toPath()));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        vertxConf = new JsonObject(conf);
+        vertxConf = new Vertx3GatewayHelper().loadJsonObjectFromResources(config, "config");
         resetter = getResetter(config.get("resetter").asText());
     }
 


### PR DESCRIPTION
We run a jenkins pipeline to test the apiman project.
We encountered that the resource loading of the test files failed if the directory name contains a `@`.

We fixed this an reduced also the duplicate code :)

Thanks @bekihm for reviewing
