### PR TITLE
Improve gateway logging and hide sensitive data

### DIFF
--- a/distro/vertx/src/main/resources/overlay/log4j2.xml
+++ b/distro/vertx/src/main/resources/overlay/log4j2.xml
@@ -24,7 +24,7 @@ See more detail at: https://logging.apache.org/log4j/2.x/manual/async.html
   </Appenders>
   <Loggers>
     <!-- apiman package only logging -->
-    <AsyncLogger level="info" name="io.apiman" additivity="false">
+    <AsyncLogger level="${sys:apiman.gateway-logLevel:-info}" name="io.apiman" additivity="false">
       <AppenderRef ref="RandomAccessFile"/>
       <AppenderRef ref="Console-Appender"/>
     </AsyncLogger>
@@ -34,7 +34,7 @@ See more detail at: https://logging.apache.org/log4j/2.x/manual/async.html
       <AppenderRef ref="Console-Appender"/>
     </AsyncLogger> -->
     <!-- Root/Global file logging config -->
-    <AsyncRoot level="info" includeLocation="false">
+    <AsyncRoot level="${sys:apiman.gateway-logLevel:-info}" includeLocation="false">
       <AppenderRef ref="RandomAccessFile"/>
       <AppenderRef ref="Console-Appender"/>
     </AsyncRoot>

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/handler/ErrorHandler.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/handler/ErrorHandler.java
@@ -1,0 +1,43 @@
+package io.apiman.gateway.engine.handler;
+
+import io.apiman.gateway.engine.beans.exceptions.ConnectorException;
+
+import java.io.InterruptedIOException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.UnknownHostException;
+
+/**
+ * This class provides helper methods for vertx and servlet gateway implementations.
+ */
+public final class ErrorHandler {
+
+    /**
+     * Private constructor
+     */
+    private ErrorHandler() {
+    }
+
+    /**
+     * This method handles a connection error that was caused while connecting the gateway to the backend.
+     *
+     * @param error the connection error to be handled
+     * @return a new ConnectorException
+     */
+    public static ConnectorException handleConnectionError(Throwable error) {
+        ConnectorException ce = null;
+        if (error instanceof UnknownHostException || error instanceof ConnectException || error instanceof NoRouteToHostException) {
+            ce = new ConnectorException("Unable to connect to backend", error); //$NON-NLS-1$
+            ce.setStatusCode(502); // BAD GATEWAY
+        } else if (error instanceof InterruptedIOException || error instanceof java.util.concurrent.TimeoutException) {
+            ce = new ConnectorException("Connection to backend terminated" + error.getMessage(), error); //$NON-NLS-1$
+            ce.setStatusCode(504); // GATEWAY TIMEOUT
+
+        }
+        if (ce != null) {
+            return ce;
+        } else {
+            return new ConnectorException(error.getMessage(), error);
+        }
+    }
+}

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/DefaultPolicyErrorWriter.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/DefaultPolicyErrorWriter.java
@@ -15,6 +15,8 @@
  */
 package io.apiman.gateway.engine.impl;
 
+import io.apiman.common.logging.DefaultDelegateFactory;
+import io.apiman.common.logging.IApimanLogger;
 import io.apiman.gateway.engine.IApiClientResponse;
 import io.apiman.gateway.engine.IPolicyErrorWriter;
 import io.apiman.gateway.engine.beans.ApiRequest;
@@ -35,6 +37,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author eric.wittmann@redhat.com
  */
 public class DefaultPolicyErrorWriter implements IPolicyErrorWriter {
+
+    private IApimanLogger logger = new DefaultDelegateFactory().createLogger(DefaultPolicyErrorWriter.class);
 
     private static final ObjectMapper mapper = new ObjectMapper();
     private static JAXBContext jaxbContext;
@@ -63,7 +67,7 @@ public class DefaultPolicyErrorWriter implements IPolicyErrorWriter {
             isXml = true;
         }
         String message = createErrorMessage(request, error);
-        // TODO get and/or print ultimate cause?
+        logger.error(message, error);
         response.setHeader("X-Gateway-Error", message);
 
         int statusCode = 500;
@@ -82,7 +86,7 @@ public class DefaultPolicyErrorWriter implements IPolicyErrorWriter {
                 jaxbMarshaller.marshal(eer, sw);
                 response.write(sw.getBuffer());
             } catch (Exception e) {
-                e.printStackTrace();
+                logger.error(e);
             }
         } else {
             response.setHeader("Content-Type", "application/json");
@@ -91,7 +95,7 @@ public class DefaultPolicyErrorWriter implements IPolicyErrorWriter {
                 mapper.writer().writeValue(sw, eer);
                 response.write(sw.getBuffer());
             } catch (Exception e) {
-                e.printStackTrace();
+                logger.error(e);
             }
         }
     }

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/HttpConnector.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/HttpConnector.java
@@ -30,6 +30,7 @@ import io.apiman.gateway.engine.beans.ApiRequest;
 import io.apiman.gateway.engine.beans.ApiResponse;
 import io.apiman.gateway.engine.beans.exceptions.ConnectorException;
 import io.apiman.gateway.engine.beans.util.QueryMap;
+import io.apiman.gateway.engine.handler.ErrorHandler;
 import io.apiman.gateway.engine.io.IApimanBuffer;
 import io.apiman.gateway.engine.io.ISignalReadStream;
 import io.apiman.gateway.engine.io.ISignalWriteStream;
@@ -316,12 +317,8 @@ class HttpConnector implements IApiConnectionResponse, IApiConnection {
     private class ExceptionHandler implements Handler<Throwable> {
         @Override
         public void handle(Throwable error) {
-            ConnectorException ce = new ConnectorException(error.getMessage(), error);
-            if (error instanceof UnknownHostException || error instanceof ConnectException || error instanceof NoRouteToHostException) {
-                ce.setStatusCode(502); // BAD GATEWAY
-            } else if (error instanceof java.util.concurrent.TimeoutException) {
-                ce.setStatusCode(504); // GATEWAY TIMEOUT
-            }
+            ConnectorException ce = ErrorHandler.handleConnectionError(error);
+            logger.error(error.getMessage(), error);
 
             resultHandler.handle(AsyncResultImpl
                     .<IApiConnectionResponse> create(ce));


### PR DESCRIPTION
Some little gateway improvements:

- allow setting the log level of the vertx gateway via a system property `apiman.gateway-logLevel`
- log policy error (till now you saw the stacktrace only if the trace was on and the stacktrace was returned in the response)
- Log connection errors instead of send them in the response 
  - In a production environment the trace mode is normally off and the gateway should not leek internal information of the backend service like hostname, IP and ports. 
```json
{"responseCode":502,"message":"Connection refused: tp-volk.e2e.ch/10.110.120.192:10013"}
```