### PR TITLE
Gateway endpoint REST Resource

### DIFF
--- a/gateway/api/rest-impl/src/main/java/io/apiman/gateway/api/rest/impl/IPlatform.java
+++ b/gateway/api/rest-impl/src/main/java/io/apiman/gateway/api/rest/impl/IPlatform.java
@@ -16,6 +16,7 @@
 package io.apiman.gateway.api.rest.impl;
 
 import io.apiman.gateway.engine.beans.ApiEndpoint;
+import io.apiman.gateway.engine.beans.GatewayEndpoint;
 
 /**
  * An interface used by the REST layer when getting information that must
@@ -37,5 +38,11 @@ public interface IPlatform {
      * @return the API endpoint
      */
     public ApiEndpoint getApiEndpoint(String organizationId, String apiId, String version);
+
+    /**
+     * Gets the gateway endpoint.
+     * @return the gateway endpoint
+     */
+    public GatewayEndpoint getEndpoint();
 
 }

--- a/gateway/api/rest-impl/src/main/java/io/apiman/gateway/api/rest/impl/SystemResourceImpl.java
+++ b/gateway/api/rest-impl/src/main/java/io/apiman/gateway/api/rest/impl/SystemResourceImpl.java
@@ -17,6 +17,7 @@
 package io.apiman.gateway.api.rest.impl;
 
 import io.apiman.gateway.api.rest.contract.ISystemResource;
+import io.apiman.gateway.engine.beans.GatewayEndpoint;
 import io.apiman.gateway.engine.beans.SystemStatus;
 
 /**
@@ -46,4 +47,11 @@ public class SystemResourceImpl extends AbstractResourceImpl implements ISystemR
         return status;
     }
 
+    /**
+     * @see io.apiman.gateway.api.rest.contract.ISystemResource#getEndpoint()
+     */
+    @Override
+    public GatewayEndpoint getEndpoint() {
+        return getPlatform().getEndpoint();
+    }
 }

--- a/gateway/api/rest/src/main/java/io/apiman/gateway/api/rest/contract/ISystemResource.java
+++ b/gateway/api/rest/src/main/java/io/apiman/gateway/api/rest/contract/ISystemResource.java
@@ -16,6 +16,7 @@
 
 package io.apiman.gateway.api.rest.contract;
 
+import io.apiman.gateway.engine.beans.GatewayEndpoint;
 import io.apiman.gateway.engine.beans.SystemStatus;
 import io.swagger.annotations.Api;
 
@@ -37,4 +38,10 @@ public interface ISystemResource {
     @Path("status")
     @Produces(MediaType.APPLICATION_JSON)
     public SystemStatus getStatus();
+
+    @GET
+    @Path("endpoint")
+    @Produces(MediaType.APPLICATION_JSON)
+    public GatewayEndpoint getEndpoint();
+
 }

--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/GatewayEndpoint.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/GatewayEndpoint.java
@@ -1,0 +1,35 @@
+package io.apiman.gateway.engine.beans;
+
+import java.io.Serializable;
+
+/**
+ * Gateway endpoint.
+ *
+ * @author benjamin.kihm@scheer-group.com
+ */
+public class GatewayEndpoint implements Serializable {
+
+    private static final long serialVersionUID = 5462692112594798640L;
+
+    private String endpoint;
+
+    /**
+     * Constructor.
+     */
+    public GatewayEndpoint() {
+    }
+
+    /**
+     * @return the endpoint
+     */
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    /**
+     * @param endpoint the endpoint to set
+     */
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+}

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/ApiResourceImpl.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/ApiResourceImpl.java
@@ -26,9 +26,7 @@ import io.apiman.gateway.engine.beans.ApiEndpoint;
 import io.apiman.gateway.engine.beans.exceptions.PublishingException;
 import io.apiman.gateway.engine.beans.exceptions.RegistrationException;
 import io.apiman.gateway.platforms.vertx3.common.config.VertxEngineConfig;
-import org.apache.commons.lang3.StringUtils;
-
-import java.net.URI;
+import io.apiman.gateway.platforms.vertx3.helpers.EndpointHelper;
 
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
@@ -73,55 +71,11 @@ public class ApiResourceImpl extends AbstractResource implements IApiResource {
     @SuppressWarnings("nls")
     public ApiEndpoint getApiEndpoint(String organizationId, String apiId, String version)
             throws NotAuthorizedException {
-        String scheme = apimanConfig.preferSecure() ? "https" : "http";
-        int port = apimanConfig.getPort(scheme);
-        String host = "localhost"; // TODO host from request context
-        String path = "";
-        // If endpoint was manually specified
-        if (apimanConfig.getPublicEndpoint() != null) {
-           URI publicEndpoint = URI.create(apimanConfig.getPublicEndpoint());
-
-           if (publicEndpoint.getPort() != -1) {
-               port = publicEndpoint.getPort();
-           }
-           if (publicEndpoint.getScheme() != null && !publicEndpoint.getScheme().isEmpty()) {
-               scheme = publicEndpoint.getScheme();
-           }
-           if (publicEndpoint.getPath() != null && !publicEndpoint.getPath().isEmpty()) {
-               path = publicEndpoint.getPath();
-           }
-           if (publicEndpoint.getHost() != null && !publicEndpoint.getHost().isEmpty()) {
-               host = publicEndpoint.getHost();
-           }
-        }
-
-        String endpoint = buildEndpoint(organizationId, apiId, version, scheme, host, port, path);
+        EndpointHelper endpointHelper = new EndpointHelper(apimanConfig);
+        String endpoint = endpointHelper.getApiEndpoint(organizationId, apiId, version);
         ApiEndpoint endpointObj = new ApiEndpoint();
         endpointObj.setEndpoint(endpoint);
         return endpointObj;
-    }
-
-    private String buildEndpoint(String organizationId, String apiId, String version, String scheme, String host, int port, String path) {
-        StringBuilder endpoint = new StringBuilder();
-        endpoint.append(scheme);
-        endpoint.append("://");
-        endpoint.append(host);
-
-        if (port != 443 && port != 80) {
-            endpoint.append(":");
-            endpoint.append(port);
-        }
-
-        if (path.isEmpty()) {
-            endpoint.append("/");
-        } else {
-            endpoint.append(path);
-            if (!StringUtils.endsWith(path, "/"))
-                endpoint.append("/");
-        }
-
-        endpoint.append(String.join("/", organizationId, apiId, version));
-        return endpoint.toString();
     }
 
     @Override
@@ -165,5 +119,4 @@ public class ApiResourceImpl extends AbstractResource implements IApiResource {
             }
         });
     }
-
 }

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/SystemResourceImpl.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/SystemResourceImpl.java
@@ -18,7 +18,9 @@ package io.apiman.gateway.platforms.vertx3.api;
 import io.apiman.gateway.api.rest.contract.ISystemResource;
 import io.apiman.gateway.engine.IEngine;
 import io.apiman.gateway.engine.beans.SystemStatus;
+import io.apiman.gateway.engine.beans.GatewayEndpoint;
 import io.apiman.gateway.platforms.vertx3.common.config.VertxEngineConfig;
+import io.apiman.gateway.platforms.vertx3.helpers.EndpointHelper;
 
 /**
  * System Resource route builder
@@ -28,8 +30,10 @@ import io.apiman.gateway.platforms.vertx3.common.config.VertxEngineConfig;
 public class SystemResourceImpl implements ISystemResource {
 
     private IEngine engine;
+    private VertxEngineConfig apimanConfig;
 
     public SystemResourceImpl(VertxEngineConfig apimanConfig, IEngine engine) {
+        this.apimanConfig = apimanConfig;
         this.engine = engine;
     }
 
@@ -39,5 +43,14 @@ public class SystemResourceImpl implements ISystemResource {
         status.setUp(true);
         status.setVersion(engine.getVersion());
         return status;
+    }
+
+    @Override
+    public GatewayEndpoint getEndpoint() {
+        EndpointHelper endpointHelper = new EndpointHelper(apimanConfig);
+        String endpoint = endpointHelper.getGatewayEndpoint();
+        GatewayEndpoint endpointObj = new GatewayEndpoint();
+        endpointObj.setEndpoint(endpoint);
+        return endpointObj;
     }
 }

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/helpers/EndpointHelper.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/helpers/EndpointHelper.java
@@ -1,0 +1,117 @@
+package io.apiman.gateway.platforms.vertx3.helpers;
+
+import io.apiman.gateway.platforms.vertx3.common.config.VertxEngineConfig;
+import org.apache.commons.lang3.StringUtils;
+
+import java.net.URI;
+
+/**
+ * Helper for Gateway and Api Endpoints (Reading Endpoint from Vertx Config)
+ */
+public class EndpointHelper {
+
+    private String scheme;
+    private int port;
+    private String host;
+    private String path;
+
+    /**
+     * Get the scheme
+     * @return scheme
+     */
+    public String getScheme() {
+        return scheme;
+    }
+
+    /**
+     * Get the port
+     * @return port
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * Get the host
+     * @return host
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * Get the path
+     * @return path
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * Reads the gateway endpoint data from the vertx configuration
+     * @param apimanConfig  vertx configuration
+     */
+    public EndpointHelper(VertxEngineConfig apimanConfig) {
+        scheme = apimanConfig.preferSecure() ? "https" : "http";
+        port = apimanConfig.getPort(scheme);
+        host = "localhost";
+        path = "";
+        // If endpoint was manually specified
+        if (apimanConfig.getPublicEndpoint() != null) {
+            URI publicEndpoint = URI.create(apimanConfig.getPublicEndpoint());
+
+            if (publicEndpoint.getPort() != -1) {
+                port = publicEndpoint.getPort();
+            }
+            if (publicEndpoint.getScheme() != null && !publicEndpoint.getScheme().isEmpty()) {
+                scheme = publicEndpoint.getScheme();
+            }
+            if (publicEndpoint.getPath() != null && !publicEndpoint.getPath().isEmpty()) {
+                path = publicEndpoint.getPath();
+            }
+            if (publicEndpoint.getHost() != null && !publicEndpoint.getHost().isEmpty()) {
+                host = publicEndpoint.getHost();
+            }
+        }
+    }
+
+
+    /**
+     * Builds the gateway endpoint
+     * @return gateway endpoint
+     */
+    public String getGatewayEndpoint() {
+        StringBuilder endpoint = new StringBuilder();
+        endpoint.append(scheme);
+        endpoint.append("://");
+        endpoint.append(host);
+
+        if (port != 443 && port != 80) {
+            endpoint.append(":");
+            endpoint.append(port);
+        }
+
+        if (path.isEmpty()) {
+            endpoint.append("/");
+        } else {
+            endpoint.append(path);
+            if (!StringUtils.endsWith(path, "/"))
+                endpoint.append("/");
+        }
+        return endpoint.toString();
+    }
+
+    /**
+     * Builds the api endpoint based on the gateway endpoint data
+     * @param organizationId Organization Id
+     * @param apiId Api Id
+     * @param apiVersion Api version
+     * @return api endpoint
+     */
+    public String getApiEndpoint(String organizationId, String apiId, String apiVersion) {
+        StringBuilder gatewayEndpoint = new StringBuilder(this.getGatewayEndpoint());
+        StringBuilder apiEndpoint = gatewayEndpoint.append(String.join("/", organizationId, apiId, apiVersion));
+        return apiEndpoint.toString();
+    }
+
+}

--- a/gateway/platforms/war/micro/src/main/java/io/apiman/gateway/platforms/war/micro/GatewayMicroServicePlatform.java
+++ b/gateway/platforms/war/micro/src/main/java/io/apiman/gateway/platforms/war/micro/GatewayMicroServicePlatform.java
@@ -17,6 +17,7 @@ package io.apiman.gateway.platforms.war.micro;
 
 import io.apiman.gateway.api.rest.impl.IPlatform;
 import io.apiman.gateway.engine.beans.ApiEndpoint;
+import io.apiman.gateway.engine.beans.GatewayEndpoint;
 import io.apiman.gateway.platforms.war.WarGateway;
 import io.apiman.gateway.platforms.war.filters.HttpRequestThreadLocalFilter;
 
@@ -28,7 +29,7 @@ import javax.servlet.http.HttpServletRequest;
  * @author eric.wittmann@redhat.com
  */
 public class GatewayMicroServicePlatform implements IPlatform {
-    
+
     public static final String APIMAN_GATEWAY_ENDPOINT = "apiman.micro.gateway.public-endpoint"; //$NON-NLS-1$
 
     /**
@@ -42,6 +43,33 @@ public class GatewayMicroServicePlatform implements IPlatform {
      */
     @Override
     public ApiEndpoint getApiEndpoint(String organizationId, String apiId, String version) {
+        StringBuilder builder = getGatewayEndpoint();
+        builder.append(organizationId);
+        builder.append("/"); //$NON-NLS-1$
+        builder.append(apiId);
+        builder.append("/"); //$NON-NLS-1$
+        builder.append(version);
+
+        ApiEndpoint rval = new ApiEndpoint();
+        rval.setEndpoint(builder.toString());
+        return rval;
+    }
+
+    /**
+     * @see io.apiman.gateway.api.rest.impl.IPlatform#getEndpoint()
+     */
+    @Override
+    public GatewayEndpoint getEndpoint() {
+        GatewayEndpoint gatewayEndpoint = new GatewayEndpoint();
+        gatewayEndpoint.setEndpoint(getGatewayEndpoint().toString());
+        return gatewayEndpoint;
+    }
+
+    /**
+     * Determine gateway endpoint
+     * @return gateway endpoint as StringBuilder
+     */
+    private StringBuilder getGatewayEndpoint() {
         String endpoint = WarGateway.config.getConfigProperty(APIMAN_GATEWAY_ENDPOINT, null);
         StringBuilder builder = new StringBuilder();
         if (endpoint == null) {
@@ -63,15 +91,7 @@ public class GatewayMicroServicePlatform implements IPlatform {
                 builder.append("/"); //$NON-NLS-1$
             }
         }
-        builder.append(organizationId);
-        builder.append("/"); //$NON-NLS-1$
-        builder.append(apiId);
-        builder.append("/"); //$NON-NLS-1$
-        builder.append(version);
-        
-        ApiEndpoint rval = new ApiEndpoint();
-        rval.setEndpoint(builder.toString());
-        return rval;
+        return builder;
     }
 
 }

--- a/gateway/platforms/war/src/main/java/io/apiman/gateway/platforms/war/WarPlatform.java
+++ b/gateway/platforms/war/src/main/java/io/apiman/gateway/platforms/war/WarPlatform.java
@@ -18,6 +18,7 @@ package io.apiman.gateway.platforms.war;
 import io.apiman.gateway.api.rest.impl.IPlatform;
 import io.apiman.gateway.engine.GatewayConfigProperties;
 import io.apiman.gateway.engine.beans.ApiEndpoint;
+import io.apiman.gateway.engine.beans.GatewayEndpoint;
 import io.apiman.gateway.platforms.war.filters.HttpRequestThreadLocalFilter;
 
 import javax.servlet.http.HttpServletRequest;
@@ -28,7 +29,7 @@ import javax.servlet.http.HttpServletRequest;
  * @author eric.wittmann@redhat.com
  */
 public class WarPlatform implements IPlatform {
-    
+
     public static final String APIMAN_GATEWAY_ENDPOINT = GatewayConfigProperties.PUBLIC_ENDPOINT;
 
     /**
@@ -42,6 +43,33 @@ public class WarPlatform implements IPlatform {
      */
     @Override
     public ApiEndpoint getApiEndpoint(String organizationId, String apiId, String version) {
+        StringBuilder builder = getGatewayEndpoint();
+        builder.append(organizationId);
+        builder.append("/"); //$NON-NLS-1$
+        builder.append(apiId);
+        builder.append("/"); //$NON-NLS-1$
+        builder.append(version);
+
+        ApiEndpoint rval = new ApiEndpoint();
+        rval.setEndpoint(builder.toString());
+        return rval;
+    }
+
+    /**
+     * @see io.apiman.gateway.api.rest.impl.IPlatform#getEndpoint()
+     */
+    @Override
+    public GatewayEndpoint getEndpoint() {
+        GatewayEndpoint gatewayEndpoint = new GatewayEndpoint();
+        gatewayEndpoint.setEndpoint(getGatewayEndpoint().toString());
+        return gatewayEndpoint;
+    }
+
+    /**
+     * Determine gateway endpoint
+     * @return gateway endpoint as StringBuilder
+     */
+    private StringBuilder getGatewayEndpoint() {
         String endpoint = WarGateway.config.getConfigProperty(APIMAN_GATEWAY_ENDPOINT, null);
         StringBuilder builder = new StringBuilder();
         if (endpoint == null) {
@@ -63,15 +91,7 @@ public class WarPlatform implements IPlatform {
                 builder.append("/"); //$NON-NLS-1$
             }
         }
-        builder.append(organizationId);
-        builder.append("/"); //$NON-NLS-1$
-        builder.append(apiId);
-        builder.append("/"); //$NON-NLS-1$
-        builder.append(version);
-        
-        ApiEndpoint rval = new ApiEndpoint();
-        rval.setEndpoint(builder.toString());
-        return rval;
+        return builder;
     }
 
 }

--- a/gateway/test/src/main/java/io/apiman/gateway/test/server/PlatformAccessor.java
+++ b/gateway/test/src/main/java/io/apiman/gateway/test/server/PlatformAccessor.java
@@ -18,6 +18,7 @@ package io.apiman.gateway.test.server;
 import io.apiman.gateway.api.rest.impl.IPlatform;
 import io.apiman.gateway.api.rest.impl.IPlatformAccessor;
 import io.apiman.gateway.engine.beans.ApiEndpoint;
+import io.apiman.gateway.engine.beans.GatewayEndpoint;
 
 /**
  * The test platform accessor.
@@ -25,13 +26,12 @@ import io.apiman.gateway.engine.beans.ApiEndpoint;
  * @author eric.wittmann@redhat.com
  */
 public class PlatformAccessor implements IPlatformAccessor {
-    
+
     private static final IPlatform platform = new IPlatform() {
         @SuppressWarnings("nls")
         @Override
         public ApiEndpoint getApiEndpoint(String organizationId, String apiId, String version) {
-            StringBuilder builder = new StringBuilder();
-            builder.append("http://localhost:").append(GatewayServer.gatewayServer.getPort()).append("/gateway/");
+            StringBuilder builder = getGatewayEndpoint();
             builder.append(organizationId);
             builder.append("/"); //$NON-NLS-1$
             builder.append(apiId);
@@ -42,6 +42,18 @@ public class PlatformAccessor implements IPlatformAccessor {
             rval.setEndpoint(builder.toString());
             return rval;
         }
+
+        public GatewayEndpoint getEndpoint() {
+            GatewayEndpoint endpoint = new GatewayEndpoint();
+            endpoint.setEndpoint(getGatewayEndpoint().toString());
+            return endpoint;
+        }
+
+        private StringBuilder getGatewayEndpoint() {
+            StringBuilder builder = new StringBuilder();
+            builder.append("http://localhost:").append(GatewayServer.gatewayServer.getPort()).append("/gateway/");
+            return  builder;
+        }
     };
 
     /**
@@ -51,5 +63,5 @@ public class PlatformAccessor implements IPlatformAccessor {
     public IPlatform getPlatform() {
         return platform;
     }
-    
+
 }

--- a/gateway/test/src/test/java/io/apiman/gateway/test/junit/GatewayRestTester.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/junit/GatewayRestTester.java
@@ -202,8 +202,8 @@ public class GatewayRestTester extends ParentRunner<TestInfo> {
         log("-------------------------------------------------------------------------------");
         log("");
 
-        System.setProperty("apiman-gateway-test.gateway-endpoint", gatewayServer.getGatewayEndpoint());
-        System.setProperty("apiman-gateway-test.endpoints.echo", gatewayServer.getEchoTestEndpoint());
+        System.setProperty("apiman.test.gateway.gateway.endpoint", gatewayServer.getGatewayEndpoint());
+        System.setProperty("apiman.test.gateway.endpoints.echo", gatewayServer.getEchoTestEndpoint());
 
         try {
             super.run(notifier);

--- a/gateway/test/src/test/java/io/apiman/gateway/test/junit/GatewayRestTester.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/junit/GatewayRestTester.java
@@ -202,6 +202,7 @@ public class GatewayRestTester extends ParentRunner<TestInfo> {
         log("-------------------------------------------------------------------------------");
         log("");
 
+        System.setProperty("apiman-gateway-test.gateway-endpoint", gatewayServer.getGatewayEndpoint());
         System.setProperty("apiman-gateway-test.endpoints.echo", gatewayServer.getEchoTestEndpoint());
 
         try {
@@ -254,7 +255,7 @@ public class GatewayRestTester extends ParentRunner<TestInfo> {
                     if (endpoint == null) {
                         endpoint = gatewayServer.getGatewayEndpoint();
                     }
-    
+
                     testInfo.plan.runner.runTest(restTest, endpoint);
                     gatewayServer.next(endpoint);
                 }

--- a/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/Vertx3GatewayFileRegistryServer.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/Vertx3GatewayFileRegistryServer.java
@@ -39,8 +39,8 @@ import java.util.concurrent.TimeUnit;
 @SuppressWarnings("nls")
 public class Vertx3GatewayFileRegistryServer implements IGatewayTestServer {
 
-    protected static final int API_PORT = 9009;
-    protected static final int GW_PORT = 8082;
+    protected static int API_PORT;
+    protected static int GW_PORT;
     protected static final int ECHO_PORT = 7654;
 
     private EchoServer echoServer = new EchoServer(ECHO_PORT);
@@ -54,6 +54,7 @@ public class Vertx3GatewayFileRegistryServer implements IGatewayTestServer {
     private CountDownLatch rewriteCdl = new CountDownLatch(1);
     private CountDownLatch resetLatch = new CountDownLatch(1);
     private CountDownLatch a2fInitLatch = new CountDownLatch(1);
+    private Vertx3GatewayHelper helper;
 
     /**
      * Constructor.
@@ -63,9 +64,12 @@ public class Vertx3GatewayFileRegistryServer implements IGatewayTestServer {
 
     @Override
     public void configure(JsonNode nodeConfig) {
-        Vertx3GatewayHelper helper = new Vertx3GatewayHelper();
+        helper = new Vertx3GatewayHelper();
         vertxConf = helper.loadJsonObjectFromResources(nodeConfig, "config");
         apiToFilePushEmulatorConfig = helper.loadJsonObjectFromResources(nodeConfig, "configPushEmulator");
+
+        API_PORT = helper.getApiPortDynamically(apiToFilePushEmulatorConfig);
+        GW_PORT = helper.getGatewayPortDynamically(apiToFilePushEmulatorConfig);
 
         apiToFileVx = Vertx.vertx(new VertxOptions()
                 .setBlockedThreadCheckInterval(99999));

--- a/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/Vertx3GatewayHelper.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/Vertx3GatewayHelper.java
@@ -24,7 +24,7 @@ public final class Vertx3GatewayHelper {
      * @param name the element of the config to be read
      * @return the vertx3 config as jsonObject
      */
-    protected JsonObject loadJsonObjectFromResources(JsonNode config, String name){
+    protected JsonObject loadJsonObjectFromResources(JsonNode config, String name) {
         ClassLoader classLoader = getClass().getClassLoader();
         String configPath = config.get(name).asText();
         String conf;
@@ -38,5 +38,25 @@ public final class Vertx3GatewayHelper {
             throw new RuntimeException(e);
         }
         return new JsonObject(conf);
+    }
+
+    /**
+     * get api port dynamically from configuration
+     * @param apiToFilePushEmulatorConfig configuration
+     * @return api port
+     */
+    public int getApiPortDynamically(JsonObject apiToFilePushEmulatorConfig) {
+        return apiToFilePushEmulatorConfig.getJsonObject("verticles").getJsonObject("api").getInteger("port");
+    }
+
+    /**
+     * get gateway port dynamically from configuration
+     * @param apiToFilePushEmulatorConfig configuration
+     * @return gateway port
+     */
+    public int getGatewayPortDynamically(JsonObject apiToFilePushEmulatorConfig) {
+        boolean preferSecure = apiToFilePushEmulatorConfig.getBoolean("preferSecure");
+        String method = preferSecure ? "https" : "http";
+        return apiToFilePushEmulatorConfig.getJsonObject("verticles").getJsonObject(method).getInteger("port");
     }
 }

--- a/gateway/test/src/test/java/io/apiman/gateway/test/policies/SimpleHttpClientPolicy.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/policies/SimpleHttpClientPolicy.java
@@ -33,7 +33,7 @@ import io.apiman.gateway.engine.policy.IPolicyContext;
  * @author eric.wittmann@redhat.com
  */
 public class SimpleHttpClientPolicy implements IPolicy {
-    
+
     /**
      * Constructor.
      */
@@ -47,7 +47,7 @@ public class SimpleHttpClientPolicy implements IPolicy {
     public Object parseConfiguration(String jsonConfiguration) {
         return new Object();
     }
-    
+
     /**
      * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ApiRequest, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
      */
@@ -55,7 +55,7 @@ public class SimpleHttpClientPolicy implements IPolicy {
     public void apply(final ApiRequest request, final IPolicyContext context, final Object config,
             final IPolicyChain<ApiRequest> chain) {
         final IHttpClientComponent httpClientComponent = context.getComponent(IHttpClientComponent.class);
-        String endpoint = System.getProperty("apiman-gateway-test.endpoints.echo"); //$NON-NLS-1$
+        String endpoint = System.getProperty("apiman.test.gateway.endpoints.echo"); //$NON-NLS-1$
         IHttpClientRequest clientRequest = httpClientComponent.request(endpoint, HttpMethod.GET, new IAsyncResultHandler<IHttpClientResponse>() {
             @Override
             public void handle(IAsyncResult<IHttpClientResponse> result) {

--- a/gateway/test/src/test/resources/test-plan-data/api-republish/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/api-republish/001-publish-api.resttest
@@ -8,7 +8,7 @@ Content-Type: application/json
   "publicAPI" : true,
   "endpointType" : "rest",
   "endpointContentType" : "json",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/public-echo"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/public-echo"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/api-republish/005-republish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/api-republish/005-republish-api.resttest
@@ -8,7 +8,7 @@ Content-Type: application/json
   "publicAPI" : true,
   "endpointType" : "rest",
   "endpointContentType" : "json",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/public-echo-republish"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/public-echo-republish"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/api/apis/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/api/apis/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/api/apis/002-publish-duplicate.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/api/apis/002-publish-duplicate.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/api/apis/003-publish-api-2.0.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/api/apis/003-publish-api-2.0.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "2.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/api/apis/004-publish-api-3.0.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/api/apis/004-publish-api-3.0.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "3.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/api/apis/006-get-endpoint.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/api/apis/006-get-endpoint.resttest
@@ -4,5 +4,5 @@ GET /apis/GatewayApiTest/echo/2.0/endpoint admin/admin
 Content-Type: application/json
 
 {
-  "endpoint":"${apiman-gateway-test.gateway-endpoint}/GatewayApiTest/echo/2.0"
+  "endpoint":"${apiman.test.gateway.gateway.endpoint}/GatewayApiTest/echo/2.0"
 }

--- a/gateway/test/src/test/resources/test-plan-data/api/apis/006-get-endpoint.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/api/apis/006-get-endpoint.resttest
@@ -4,5 +4,5 @@ GET /apis/GatewayApiTest/echo/2.0/endpoint admin/admin
 Content-Type: application/json
 
 {
-  "endpoint":"http://localhost:6060/gateway/GatewayApiTest/echo/2.0"
+  "endpoint":"${apiman-gateway-test.gateway-endpoint}/GatewayApiTest/echo/2.0"
 }

--- a/gateway/test/src/test/resources/test-plan-data/api/apis/007-republish-api-3.0.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/api/apis/007-republish-api-3.0.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "3.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/client-reregister/setup/001-publish-api-1.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/client-reregister/setup/001-publish-api-1.resttest
@@ -7,7 +7,7 @@ Content-Type: application/json
   "version" : "1.0",
   "endpointType" : "rest",
   "endpointContentType" : "json",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/echo-1"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/echo-1"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/client-reregister/setup/002-publish-api-2.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/client-reregister/setup/002-publish-api-2.resttest
@@ -7,7 +7,7 @@ Content-Type: application/json
   "version" : "1.0",
   "endpointType" : "rest",
   "endpointContentType" : "json",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/echo-2"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/echo-2"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/perf/overhead/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/perf/overhead/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/plugins/test-policy/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/plugins/test-policy/001-publish-api.resttest
@@ -7,7 +7,7 @@ Content-Type: application/json
   "version" : "1.0",
   "publicAPI" : true,
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/",
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/",
   "apiPolicies" : [
     {
       "policyImpl" : "plugin:io.apiman:apiman-plugins-test-policy:1.2.3-SNAPSHOT:war/io.apiman.plugins.test_policy.TestPolicy",

--- a/gateway/test/src/test/resources/test-plan-data/policies/basic-auth-static/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/basic-auth-static/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/policies/failure-processing/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/failure-processing/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/policies/ignored-resources-xml/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/ignored-resources-xml/001-publish-api.resttest
@@ -7,7 +7,7 @@ Content-Type: application/json
   "version" : "1.0.0",
   "endpointType" : "rest",
   "endpointContentType" : "xml",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/policies/ignored-resources/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/ignored-resources/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/policies/ip-blacklist/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/ip-blacklist/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/policies/ip-whitelist/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/ip-whitelist/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/policies/logging/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/logging/001-publish-api.resttest
@@ -7,7 +7,7 @@ Content-Type: application/json
   "version" : "2.0",
   "publicAPI" : true,
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/",
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/",
   "apiPolicies" : [
         {
           "policyImpl" : "class:io.apiman.gateway.test.policies.LoggingPolicy",

--- a/gateway/test/src/test/resources/test-plan-data/policies/rate-limiting/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/rate-limiting/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/simple/bean-shared-state-policy/setup/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/bean-shared-state-policy/setup/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-conversation-policy/setup/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-conversation-policy/setup/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-data-policy/setup/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-data-policy/setup/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-echo-1227/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-echo-1227/001-publish-api.resttest
@@ -7,7 +7,7 @@ Content-Type: application/json
   "version" : "1.0",
   "publicAPI" : true,
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/endpoint/with-trailing-slash/",
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/endpoint/with-trailing-slash/",
   "apiPolicies" : [ ]
 }
 ----

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-echo-1227/noslash-001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-echo-1227/noslash-001-publish-api.resttest
@@ -7,7 +7,7 @@ Content-Type: application/json
   "version" : "1.0",
   "publicAPI" : true,
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/endpoint/without-trailing-slash",
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/endpoint/without-trailing-slash",
   "apiPolicies" : [ ]
 }
 ----

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-echo-public/setup/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-echo-public/setup/001-publish-api.resttest
@@ -7,7 +7,7 @@ Content-Type: application/json
   "version" : "1.0",
   "publicAPI" : false,
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-echo-public/setup/002-publish-api-public.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-echo-public/setup/002-publish-api-public.resttest
@@ -7,7 +7,7 @@ Content-Type: application/json
   "version" : "2.0",
   "publicAPI" : true,
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/",
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/",
   "apiPolicies" : [ ]
 }
 ----

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-echo-redirect/setup/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-echo-redirect/setup/001-publish-api.resttest
@@ -7,7 +7,7 @@ Content-Type: application/json
   "version" : "1.0",
   "publicAPI" : true,
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/",
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/",
   "apiPolicies" : [ ]
 }
 ----

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-echo-replacement/setup/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-echo-replacement/setup/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/@{SimpleEchoReplacementTest-path}"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/@{SimpleEchoReplacementTest-path}"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-echo/setup/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-echo/setup/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-httpclient-policy/setup/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-httpclient-policy/setup/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-httpheader-policy/setup/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-httpheader-policy/setup/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-payload-policy/setup/001-publish-json-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-payload-policy/setup/001-publish-json-api.resttest
@@ -5,12 +5,12 @@ Content-Type: application/json
   "organizationId" : "SimplePayloadPolicyTest",
   "apiId" : "echo-json",
   "version" : "1.0.0",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/",
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/",
   "endpointType" : "rest",
   "endpointContentType" : "json",
   "parsePayload" : true,
   "publicAPI" : true,
-  "apiPolicies" : [ 
+  "apiPolicies" : [
         {
           "policyImpl" : "class:io.apiman.gateway.test.policies.SimpleJsonPayloadPolicy",
           "policyJsonConfig" : ""

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-payload-policy/setup/002-publish-xml-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-payload-policy/setup/002-publish-xml-api.resttest
@@ -5,12 +5,12 @@ Content-Type: application/json
   "organizationId" : "SimplePayloadPolicyTest",
   "apiId" : "echo-xml",
   "version" : "1.0.0",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/",
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/",
   "endpointType" : "rest",
   "endpointContentType" : "xml",
   "parsePayload" : true,
   "publicAPI" : true,
-  "apiPolicies" : [ 
+  "apiPolicies" : [
         {
           "policyImpl" : "class:io.apiman.gateway.test.policies.SimpleXmlPayloadPolicy",
           "policyJsonConfig" : ""

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-payload-policy/setup/003-publish-soap-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-payload-policy/setup/003-publish-soap-api.resttest
@@ -5,12 +5,12 @@ Content-Type: application/json
   "organizationId" : "SimplePayloadPolicyTest",
   "apiId" : "echo-soap",
   "version" : "1.0.0",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/",
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/",
   "endpointType" : "soap",
   "endpointContentType" : "xml",
   "parsePayload" : true,
   "publicAPI" : true,
-  "apiPolicies" : [ 
+  "apiPolicies" : [
         {
           "policyImpl" : "class:io.apiman.gateway.test.policies.SimpleSoapPayloadPolicy",
           "policyJsonConfig" : ""

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-policy/setup/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-policy/setup/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plan-data/simple/simple-shared-state-policy/setup/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/simple/simple-shared-state-policy/setup/001-publish-api.resttest
@@ -6,7 +6,7 @@ Content-Type: application/json
   "apiId" : "echo",
   "version" : "1.0.0",
   "endpointType" : "REST",
-  "endpoint" : "${apiman-gateway-test.endpoints.echo}/"
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
 }
 ----
 204

--- a/gateway/test/src/test/resources/test-plans/api/api-testPlan.xml
+++ b/gateway/test/src/test/resources/test-plans/api/api-testPlan.xml
@@ -7,8 +7,7 @@
     <test name="Publish Api 2.0">test-plan-data/api/apis/003-publish-api-2.0.resttest</test>
     <test name="Publish Api 3.0">test-plan-data/api/apis/004-publish-api-3.0.resttest</test>
     <test name="Retire Api 3.0">test-plan-data/api/apis/005-retire-api-3.0.resttest</test>
-<!-- This test is commented out because vert.x and servlet impls return different values. -->
-<!--     <test name="Get Api Endpoint">test-plan-data/api/apis/006-get-endpoint.resttest</test> -->
+    <test name="Get Api Endpoint">test-plan-data/api/apis/006-get-endpoint.resttest</test>
     <test name="Republish Api 3.0">test-plan-data/api/apis/007-republish-api-3.0.resttest</test>
     <test name="Retire Api 3.0 (again)">test-plan-data/api/apis/005-retire-api-3.0.resttest</test>
   </testGroup>
@@ -21,12 +20,12 @@
     <test name="Unregister Client" delay="2000">test-plan-data/api/clients/005-unregister-client.resttest</test>
     <test name="Reregister Client">test-plan-data/api/clients/006-reregister-client.resttest</test>
   </testGroup>
-  
+
   <testGroup name="List entities">
     <test name="Wait for elasticsearch" delay="2000" />
     <!-- Orgs  -->
     <test name="List Orgs">test-plan-data/api/list/000-list-orgs.resttest</test>
-    <!-- APIs  -->    
+    <!-- APIs  -->
     <test name="List APIs">test-plan-data/api/list/001-list-apis.resttest</test>
     <test name="List API Versions">test-plan-data/api/list/002-list-api-versions.resttest</test>
     <!-- Clients  -->

--- a/gateway/test/src/test/resources/vertx3/conf-api-to-file.json
+++ b/gateway/test/src/test/resources/vertx3/conf-api-to-file.json
@@ -1,4 +1,4 @@
-{ // This is a special config file that uses the ApiToFileRegistry in combination 
+{ // This is a special config file that uses the ApiToFileRegistry in combination
   // with Vertx3GatewayFileRegistryServer to emulate push behaviour for testing purposes.
     "registry": {
         "class": "io.apiman.gateway.test.junit.vertx3.ApiToFileRegistry",
@@ -103,7 +103,7 @@
     // Count - Number of given verticle type launched
     "verticles": {
         "http": {
-            "port": 8999,
+            "port": 8082,
             "count": 0
         },
         "https": {

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/summary/GatewayEndpointSummaryBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/summary/GatewayEndpointSummaryBean.java
@@ -1,0 +1,31 @@
+package io.apiman.manager.api.beans.summary;
+
+import java.io.Serializable;
+
+/**
+ * A summary bean for a gateway endpoint.
+ *
+ * @author benjamin.kihm@scheer-group.com
+ */
+public class GatewayEndpointSummaryBean implements Serializable {
+
+    private static final long serialVersionUID = -213566882390484357L;
+
+    private String endpoint;
+
+    /**
+     * Get gateway endpoint
+     * @return endpoint the gateway endpoint
+     */
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    /**
+     * Set gateway endpoint
+     * @param endpoint gateway endpoint
+     */
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+}

--- a/manager/api/es/src/main/java/io/apiman/manager/api/es/EsStorage.java
+++ b/manager/api/es/src/main/java/io/apiman/manager/api/es/EsStorage.java
@@ -1123,10 +1123,10 @@ public class EsStorage implements IStorage, IStorageQuery {
         String apiVersion = (String) source.get("apiVersion");
         String planId = (String) source.get("planId");
         String planVersion = (String) source.get("planVersion");
-        ClientVersionBean avb = getClientVersion(clientOrgId, clientId, clientVersion);
+        ClientVersionBean cvb = getClientVersion(clientOrgId, clientId, clientVersion);
         ApiVersionBean svb = getApiVersion(apiOrgId, apiId, apiVersion);
         PlanVersionBean pvb = getPlanVersion(apiOrgId, planId, planVersion);
-        contract.setClient(avb);
+        contract.setClient(cvb);
         contract.setPlan(pvb);
         contract.setApi(svb);
         return contract;

--- a/manager/api/export-import/src/main/java/io/apiman/manager/api/exportimport/manager/StorageImportDispatcher.java
+++ b/manager/api/export-import/src/main/java/io/apiman/manager/api/exportimport/manager/StorageImportDispatcher.java
@@ -422,13 +422,13 @@ public class StorageImportDispatcher implements IImportReaderDispatcher {
      */
     @Override
     public void clientContract(ContractBean contract) {
-        ClientVersionBean avb = new ClientVersionBean();
-        avb.setClient(new ClientBean());
-        avb.getClient().setOrganization(new OrganizationBean());
-        avb.getClient().setId(currentClient.getId());
-        avb.getClient().getOrganization().setId(currentOrg.getId());
-        avb.setVersion(currentClientVersion.getVersion());
-        contract.setClient(avb);
+        ClientVersionBean clientVersion = new ClientVersionBean();
+        clientVersion.setClient(new ClientBean());
+        clientVersion.getClient().setOrganization(new OrganizationBean());
+        clientVersion.getClient().setId(currentClient.getId());
+        clientVersion.getClient().getOrganization().setId(currentOrg.getId());
+        clientVersion.setVersion(currentClientVersion.getVersion());
+        contract.setClient(clientVersion);
         contracts.add(contract);
     }
 

--- a/manager/api/gateway/src/main/java/io/apiman/manager/api/gateway/IGatewayLink.java
+++ b/manager/api/gateway/src/main/java/io/apiman/manager/api/gateway/IGatewayLink.java
@@ -16,10 +16,7 @@
 package io.apiman.manager.api.gateway;
 
 import io.apiman.gateway.api.rest.contract.exceptions.NotAuthorizedException;
-import io.apiman.gateway.engine.beans.Api;
-import io.apiman.gateway.engine.beans.ApiEndpoint;
-import io.apiman.gateway.engine.beans.Client;
-import io.apiman.gateway.engine.beans.SystemStatus;
+import io.apiman.gateway.engine.beans.*;
 import io.apiman.gateway.engine.beans.exceptions.PublishingException;
 import io.apiman.gateway.engine.beans.exceptions.RegistrationException;
 
@@ -72,6 +69,13 @@ public interface IGatewayLink {
      * @throws GatewayAuthenticationException when unable to authenticate with gateway
      */
     public void unregisterClient(Client client) throws RegistrationException, GatewayAuthenticationException;
+
+    /**
+     * Gets the gateway endpoint from the gateway
+     * @return the gateway endpoint
+     * @throws GatewayAuthenticationException when unable to authenticate with gateway
+     */
+    public GatewayEndpoint getGatewayEndpoint() throws GatewayAuthenticationException;
 
     /**
      * Gets the api endpoint from the gateway.

--- a/manager/api/gateway/src/main/java/io/apiman/manager/api/gateway/rest/RestGatewayLink.java
+++ b/manager/api/gateway/src/main/java/io/apiman/manager/api/gateway/rest/RestGatewayLink.java
@@ -21,6 +21,7 @@ import io.apiman.common.util.crypt.CurrentDataEncrypter;
 import io.apiman.common.util.crypt.DataEncryptionContext;
 import io.apiman.gateway.engine.beans.Api;
 import io.apiman.gateway.engine.beans.ApiEndpoint;
+import io.apiman.gateway.engine.beans.GatewayEndpoint;
 import io.apiman.gateway.engine.beans.Client;
 import io.apiman.gateway.engine.beans.SystemStatus;
 import io.apiman.gateway.engine.beans.exceptions.PublishingException;
@@ -145,6 +146,13 @@ public class RestGatewayLink implements IGatewayLink {
     @Override
     public SystemStatus getStatus() throws GatewayAuthenticationException {
         return getClient().getStatus();
+    }
+
+    /**
+     * @see io.apiman.manager.api.gateway.IGatewayLink#getGatewayEndpoint()
+     */
+    public GatewayEndpoint getGatewayEndpoint() throws GatewayAuthenticationException {
+        return getClient().getGatewayEndpoint();
     }
 
     /**

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/GatewayResourceImpl.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/GatewayResourceImpl.java
@@ -82,16 +82,16 @@ public class GatewayResourceImpl implements IGatewayResource {
      * @see io.apiman.manager.api.rest.contract.IGatewayResource#test(io.apiman.manager.api.beans.gateways.NewGatewayBean)
      */
     @Override
-    public GatewayTestResultBean test(NewGatewayBean bean) throws NotAuthorizedException {
+    public GatewayTestResultBean test(NewGatewayBean gatewayToTest) throws NotAuthorizedException {
         if (!securityContext.isAdmin())
             throw ExceptionFactory.notAuthorizedException();
         GatewayTestResultBean rval = new GatewayTestResultBean();
 
         try {
             GatewayBean testGateway = new GatewayBean();
-            testGateway.setName(bean.getName());
-            testGateway.setType(bean.getType());
-            testGateway.setConfiguration(bean.getConfiguration());
+            testGateway.setName(gatewayToTest.getName());
+            testGateway.setType(gatewayToTest.getType());
+            testGateway.setConfiguration(gatewayToTest.getConfiguration());
             IGatewayLink gatewayLink = gatewayLinkFactory.create(testGateway);
             SystemStatus status = gatewayLink.getStatus();
             String detail = mapper.writer().writeValueAsString(status);
@@ -124,18 +124,18 @@ public class GatewayResourceImpl implements IGatewayResource {
      * @see io.apiman.manager.api.rest.contract.IGatewayResource#create(io.apiman.manager.api.beans.gateways.NewGatewayBean)
      */
     @Override
-    public GatewayBean create(NewGatewayBean bean) throws GatewayAlreadyExistsException {
+    public GatewayBean create(NewGatewayBean gatewayToInsert) throws GatewayAlreadyExistsException {
         if (!securityContext.isAdmin())
             throw ExceptionFactory.notAuthorizedException();
 
         Date now = new Date();
 
         GatewayBean gateway = new GatewayBean();
-        gateway.setId(BeanUtils.idFromName(bean.getName()));
-        gateway.setName(bean.getName());
-        gateway.setDescription(bean.getDescription());
-        gateway.setType(bean.getType());
-        gateway.setConfiguration(bean.getConfiguration());
+        gateway.setId(BeanUtils.idFromName(gatewayToInsert.getName()));
+        gateway.setName(gatewayToInsert.getName());
+        gateway.setDescription(gatewayToInsert.getDescription());
+        gateway.setType(gatewayToInsert.getType());
+        gateway.setConfiguration(gatewayToInsert.getConfiguration());
         gateway.setCreatedBy(securityContext.getCurrentUser());
         gateway.setCreatedOn(now);
         gateway.setModifiedBy(securityContext.getCurrentUser());
@@ -169,19 +169,19 @@ public class GatewayResourceImpl implements IGatewayResource {
     public GatewayBean get(String gatewayId) throws GatewayNotFoundException, NotAuthorizedException {
         try {
             storage.beginTx();
-            GatewayBean bean = storage.getGateway(gatewayId);
-            if (bean == null) {
+            GatewayBean gateway = storage.getGateway(gatewayId);
+            if (gateway == null) {
                 throw ExceptionFactory.gatewayNotFoundException(gatewayId);
             }
             if (!securityContext.isAdmin()) {
-                bean.setConfiguration(null);
+                gateway.setConfiguration(null);
             } else {
-                decryptPasswords(bean);
+                decryptPasswords(gateway);
             }
             storage.commitTx();
 
-            log.debug(String.format("Successfully fetched gateway %s: %s", bean.getName(), bean)); //$NON-NLS-1$
-            return bean;
+            log.debug(String.format("Successfully fetched gateway %s: %s", gateway.getName(), gateway)); //$NON-NLS-1$
+            return gateway;
         } catch (AbstractRestException e) {
             storage.rollbackTx();
             throw e;
@@ -206,10 +206,10 @@ public class GatewayResourceImpl implements IGatewayResource {
             }
             IGatewayLink link = gatewayLinkFactory.create(gateway);
             GatewayEndpoint endpoint = link.getGatewayEndpoint();
-            GatewayEndpointSummaryBean rval = new GatewayEndpointSummaryBean();
-            rval.setEndpoint(endpoint.getEndpoint());
+            GatewayEndpointSummaryBean gatewayEndpoint = new GatewayEndpointSummaryBean();
+            gatewayEndpoint.setEndpoint(endpoint.getEndpoint());
             storage.commitTx();
-            return rval;
+            return gatewayEndpoint;
         } catch (AbstractRestException e) {
             storage.rollbackTx();
             throw e;
@@ -223,7 +223,7 @@ public class GatewayResourceImpl implements IGatewayResource {
      * @see io.apiman.manager.api.rest.contract.IGatewayResource#update(java.lang.String, io.apiman.manager.api.beans.gateways.UpdateGatewayBean)
      */
     @Override
-    public void update(String gatewayId, UpdateGatewayBean bean) throws GatewayNotFoundException,
+    public void update(String gatewayId, UpdateGatewayBean gatewayToUpdate) throws GatewayNotFoundException,
             NotAuthorizedException {
         if (!securityContext.isAdmin())
             throw ExceptionFactory.notAuthorizedException();
@@ -231,23 +231,23 @@ public class GatewayResourceImpl implements IGatewayResource {
             storage.beginTx();
             Date now = new Date();
 
-            GatewayBean gbean = storage.getGateway(gatewayId);
-            if (gbean == null) {
+            GatewayBean gateway = storage.getGateway(gatewayId);
+            if (gateway == null) {
                 throw ExceptionFactory.gatewayNotFoundException(gatewayId);
             }
-            gbean.setModifiedBy(securityContext.getCurrentUser());
-            gbean.setModifiedOn(now);
-            if (bean.getDescription() != null)
-                gbean.setDescription(bean.getDescription());
-            if (bean.getType() != null)
-                gbean.setType(bean.getType());
-            if (bean.getConfiguration() != null)
-                gbean.setConfiguration(bean.getConfiguration());
-            encryptPasswords(gbean);
-            storage.updateGateway(gbean);
+            gateway.setModifiedBy(securityContext.getCurrentUser());
+            gateway.setModifiedOn(now);
+            if (gatewayToUpdate.getDescription() != null)
+                gateway.setDescription(gatewayToUpdate.getDescription());
+            if (gatewayToUpdate.getType() != null)
+                gateway.setType(gatewayToUpdate.getType());
+            if (gatewayToUpdate.getConfiguration() != null)
+                gateway.setConfiguration(gatewayToUpdate.getConfiguration());
+            encryptPasswords(gateway);
+            storage.updateGateway(gateway);
             storage.commitTx();
 
-            log.debug(String.format("Successfully updated gateway %s: %s", gbean.getName(), gbean)); //$NON-NLS-1$
+            log.debug(String.format("Successfully updated gateway %s: %s", gateway.getName(), gateway)); //$NON-NLS-1$
         } catch (AbstractRestException e) {
             storage.rollbackTx();
             throw e;
@@ -267,14 +267,14 @@ public class GatewayResourceImpl implements IGatewayResource {
             throw ExceptionFactory.notAuthorizedException();
         try {
             storage.beginTx();
-            GatewayBean gbean = storage.getGateway(gatewayId);
-            if (gbean == null) {
+            GatewayBean gateway = storage.getGateway(gatewayId);
+            if (gateway == null) {
                 throw ExceptionFactory.gatewayNotFoundException(gatewayId);
             }
-            storage.deleteGateway(gbean);
+            storage.deleteGateway(gateway);
             storage.commitTx();
 
-            log.debug(String.format("Successfully deleted gateway %s: %s", gbean.getName(), gbean)); //$NON-NLS-1$
+            log.debug(String.format("Successfully deleted gateway %s: %s", gateway.getName(), gateway)); //$NON-NLS-1$
         } catch (AbstractRestException e) {
             storage.rollbackTx();
             throw e;
@@ -285,17 +285,17 @@ public class GatewayResourceImpl implements IGatewayResource {
     }
 
     /**
-     * @param bean
+     * @param gateway
      */
-    private void encryptPasswords(GatewayBean bean) {
-        if (bean.getConfiguration() == null) {
+    private void encryptPasswords(GatewayBean gateway) {
+        if (gateway.getConfiguration() == null) {
             return;
         }
         try {
-            if (bean.getType() == GatewayType.REST) {
-                RestGatewayConfigBean configBean = mapper.readValue(bean.getConfiguration(), RestGatewayConfigBean.class);
-                configBean.setPassword(encrypter.encrypt(configBean.getPassword(), new DataEncryptionContext()));
-                bean.setConfiguration(mapper.writeValueAsString(configBean));
+            if (gateway.getType() == GatewayType.REST) {
+                RestGatewayConfigBean config = mapper.readValue(gateway.getConfiguration(), RestGatewayConfigBean.class);
+                config.setPassword(encrypter.encrypt(config.getPassword(), new DataEncryptionContext()));
+                gateway.setConfiguration(mapper.writeValueAsString(config));
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -303,17 +303,17 @@ public class GatewayResourceImpl implements IGatewayResource {
     }
 
     /**
-     * @param bean
+     * @param gateway
      */
-    private void decryptPasswords(GatewayBean bean) {
-        if (bean.getConfiguration() == null) {
+    private void decryptPasswords(GatewayBean gateway) {
+        if (gateway.getConfiguration() == null) {
             return;
         }
         try {
-            if (bean.getType() == GatewayType.REST) {
-                RestGatewayConfigBean configBean = mapper.readValue(bean.getConfiguration(), RestGatewayConfigBean.class);
-                configBean.setPassword(encrypter.decrypt(configBean.getPassword(), new DataEncryptionContext()));
-                bean.setConfiguration(mapper.writeValueAsString(configBean));
+            if (gateway.getType() == GatewayType.REST) {
+                RestGatewayConfigBean config = mapper.readValue(gateway.getConfiguration(), RestGatewayConfigBean.class);
+                config.setPassword(encrypter.decrypt(config.getPassword(), new DataEncryptionContext()));
+                gateway.setConfiguration(mapper.writeValueAsString(config));
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/manager/api/rest/src/main/java/io/apiman/manager/api/rest/contract/IGatewayResource.java
+++ b/manager/api/rest/src/main/java/io/apiman/manager/api/rest/contract/IGatewayResource.java
@@ -19,6 +19,7 @@ package io.apiman.manager.api.rest.contract;
 import io.apiman.manager.api.beans.gateways.GatewayBean;
 import io.apiman.manager.api.beans.gateways.NewGatewayBean;
 import io.apiman.manager.api.beans.gateways.UpdateGatewayBean;
+import io.apiman.manager.api.beans.summary.GatewayEndpointSummaryBean;
 import io.apiman.manager.api.beans.summary.GatewaySummaryBean;
 import io.apiman.manager.api.beans.summary.GatewayTestResultBean;
 import io.apiman.manager.api.rest.contract.exceptions.GatewayAlreadyExistsException;
@@ -40,24 +41,24 @@ import javax.ws.rs.core.MediaType;
 
 /**
  * The Gateway API.
- * 
+ *
  * @author eric.wittmann@redhat.com
  */
 @Path("gateways")
 @Api
 public interface IGatewayResource {
-    
+
     /**
-     * This endpoint is used to test the Gateway's settings prior to either creating 
+     * This endpoint is used to test the Gateway's settings prior to either creating
      * or updating it.  The information will be used to attempt to create a link between
-     * the API Manager and the Gateway, by simply trying to ping the Gateway's "status" 
+     * the API Manager and the Gateway, by simply trying to ping the Gateway's "status"
      * endpoint.
      * @summary Test a Gateway
      * @servicetag admin
      * @param bean Details of the Gateway for testing.
      * @statuscode 200 If the test is performed (regardless of the outcome of the test).
      * @return The result of testing the Gateway settings.
-     * @throws NotAuthorizedException when attempt to do something user is not authorized to do 
+     * @throws NotAuthorizedException when attempt to do something user is not authorized to do
      */
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
@@ -89,7 +90,7 @@ public interface IGatewayResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public GatewayBean create(NewGatewayBean bean) throws GatewayAlreadyExistsException, NotAuthorizedException;
-    
+
     /**
      * Call this endpoint to get the details of a single configured Gateway.
      * @summary Get a Gateway by ID
@@ -136,5 +137,18 @@ public interface IGatewayResource {
     @Path("{gatewayId}")
     public void delete(@PathParam("gatewayId") String gatewayId)
             throws GatewayNotFoundException, NotAuthorizedException;
+
+    /**
+     * This endpoint delivers the gateway endpoint for the corresponding gateway id
+     * @param gatewayId gateway id
+     * @return The corresponding gateway endpoint
+     * @throws GatewayNotFoundException when gateway is not found
+     * @throws NotAuthorizedException when attempt to do something user is not authorized to do
+     */
+    @GET
+    @Path("{gatewayId}/endpoint")
+    @Produces(MediaType.APPLICATION_JSON)
+    public GatewayEndpointSummaryBean getGatewayEndpoint(@PathParam("gatewayId") String gatewayId) throws GatewayNotFoundException,
+    NotAuthorizedException;
 
 }

--- a/manager/test/api/src/main/java/io/apiman/manager/test/server/MockGatewayServlet.java
+++ b/manager/test/api/src/main/java/io/apiman/manager/test/server/MockGatewayServlet.java
@@ -66,7 +66,7 @@ public class MockGatewayServlet extends HttpServlet {
             IOException {
         builder.append("GET:").append(req.getRequestURI()).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
         payloads.add(null);
-        if (req.getRequestURI().endsWith("/system/status")) { //$NON-NLS-1$
+        if (req.getRequestURI().contains("/system/status")) { //$NON-NLS-1$
             resp.setStatus(200);
             resp.setContentType("application/json"); //$NON-NLS-1$
             PrintWriter printWriter = new PrintWriter(resp.getOutputStream());
@@ -78,6 +78,13 @@ public class MockGatewayServlet extends HttpServlet {
             resp.setContentType("application/json"); //$NON-NLS-1$
             PrintWriter printWriter = new PrintWriter(resp.getOutputStream());
             printWriter.println("{ \"endpoint\" : \"http://example.org/endpoint\" }"); //$NON-NLS-1$
+            printWriter.flush();
+            printWriter.close();
+        } else if (req.getRequestURI().contains("system/endpoint")) { //$NON-NLS-1$
+            resp.setStatus(200);
+            resp.setContentType("application/json"); //$NON-NLS-1$
+            PrintWriter printWriter = new PrintWriter(resp.getOutputStream());
+            printWriter.println("{ \"endpoint\" : \"" + System.getProperty("apiman.test.gateway.endpoint") + "\" }"); //$NON-NLS-1$
             printWriter.flush();
             printWriter.close();
         } else {

--- a/manager/test/api/src/test/java/io/apiman/manager/test/GatewaysTest.java
+++ b/manager/test/api/src/test/java/io/apiman/manager/test/GatewaysTest.java
@@ -15,6 +15,7 @@
  */
 package io.apiman.manager.test;
 
+import io.apiman.manager.test.junit.ManagerRestTestGatewayLog;
 import io.apiman.manager.test.junit.ManagerRestTestPlan;
 import io.apiman.manager.test.junit.ManagerRestTester;
 
@@ -27,6 +28,9 @@ import org.junit.runner.RunWith;
  */
 @RunWith(ManagerRestTester.class)
 @ManagerRestTestPlan("test-plans/gateways-testPlan.xml")
+@ManagerRestTestGatewayLog(
+   "GET:/mock-gateway/system/status\n" +
+   "GET:/mock-gateway/system/endpoint\n"
+)
 public class GatewaysTest {
-
 }

--- a/manager/test/api/src/test/resources/test-plan-data/gateways/011_create-gateway-to-test-get-endpoint.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/gateways/011_create-gateway-to-test-get-endpoint.resttest
@@ -1,0 +1,20 @@
+POST /gateways admin/admin
+Content-Type: application/json
+
+{
+  "name" : "Gateway Endpoint",
+  "description" : "This is the get endpoint test gateway.",
+  "type" : "REST",
+  "configuration" : "{\"endpoint\":\"${apiman.test.gateway.endpoint}\",\"username\":\"admin\",\"password\":\"password\"}"
+}
+----
+200
+Content-Type: application/json
+
+{
+  "id" : "GatewayEndpoint",
+  "name" : "Gateway Endpoint",
+  "description" : "This is the get endpoint test gateway.",
+  "type" : "REST",
+  "configuration" : "{\"endpoint\":\"${apiman.test.gateway.endpoint}\",\"username\":\"admin\",\"password\":\"password\"}"
+}

--- a/manager/test/api/src/test/resources/test-plan-data/gateways/012-list-gateways.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/gateways/012-list-gateways.resttest
@@ -1,0 +1,8 @@
+GET /gateways/GatewayEndpoint/endpoint admin/admin
+----
+200
+Content-Type: application/json
+
+{
+    "endpoint": "${apiman.test.gateway.endpoint}"
+}

--- a/manager/test/api/src/test/resources/test-plans/gateways-testPlan.xml
+++ b/manager/test/api/src/test/resources/test-plans/gateways-testPlan.xml
@@ -14,6 +14,9 @@
     <test name="Get Gateway 1 (Updated)">test-plan-data/gateways/009_get-1.resttest</test>
 
     <test name="Test Gateway">test-plan-data/gateways/010_test_gateway_success.resttest</test>
+
+    <test name="Create Gateway Endpoint Test">test-plan-data/gateways/011_create-gateway-to-test-get-endpoint.resttest</test>
+    <test name="Get gateway endpoint">test-plan-data/gateways/012-list-gateways.resttest</test>
   </testGroup>
 
 </testPlan>


### PR DESCRIPTION
Hello @EricWittmann and @msavy ,
we needed in our scenario the possibility to access the gateway endpoint directly from the UI REST interface instead of going the indirection over the api endpoint.

We contribute with this PR  also the missing tests for the API endpoint REST resource and added tests for the new gateway endpoint REST resource (and some refactoring on tests and variable names).

This PR allows further optimizations of the API list on the client UI page which is not done yet in this PR (One could cache the gateway endpoints and build the api endpoints with this data instead of calling for each api endpoint the gateway resource again):
![2020-01-16 14_56_21-APIman - Optimization - Consumer (APIs)](https://user-images.githubusercontent.com/33115480/72531604-15b78f80-3872-11ea-876e-b1a03cf8b6f8.png)

Special thanks to @volkflo for the reviews on this.

Regards
Benjamin

