### PR TITLE
Allow override of Keycloak Realm & URL via environment

### DIFF
--- a/distro/eap7/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
+++ b/distro/eap7/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
@@ -430,8 +430,8 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:keycloak:1.1">
           <secure-deployment name="apiman.war">
-            <realm>${env.REALM:apiman}</realm>
-            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
+            <realm>${env.APIMAN_AUTH_REALM:apiman}</realm>
+            <auth-server-url>${env.APIMAN_AUTH_URL:/auth}</auth-server-url>
             <resource>apiman</resource>
             <credential name="secret">5af5458f-0a96-4251-8f92-08ebcc3a8aa2</credential>
             <disable-trust-manager>true</disable-trust-manager>
@@ -440,8 +440,8 @@
             <principal-attribute>preferred_username</principal-attribute>
           </secure-deployment>
           <secure-deployment name="apimanui.war">
-            <realm>${env.REALM:apiman}</realm>
-            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
+            <realm>${env.APIMAN_AUTH_REALM:apiman}</realm>
+            <auth-server-url>${env.APIMAN_AUTH_URL:/auth}</auth-server-url>
             <resource>apimanui</resource>
             <credential name="secret">722557fd-a725-4cc0-9dff-7d09c0c47038</credential>
             <disable-trust-manager>true</disable-trust-manager>
@@ -449,8 +449,8 @@
             <principal-attribute>preferred_username</principal-attribute>
           </secure-deployment>
           <secure-deployment name="apiman-gateway-api.war">
-            <realm>${env.REALM:apiman}</realm>
-            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
+            <realm>${env.APIMAN_AUTH_REALM:apiman}</realm>
+            <auth-server-url>${env.APIMAN_AUTH_URL:/auth}</auth-server-url>
             <resource>apiman-gateway-api</resource>
             <credential name="secret">217b725d-7790-47a7-a3fc-5cf31f92a8db</credential>
             <disable-trust-manager>true</disable-trust-manager>

--- a/distro/eap7/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
+++ b/distro/eap7/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
@@ -168,7 +168,7 @@
             <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000" runtime-failure-causes-rollback="${jboss.deployment.scanner.rollback.on.failure:false}"/>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:ee:4.0">
-            <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
+            <spec-descriptor-property-replacement>true</spec-descriptor-property-replacement>
             <concurrent>
                 <context-services>
                     <context-service name="default" jndi-name="java:jboss/ee/concurrency/context/default" use-transaction-setup-provider="true"/>
@@ -429,35 +429,34 @@
           <web-context>auth</web-context>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:keycloak:1.1">
-          <realm name="apiman">
-            <realm-public-key>MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxyG61ohrfJQKNmDA/ePZtqZVpPXjwn3k3T+iWiTvMsxW2+WlnqIEmL5qZ09DMhBH9r50WZRO2gVoCb657Er9x0vfD6GNf/47XU2y33TX8axhP+hSwkv/VViaDlu4jQrfgPWz/FXMjWIZxg1xQS+nOBF2ScCRYWNQ/ZnUNnvrq8dGC2/AlyeYcgDUOdwlJuvgkGlF0QoVPQiRPurR3RwlG+BjL8JB3hbaAZhdJqwqApmGQbcpgLj2tODnlrZnEAp5cPPU/lgqCE1OOp78BAEiE91ZLPl/+D8qDHk+Maz0Io3bkeRZMXPpvtbL3qN+3GlF8Yz264HDSsTNrH+nd19tFQIDAQAB</realm-public-key>
-            <auth-server-url>/auth</auth-server-url>
-            <ssl-required>none</ssl-required>
-            <enable-cors>false</enable-cors>
-            <principal-attribute>preferred_username</principal-attribute>
-          </realm>
           <secure-deployment name="apiman.war">
-            <realm>apiman</realm>
+            <realm>${env.REALM:apiman}</realm>
+            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
             <resource>apiman</resource>
             <credential name="secret">5af5458f-0a96-4251-8f92-08ebcc3a8aa2</credential>
             <disable-trust-manager>true</disable-trust-manager>
             <bearer-only>true</bearer-only>
             <enable-basic-auth>true</enable-basic-auth>
+            <principal-attribute>preferred_username</principal-attribute>
           </secure-deployment>
           <secure-deployment name="apimanui.war">
-            <realm>apiman</realm>
+            <realm>${env.REALM:apiman}</realm>
+            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
             <resource>apimanui</resource>
             <credential name="secret">722557fd-a725-4cc0-9dff-7d09c0c47038</credential>
             <disable-trust-manager>true</disable-trust-manager>
             <public-client>true</public-client>
+            <principal-attribute>preferred_username</principal-attribute>
           </secure-deployment>
           <secure-deployment name="apiman-gateway-api.war">
-            <realm>apiman</realm>
+            <realm>${env.REALM:apiman}</realm>
+            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
             <resource>apiman-gateway-api</resource>
             <credential name="secret">217b725d-7790-47a7-a3fc-5cf31f92a8db</credential>
             <disable-trust-manager>true</disable-trust-manager>
             <bearer-only>true</bearer-only>
             <enable-basic-auth>true</enable-basic-auth>
+            <principal-attribute>preferred_username</principal-attribute>
           </secure-deployment>
         </subsystem>
     </profile>

--- a/distro/wildfly10/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
+++ b/distro/wildfly10/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
@@ -168,7 +168,7 @@
             <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000" runtime-failure-causes-rollback="${jboss.deployment.scanner.rollback.on.failure:false}"/>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:ee:4.0">
-            <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
+            <spec-descriptor-property-replacement>true</spec-descriptor-property-replacement>
             <concurrent>
                 <context-services>
                     <context-service name="default" jndi-name="java:jboss/ee/concurrency/context/default" use-transaction-setup-provider="true"/>
@@ -515,35 +515,34 @@
             </spi>
         </subsystem> <!-- foo -->
         <subsystem xmlns="urn:jboss:domain:keycloak:1.1">
-          <realm name="apiman">
-            <realm-public-key>MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxyG61ohrfJQKNmDA/ePZtqZVpPXjwn3k3T+iWiTvMsxW2+WlnqIEmL5qZ09DMhBH9r50WZRO2gVoCb657Er9x0vfD6GNf/47XU2y33TX8axhP+hSwkv/VViaDlu4jQrfgPWz/FXMjWIZxg1xQS+nOBF2ScCRYWNQ/ZnUNnvrq8dGC2/AlyeYcgDUOdwlJuvgkGlF0QoVPQiRPurR3RwlG+BjL8JB3hbaAZhdJqwqApmGQbcpgLj2tODnlrZnEAp5cPPU/lgqCE1OOp78BAEiE91ZLPl/+D8qDHk+Maz0Io3bkeRZMXPpvtbL3qN+3GlF8Yz264HDSsTNrH+nd19tFQIDAQAB</realm-public-key>
-            <auth-server-url>/auth</auth-server-url>
-            <ssl-required>none</ssl-required>
-            <enable-cors>false</enable-cors>
-            <principal-attribute>preferred_username</principal-attribute>
-          </realm>
           <secure-deployment name="apiman.war">
-            <realm>apiman</realm>
+            <realm>${env.REALM:apiman}</realm>
+            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
             <resource>apiman</resource>
             <credential name="secret">5af5458f-0a96-4251-8f92-08ebcc3a8aa2</credential>
             <disable-trust-manager>true</disable-trust-manager>
             <bearer-only>true</bearer-only>
             <enable-basic-auth>true</enable-basic-auth>
+            <principal-attribute>preferred_username</principal-attribute>
           </secure-deployment>
           <secure-deployment name="apimanui.war">
-            <realm>apiman</realm>
+            <realm>${env.REALM:apiman}</realm>
+            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
             <resource>apimanui</resource>
             <credential name="secret">722557fd-a725-4cc0-9dff-7d09c0c47038</credential>
             <disable-trust-manager>true</disable-trust-manager>
             <public-client>true</public-client>
+            <principal-attribute>preferred_username</principal-attribute>
           </secure-deployment>
           <secure-deployment name="apiman-gateway-api.war">
-            <realm>apiman</realm>
+            <realm>${env.REALM:apiman}</realm>
+            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
             <resource>apiman-gateway-api</resource>
             <credential name="secret">217b725d-7790-47a7-a3fc-5cf31f92a8db</credential>
             <disable-trust-manager>true</disable-trust-manager>
             <bearer-only>true</bearer-only>
             <enable-basic-auth>true</enable-basic-auth>
+            <principal-attribute>preferred_username</principal-attribute>
           </secure-deployment>
         </subsystem>
     </profile>

--- a/distro/wildfly10/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
+++ b/distro/wildfly10/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
@@ -516,8 +516,8 @@
         </subsystem> <!-- foo -->
         <subsystem xmlns="urn:jboss:domain:keycloak:1.1">
           <secure-deployment name="apiman.war">
-            <realm>${env.REALM:apiman}</realm>
-            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
+            <realm>${env.APIMAN_AUTH_REALM:apiman}</realm>
+            <auth-server-url>${env.APIMAN_AUTH_URL:/auth}</auth-server-url>
             <resource>apiman</resource>
             <credential name="secret">5af5458f-0a96-4251-8f92-08ebcc3a8aa2</credential>
             <disable-trust-manager>true</disable-trust-manager>
@@ -526,8 +526,8 @@
             <principal-attribute>preferred_username</principal-attribute>
           </secure-deployment>
           <secure-deployment name="apimanui.war">
-            <realm>${env.REALM:apiman}</realm>
-            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
+            <realm>${env.APIMAN_AUTH_REALM:apiman}</realm>
+            <auth-server-url>${env.APIMAN_AUTH_URL:/auth}</auth-server-url>
             <resource>apimanui</resource>
             <credential name="secret">722557fd-a725-4cc0-9dff-7d09c0c47038</credential>
             <disable-trust-manager>true</disable-trust-manager>
@@ -535,8 +535,8 @@
             <principal-attribute>preferred_username</principal-attribute>
           </secure-deployment>
           <secure-deployment name="apiman-gateway-api.war">
-            <realm>${env.REALM:apiman}</realm>
-            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
+            <realm>${env.APIMAN_AUTH_REALM:apiman}</realm>
+            <auth-server-url>${env.APIMAN_AUTH_URL:/auth}</auth-server-url>
             <resource>apiman-gateway-api</resource>
             <credential name="secret">217b725d-7790-47a7-a3fc-5cf31f92a8db</credential>
             <disable-trust-manager>true</disable-trust-manager>

--- a/distro/wildfly11/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
+++ b/distro/wildfly11/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
@@ -177,7 +177,7 @@
             <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000" runtime-failure-causes-rollback="${jboss.deployment.scanner.rollback.on.failure:false}"/>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:ee:4.0">
-            <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
+            <spec-descriptor-property-replacement>true</spec-descriptor-property-replacement>
             <concurrent>
                 <context-services>
                     <context-service name="default" jndi-name="java:jboss/ee/concurrency/context/default" use-transaction-setup-provider="true"/>
@@ -623,35 +623,34 @@
         </subsystem>
         <!-- Apiman's Keycloak client adapter configuration. -->
         <subsystem xmlns="urn:jboss:domain:keycloak:1.1">
-          <realm name="apiman">
-            <realm-public-key>MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxyG61ohrfJQKNmDA/ePZtqZVpPXjwn3k3T+iWiTvMsxW2+WlnqIEmL5qZ09DMhBH9r50WZRO2gVoCb657Er9x0vfD6GNf/47XU2y33TX8axhP+hSwkv/VViaDlu4jQrfgPWz/FXMjWIZxg1xQS+nOBF2ScCRYWNQ/ZnUNnvrq8dGC2/AlyeYcgDUOdwlJuvgkGlF0QoVPQiRPurR3RwlG+BjL8JB3hbaAZhdJqwqApmGQbcpgLj2tODnlrZnEAp5cPPU/lgqCE1OOp78BAEiE91ZLPl/+D8qDHk+Maz0Io3bkeRZMXPpvtbL3qN+3GlF8Yz264HDSsTNrH+nd19tFQIDAQAB</realm-public-key>
-            <auth-server-url>/auth</auth-server-url>
-            <ssl-required>none</ssl-required>
-            <enable-cors>false</enable-cors>
-            <principal-attribute>preferred_username</principal-attribute>
-          </realm>
           <secure-deployment name="apiman.war">
-            <realm>apiman</realm>
+            <realm>${env.REALM:apiman}</realm>
+            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
             <resource>apiman</resource>
             <credential name="secret">5af5458f-0a96-4251-8f92-08ebcc3a8aa2</credential>
             <disable-trust-manager>true</disable-trust-manager>
             <bearer-only>true</bearer-only>
             <enable-basic-auth>true</enable-basic-auth>
+            <principal-attribute>preferred_username</principal-attribute>
           </secure-deployment>
           <secure-deployment name="apimanui.war">
-            <realm>apiman</realm>
+            <realm>${env.REALM:apiman}</realm>
+            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
             <resource>apimanui</resource>
             <credential name="secret">722557fd-a725-4cc0-9dff-7d09c0c47038</credential>
             <disable-trust-manager>true</disable-trust-manager>
             <public-client>true</public-client>
+            <principal-attribute>preferred_username</principal-attribute>
           </secure-deployment>
           <secure-deployment name="apiman-gateway-api.war">
-            <realm>apiman</realm>
+            <realm>${env.REALM:apiman}</realm>
+            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
             <resource>apiman-gateway-api</resource>
             <credential name="secret">217b725d-7790-47a7-a3fc-5cf31f92a8db</credential>
             <disable-trust-manager>true</disable-trust-manager>
             <bearer-only>true</bearer-only>
             <enable-basic-auth>true</enable-basic-auth>
+            <principal-attribute>preferred_username</principal-attribute>
           </secure-deployment>
         </subsystem>
     </profile>

--- a/distro/wildfly11/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
+++ b/distro/wildfly11/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
@@ -624,8 +624,8 @@
         <!-- Apiman's Keycloak client adapter configuration. -->
         <subsystem xmlns="urn:jboss:domain:keycloak:1.1">
           <secure-deployment name="apiman.war">
-            <realm>${env.REALM:apiman}</realm>
-            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
+            <realm>${env.APIMAN_AUTH_REALM:apiman}</realm>
+            <auth-server-url>${env.APIMAN_AUTH_URL:/auth}</auth-server-url>
             <resource>apiman</resource>
             <credential name="secret">5af5458f-0a96-4251-8f92-08ebcc3a8aa2</credential>
             <disable-trust-manager>true</disable-trust-manager>
@@ -634,8 +634,8 @@
             <principal-attribute>preferred_username</principal-attribute>
           </secure-deployment>
           <secure-deployment name="apimanui.war">
-            <realm>${env.REALM:apiman}</realm>
-            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
+            <realm>${env.APIMAN_AUTH_REALM:apiman}</realm>
+            <auth-server-url>${env.APIMAN_AUTH_URL:/auth}</auth-server-url>
             <resource>apimanui</resource>
             <credential name="secret">722557fd-a725-4cc0-9dff-7d09c0c47038</credential>
             <disable-trust-manager>true</disable-trust-manager>
@@ -643,8 +643,8 @@
             <principal-attribute>preferred_username</principal-attribute>
           </secure-deployment>
           <secure-deployment name="apiman-gateway-api.war">
-            <realm>${env.REALM:apiman}</realm>
-            <auth-server-url>${env.SSO_URL:/auth}</auth-server-url>
+            <realm>${env.APIMAN_AUTH_REALM:apiman}</realm>
+            <auth-server-url>${env.APIMAN_AUTH_URL:/auth}</auth-server-url>
             <resource>apiman-gateway-api</resource>
             <credential name="secret">217b725d-7790-47a7-a3fc-5cf31f92a8db</credential>
             <disable-trust-manager>true</disable-trust-manager>

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/rates/RateLimiterBucket.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/rates/RateLimiterBucket.java
@@ -67,7 +67,7 @@ public class RateLimiterBucket implements Serializable {
      * Gets the period boundary for the period bounding the last
      * request.
      * @param period
-    ZZZZ*/
+     */
     private long getLastPeriodBoundary(RateBucketPeriod period) {
         return getPeriodBoundary(getLast(), period);
     }

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/rates/RateLimiterBucket.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/rates/RateLimiterBucket.java
@@ -67,7 +67,7 @@ public class RateLimiterBucket implements Serializable {
      * Gets the period boundary for the period bounding the last
      * request.
      * @param period
-     */
+    ZZZZ*/
     private long getLastPeriodBoundary(RateBucketPeriod period) {
         return getPeriodBoundary(getLast(), period);
     }

--- a/gateway/platforms/war/tomcat8/api/src/main/webapp/WEB-INF/web.xml
+++ b/gateway/platforms/war/tomcat8/api/src/main/webapp/WEB-INF/web.xml
@@ -95,7 +95,7 @@
   </security-constraint>
   <login-config>
     <auth-method>BASIC</auth-method>
-    <realm-name>apiman</realm-name>
+    <realm-name>${env.REALM:apiman}</realm-name>
   </login-config>
   <security-role>
     <role-name>apipublisher</role-name>

--- a/gateway/platforms/war/tomcat8/api/src/main/webapp/WEB-INF/web.xml
+++ b/gateway/platforms/war/tomcat8/api/src/main/webapp/WEB-INF/web.xml
@@ -95,7 +95,7 @@
   </security-constraint>
   <login-config>
     <auth-method>BASIC</auth-method>
-    <realm-name>${env.REALM:apiman}</realm-name>
+    <realm-name>${env.APIMAN_AUTH_REALM:apiman}</realm-name>
   </login-config>
   <security-role>
     <role-name>apipublisher</role-name>

--- a/gateway/platforms/war/wildfly8/api/src/main/webapp/WEB-INF/web.xml
+++ b/gateway/platforms/war/wildfly8/api/src/main/webapp/WEB-INF/web.xml
@@ -56,7 +56,7 @@
   </security-constraint>
   <login-config>
     <auth-method>BASIC</auth-method>
-    <realm-name>${env.REALM:apiman}</realm-name>
+    <realm-name>${env.APIMAN_AUTH_REALM:apiman}</realm-name>
   </login-config>
   <security-role>
     <role-name>apipublisher</role-name>

--- a/gateway/platforms/war/wildfly8/api/src/main/webapp/WEB-INF/web.xml
+++ b/gateway/platforms/war/wildfly8/api/src/main/webapp/WEB-INF/web.xml
@@ -56,7 +56,7 @@
   </security-constraint>
   <login-config>
     <auth-method>BASIC</auth-method>
-    <realm-name>apiman</realm-name>
+    <realm-name>${env.REALM:apiman}</realm-name>
   </login-config>
   <security-role>
     <role-name>apipublisher</role-name>

--- a/manager/api/war/tomcat8/src/main/webapp/WEB-INF/web.xml
+++ b/manager/api/war/tomcat8/src/main/webapp/WEB-INF/web.xml
@@ -102,7 +102,7 @@
 
   <login-config>
     <auth-method>BASIC</auth-method>
-    <realm-name>apiman</realm-name>
+    <realm-name>${env.REALM:apiman}</realm-name>
   </login-config>
   <security-role>
     <role-name>apiuser</role-name>

--- a/manager/api/war/tomcat8/src/main/webapp/WEB-INF/web.xml
+++ b/manager/api/war/tomcat8/src/main/webapp/WEB-INF/web.xml
@@ -102,7 +102,7 @@
 
   <login-config>
     <auth-method>BASIC</auth-method>
-    <realm-name>${env.REALM:apiman}</realm-name>
+    <realm-name>${env.APIMAN_AUTH_REALM:apiman}</realm-name>
   </login-config>
   <security-role>
     <role-name>apiuser</role-name>

--- a/manager/api/war/wildfly8/src/main/webapp/WEB-INF/web.xml
+++ b/manager/api/war/wildfly8/src/main/webapp/WEB-INF/web.xml
@@ -176,7 +176,7 @@
   </security-constraint>
   <login-config>
     <auth-method>BASIC</auth-method>
-    <realm-name>apiman</realm-name>
+    <realm-name>${env.REALM:apiman}</realm-name>
   </login-config>
   <security-role>
     <role-name>apiuser</role-name>

--- a/manager/api/war/wildfly8/src/main/webapp/WEB-INF/web.xml
+++ b/manager/api/war/wildfly8/src/main/webapp/WEB-INF/web.xml
@@ -176,7 +176,7 @@
   </security-constraint>
   <login-config>
     <auth-method>BASIC</auth-method>
-    <realm-name>${env.REALM:apiman}</realm-name>
+    <realm-name>${env.APIMAN_AUTH_REALM:apiman}</realm-name>
   </login-config>
   <security-role>
     <role-name>apiuser</role-name>

--- a/manager/test/api/src/test/java/io/apiman/manager/test/es/ESMetricsAccessorTest.java
+++ b/manager/test/api/src/test/java/io/apiman/manager/test/es/ESMetricsAccessorTest.java
@@ -47,6 +47,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
 import org.joda.time.DateTime;
@@ -85,6 +86,7 @@ public class ESMetricsAccessorTest {
             .withElasticVersion(ApimanEmbeddedElastic.getEsBuildVersion())
             .withDownloadDirectory(esDownloadCache)
             .withSetting(PopularProperties.CLUSTER_NAME, "apiman")
+            .withStartTimeout(1, TimeUnit.MINUTES)
             .withCleanInstallationDirectoryOnStop(true)
             .build()
             .start();

--- a/manager/ui/war/wildfly8/src/main/webapp/WEB-INF/web.xml
+++ b/manager/ui/war/wildfly8/src/main/webapp/WEB-INF/web.xml
@@ -86,7 +86,7 @@
   </security-constraint>
   <login-config>
     <auth-method>BASIC</auth-method>
-    <realm-name>apiman</realm-name>
+    <realm-name>${env.REALM:apiman}</realm-name>
   </login-config>
   <security-role>
     <role-name>apiuser</role-name>

--- a/manager/ui/war/wildfly8/src/main/webapp/WEB-INF/web.xml
+++ b/manager/ui/war/wildfly8/src/main/webapp/WEB-INF/web.xml
@@ -86,7 +86,7 @@
   </security-constraint>
   <login-config>
     <auth-method>BASIC</auth-method>
-    <realm-name>${env.REALM:apiman}</realm-name>
+    <realm-name>${env.APIMAN_AUTH_REALM:apiman}</realm-name>
   </login-config>
   <security-role>
     <role-name>apiuser</role-name>


### PR DESCRIPTION
I need to be able to easily use a different realm and URL when the Keycloak server is external. This allows the use of environment variables, making them easily overridden for a docker container, while leaving the current defaults. Also fix test that did not wait for Elasticsearch to start.