### PR TITLE
Only safe integers for rate limiting policy

### DIFF
--- a/manager/ui/war/plugins/api-manager/ts/policies.ts
+++ b/manager/ui/war/plugins/api-manager/ts/policies.ts
@@ -140,6 +140,10 @@ module Apiman {
                     valid = false;
                 }
 
+                if (!Number.isSafeInteger(config.limit)){
+                    config.limit = Number.MAX_SAFE_INTEGER;
+                }
+
                 if (!config.granularity) {
                     valid = false;
                 }


### PR DESCRIPTION
A customer asked us if there is a maximum value for the rate-limiting policy.
The limit is of type long in the java code but this can't be easily represented in javascript.
So we decided to check for `Numbers.isSafeInteger`.

Via the UI following applies:
The value is restricted through Javascript.
The maximum value you can set via the **UI is 9007199254740991** (2<sup>53</sup> - 1).

Via the REST API following applies:
The value is restricted through Java.
The maximum value you can set via the **REST API is 9223372036854775807**(2<sup>63</sup> - 1).

So let us know what you think about this little improvement :)