### PR TITLE
Fix maven errors

### DIFF
--- a/gateway/engine/core/pom.xml
+++ b/gateway/engine/core/pom.xml
@@ -91,7 +91,19 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Export-Package>io.apiman.gateway.engine,io.apiman.gateway.engine.i18n,io.apiman.gateway.engine.async,io.apiman.gateway.engine.components,io.apiman.gateway.engine.impl,io.apiman.gateway.engine.policy</Export-Package>
+            <Export-Package>
+              io.apiman.gateway.engine,
+              io.apiman.gateway.engine.i18n,
+              io.apiman.gateway.engine.async,
+              io.apiman.gateway.engine.components,
+              io.apiman.gateway.engine.impl,
+              io.apiman.gateway.engine.policy,
+              io.apiman.gateway.engine.metrics,
+              io.apiman.gateway.engine.io,
+              io.apiman.gateway.engine.auth,
+              io.apiman.gateway.engine.rates,
+              io.apiman.gateway.engine.components.*
+            </Export-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/manager/ui/war/src/main/assembly/ui.xml
+++ b/manager/ui/war/src/main/assembly/ui.xml
@@ -8,7 +8,7 @@
   <fileSets>
     <fileSet>
       <directory>target/apimanui</directory>
-      <outputDirectory>/apimanui</outputDirectory>
+      <outputDirectory>./apimanui</outputDirectory>
       <filtered>false</filtered>
       <directoryMode>0755</directoryMode>
       <fileMode>0755</fileMode>


### PR DESCRIPTION
With this small improvement we fix a maven warning when building on windows and also added a missing export package which caused a lot of annoying warnings in IntelliJ IDEA.

Thanks again to @bekihm :)