### PR TITLE
Allows user to pass authorization header downstream

### DIFF
--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/BasicAuthenticationPolicy.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/BasicAuthenticationPolicy.java
@@ -33,6 +33,7 @@ import io.apiman.gateway.engine.policy.IPolicyContext;
 import io.apiman.gateway.engine.policy.PolicyContextKeys;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.BooleanUtils;
 
 /**
  * An implementation of an apiman policy that supports multiple styles of authentication.
@@ -138,9 +139,11 @@ public class BasicAuthenticationPolicy extends AbstractMappedPolicy<BasicAuthent
                         if (metric != null) {
                             metric.setUser(forwardedUsername);
                         }
-                        // Remove the authorization header so that it doesn't get passed through to the backend API
-                        // TODO: make this optional - perhaps they *want* the auth header passed through?
-                        request.getHeaders().remove("Authorization"); //$NON-NLS-1$
+                        boolean forwardBasicAuthDownstream = BooleanUtils.toBooleanDefaultIfNull(config.isForwardBasicAuthDownstream(), Boolean.FALSE);
+                        if(!forwardBasicAuthDownstream) {
+                            // Remove the authorization header so that it doesn't get passed through to the backend API
+                            request.getHeaders().remove("Authorization"); //$NON-NLS-1$
+                        }
                         chain.doApply(request);
                     } else {
                         sendAuthFailure(context, chain, config, PolicyFailureCodes.BASIC_AUTH_FAILED);

--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/config/BasicAuthenticationConfig.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/config/BasicAuthenticationConfig.java
@@ -31,6 +31,7 @@ public class BasicAuthenticationConfig {
     private String forwardIdentityHttpHeader;
     private boolean requireTransportSecurity;
     private Boolean requireBasicAuth;
+    private Boolean forwardBasicAuthDownstream;
 
     private StaticIdentitySource staticIdentity;
     private LDAPIdentitySource ldapIdentity;
@@ -140,4 +141,17 @@ public class BasicAuthenticationConfig {
         this.requireBasicAuth = requireBasicAuth;
     }
 
+    /**
+     * @return the forwardBasicAuthDownstream
+     */
+    public Boolean isForwardBasicAuthDownstream() {
+        return forwardBasicAuthDownstream;
+    }
+
+    /**
+     * @param forwardBasicAuthDownstream the forwardBasicAuthDownstream to set
+     */
+    public void setForwardBasicAuthDownstream(Boolean forwardBasicAuthDownstream) {
+        this.forwardBasicAuthDownstream = forwardBasicAuthDownstream;
+    }
 }

--- a/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/BasicAuthenticationConfigTest.java
+++ b/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/BasicAuthenticationConfigTest.java
@@ -53,6 +53,45 @@ public class BasicAuthenticationConfigTest {
         Assert.assertEquals("X-Authenticated-Identity", parsedConfig.getForwardIdentityHttpHeader());
         Assert.assertEquals(Boolean.TRUE, parsedConfig.isRequireTransportSecurity());
         Assert.assertEquals(Boolean.TRUE, parsedConfig.getRequireBasicAuth());
+        Assert.assertNull(parsedConfig.isForwardBasicAuthDownstream());
+
+        //Basic properties with forwardBasicAuthDownstream true
+        config =
+                "{\r\n" +
+                        "    \"realm\" : \"TestRealm\",\r\n" +
+                        "    \"forwardIdentityHttpHeader\" : \"X-Authenticated-Identity\",\r\n" +
+                        "    \"requireTransportSecurity\" : true,\r\n" +
+                        "    \"requireBasicAuth\" : true,\r\n" +
+                        "    \"forwardBasicAuthDownstream\" : true\r\n" +
+                        "}";
+        parsed = policy.parseConfiguration(config);
+        Assert.assertNotNull(parsed);
+        Assert.assertEquals(BasicAuthenticationConfig.class, parsed.getClass());
+        parsedConfig = (BasicAuthenticationConfig) parsed;
+        Assert.assertEquals("TestRealm", parsedConfig.getRealm());
+        Assert.assertEquals("X-Authenticated-Identity", parsedConfig.getForwardIdentityHttpHeader());
+        Assert.assertEquals(Boolean.TRUE, parsedConfig.isRequireTransportSecurity());
+        Assert.assertEquals(Boolean.TRUE, parsedConfig.getRequireBasicAuth());
+        Assert.assertEquals(Boolean.TRUE, parsedConfig.isForwardBasicAuthDownstream());
+
+        //Basic properties with forwardBasicAuthDownstream false
+        config =
+                "{\r\n" +
+                        "    \"realm\" : \"TestRealm\",\r\n" +
+                        "    \"forwardIdentityHttpHeader\" : \"X-Authenticated-Identity\",\r\n" +
+                        "    \"requireTransportSecurity\" : true,\r\n" +
+                        "    \"requireBasicAuth\" : true,\r\n" +
+                        "    \"forwardBasicAuthDownstream\" : false\r\n" +
+                        "}";
+        parsed = policy.parseConfiguration(config);
+        Assert.assertNotNull(parsed);
+        Assert.assertEquals(BasicAuthenticationConfig.class, parsed.getClass());
+        parsedConfig = (BasicAuthenticationConfig) parsed;
+        Assert.assertEquals("TestRealm", parsedConfig.getRealm());
+        Assert.assertEquals("X-Authenticated-Identity", parsedConfig.getForwardIdentityHttpHeader());
+        Assert.assertEquals(Boolean.TRUE, parsedConfig.isRequireTransportSecurity());
+        Assert.assertEquals(Boolean.TRUE, parsedConfig.getRequireBasicAuth());
+        Assert.assertEquals(Boolean.FALSE, parsedConfig.isForwardBasicAuthDownstream());
 
         // Static identities
         config =

--- a/gateway/test/src/test/resources/test-plan-data/policies/basic-auth-static/002-register-client.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/basic-auth-static/002-register-client.resttest
@@ -14,7 +14,7 @@ Content-Type: application/json
       "policies" : [
         {
           "policyImpl" : "class:io.apiman.gateway.engine.policies.BasicAuthenticationPolicy",
-          "policyJsonConfig" : "{ \"realm\" : \"Test\", \"forwardIdentityHttpHeader\" : \"X-Authenticated-Identity\", \"staticIdentity\" : { \"identities\" : [ { \"username\" : \"bwayne\", \"password\" : \"bwayne\" } ] }  }"
+          "policyJsonConfig" : "{ \"realm\" : \"Test\", \"forwardIdentityHttpHeader\" : \"X-Authenticated-Identity\", \"staticIdentity\" : { \"identities\" : [ { \"username\" : \"bwayne\", \"password\" : \"bwayne\" } ] }, \"forwardBasicAuthDownstream\" : true  }"
         }
       ]
     }

--- a/gateway/test/src/test/resources/test-plan-data/policies/basic-auth-static/008-forward-basic-auth-downstream.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/basic-auth-static/008-forward-basic-auth-downstream.resttest
@@ -1,0 +1,16 @@
+GET /Policy_BasicAuthStatic/echo/1.0.0/path/to/app/resource bwayne/bwayne
+X-API-Key: 12345
+
+----
+200
+Content-Type: application/json
+
+{
+  "method" : "GET",
+  "resource" : "/path/to/app/resource",
+  "uri" : "/path/to/app/resource",
+  "headers" : {
+    "X-Authenticated-Identity" : "bwayne",
+    "Authorization" : "Basic YndheW5lOmJ3YXluZQ=="
+  }
+}

--- a/gateway/test/src/test/resources/test-plans/policies/basic-auth-testPlan.xml
+++ b/gateway/test/src/test/resources/test-plans/policies/basic-auth-testPlan.xml
@@ -9,6 +9,7 @@
     <test name="Failure (no creds)">test-plan-data/policies/basic-auth-static/005-failure.resttest</test>
     <test name="Register Client 2 (require-basic)" endpoint="api">test-plan-data/policies/basic-auth-static/006-register-client-2.resttest</test>
     <test name="Success (no creds)">test-plan-data/policies/basic-auth-static/007-success.resttest</test>
+    <test name="Forward Basic Auth header">test-plan-data/policies/basic-auth-static/008-forward-basic-auth-downstream.resttest</test>
   </testGroup>
 
 </testPlan>


### PR DESCRIPTION
The basic-authentication-policy discards the `Authorization` header before passing the request downstream causing the target system to fail authenticating the request

This change is meant to allow the used to specify whether it needs to pass the `Authorization` header downstream to the tagert system by configuring `"forwardBasicAuthDownstream": true` property on the policy. If the property values is `false` or is not set at all the policy will strip down the `Authorization` header in order to maintain the backward compatibility