### PR TITLE
Soap12 endpoint replacement

### DIFF
--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/OrganizationResourceImpl.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/OrganizationResourceImpl.java
@@ -1836,7 +1836,7 @@ public class OrganizationResourceImpl implements IOrganizationResource {
             } else if (apiVersion.getDefinitionType() == ApiDefinitionType.SwaggerYAML) {
                 builder.type("application/x-yaml"); //$NON-NLS-1$
             } else if (apiVersion.getDefinitionType() == ApiDefinitionType.WSDL) {
-                builder.type("application/wsdl+xml"); //$NON-NLS-1$
+                builder.type("text/xml"); //$NON-NLS-1$
             } else {
                 IOUtils.closeQuietly(definition);
                 throw new Exception("API definition type not supported: " + apiVersion.getDefinitionType()); //$NON-NLS-1$

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/util/SwaggerWsdlHelper.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/util/SwaggerWsdlHelper.java
@@ -150,13 +150,9 @@ public final class SwaggerWsdlHelper {
      */
     public static String updateLocationEndpointInWsdl(InputStream wsdlStream, URL managedEndpoint, ApiVersionBean apiVersion, IStorage storage) throws StorageException {
         Document document = readWsdlInputStream(wsdlStream);
-
         Boolean updateStorage = false;
-
         for(int i = 0; i < SOAP_ADDRESS.length;i++) {
-
             NodeList nodeList = document.getDocumentElement().getElementsByTagName(SOAP_ADDRESS[i]);
-
             if (nodeList != null) {
                 for (int j = 0; j < nodeList.getLength(); j++) {
                     Node node = nodeList.item(j);
@@ -169,12 +165,10 @@ public final class SwaggerWsdlHelper {
                 }
             }
         }
-
         String wsdl = xmlDocumentToString(document);
-
-        if (updateStorage)
+        if (updateStorage) {
             storage.updateApiDefinition(apiVersion, new ByteArrayInputStream(wsdl.getBytes(StandardCharsets.UTF_8)));
-
+        }
         return wsdl;
     }
 

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/util/SwaggerWsdlHelper.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/util/SwaggerWsdlHelper.java
@@ -30,7 +30,7 @@ public final class SwaggerWsdlHelper {
     private static final String BASE_PATH = "basePath";
     private static final String HOST = "host";
     private static final String LOCATION = "location";
-    private static final String SOAP_ADDRESS = "soap:address";
+    private static final String SOAP_ADDRESS[] = {"soap:address","soap12:address"};
     private static final String SWAGGER = "swagger";
 
     /**
@@ -150,20 +150,28 @@ public final class SwaggerWsdlHelper {
      */
     public static String updateLocationEndpointInWsdl(InputStream wsdlStream, URL managedEndpoint, ApiVersionBean apiVersion, IStorage storage) throws StorageException {
         Document document = readWsdlInputStream(wsdlStream);
-        NodeList nodeList = document.getDocumentElement().getElementsByTagName(SOAP_ADDRESS);
 
         Boolean updateStorage = false;
-        for (int i = 0; i < nodeList.getLength(); i++) {
-            Node node = nodeList.item(i);
-            String location = node.getAttributes().getNamedItem(LOCATION).getNodeValue();
-            String endpoint = managedEndpoint.toString();
-            if (!location.equals(endpoint)) {
-                node.getAttributes().getNamedItem(LOCATION).setNodeValue(managedEndpoint.toString());
-                updateStorage = true;
+
+        for(int i = 0; i < SOAP_ADDRESS.length;i++) {
+
+            NodeList nodeList = document.getDocumentElement().getElementsByTagName(SOAP_ADDRESS[i]);
+
+            if (nodeList != null) {
+                for (int j = 0; j < nodeList.getLength(); j++) {
+                    Node node = nodeList.item(j);
+                    String location = node.getAttributes().getNamedItem(LOCATION).getNodeValue();
+                    String endpoint = managedEndpoint.toString();
+                    if (!location.equals(endpoint)) {
+                        node.getAttributes().getNamedItem(LOCATION).setNodeValue(managedEndpoint.toString());
+                        updateStorage = true;
+                    }
+                }
             }
         }
 
         String wsdl = xmlDocumentToString(document);
+
         if (updateStorage)
             storage.updateApiDefinition(apiVersion, new ByteArrayInputStream(wsdl.getBytes(StandardCharsets.UTF_8)));
 

--- a/tools/server-all/pom.xml
+++ b/tools/server-all/pom.xml
@@ -242,11 +242,11 @@
                     <echo>Ant Version: ${antversion}</echo>
                     <property name="appserver.id" value="tomcat8" />
                     <property name="apiman.tomcat.download.url"
-                      value="http://apache.cs.utah.edu/tomcat/tomcat-8/v8.5.51/bin/apache-tomcat-8.5.51.zip" />
+                      value="https://apache.cs.utah.edu/tomcat/tomcat-8/v8.5.53/bin/apache-tomcat-8.5.53.zip" />
                     <property name="apiman.tempdir" value="${project.build.directory}/_tmp" />
                     <property name="apiman.install.dir" value="${project.build.directory}" />
-                    <property name="apiman.appserver.dir" location="${apiman.install.dir}/apache-tomcat-8.5.51" />
-                    <property name="apiman.appserver.zip" location="${basedir}/apache-tomcat-8.5.51.zip" />
+                    <property name="apiman.appserver.dir" location="${apiman.install.dir}/apache-tomcat-8.5.53" />
+                    <property name="apiman.appserver.zip" location="${basedir}/apache-tomcat-8.5.53.zip" />
                     <property name="apiman.apiman-distro-tomcat8.zip" value="${maven.dependency.io.apiman.apiman-distro-tomcat8.overlay.zip.path}" />
                     <property name="apiman.apiman-tools-services.war" value="${maven.dependency.io.apiman.apiman-tools-services.war.path}" />
                     <property name="apiman.tomcat.home" location="${apiman.appserver.dir}" />
@@ -269,7 +269,7 @@
                     <unzip src="${apiman.appserver.zip}" dest="${apiman.install.dir}" overwrite="false" />
 
                     <!-- Overlay APIMan on top of Tomcat 8 -->
-                    <unzip src="${apiman.apiman-distro-tomcat8.zip}" dest="${apiman.install.dir}/apache-tomcat-8.5.51" overwrite="true" />
+                    <unzip src="${apiman.apiman-distro-tomcat8.zip}" dest="${apiman.install.dir}/apache-tomcat-8.5.53" overwrite="true" />
 
                     <!-- Make sure to chmod 755 the shell scripts -->
                     <chmod perm="a+x" dir="${apiman.appserver.dir}/bin">


### PR DESCRIPTION
When i downloading wsdl definitions i realized that only one endpoint was replaced (soap:address) by gateway endpoint, but in some SOAP web services (all of Microsoft .net), wsdl returns 2 endpoints one for soap 1.0 and other for soap 1.2.

Example:
`  <wsdl:service name="Service">
    <wsdl:port binding="tns:ServiceSoap" name="ServiceSoap">
      <soap:address location="https://localhost:8443/apiman-gateway/TEST/TEST2/1.0"/>
    </wsdl:port>
    <wsdl:port binding="tns:ServiceSoap12" name="ServiceSoap12">
      <soap12:address location="http://<mylocalserver>/my-service.asmx"/>
    </wsdl:port>
  </wsdl:service>
`

I added some changes on SwaggerWsdlHelper and the definition was show correct.

`  <wsdl:service name="Service">
    <wsdl:port binding="tns:ServiceSoap" name="ServiceSoap">
      <soap:address location="https://localhost:8443/apiman-gateway/TEST/TEST2/1.0"/>
    </wsdl:port>
    <wsdl:port binding="tns:ServiceSoap12" name="ServiceSoap12">
      <soap12:address location="https://localhost:8443/apiman-gateway/TEST/TEST2/1.0"/>
    </wsdl:port>
  </wsdl:service>`




      