### PR TITLE
Rate Limiting Policy: Handle undefined

### DIFF
--- a/manager/ui/war/plugins/api-manager/ts/policies.ts
+++ b/manager/ui/war/plugins/api-manager/ts/policies.ts
@@ -140,7 +140,7 @@ module Apiman {
                     valid = false;
                 }
 
-                if (!Number.isSafeInteger(config.limit)){
+                if (valid && !Number.isSafeInteger(config.limit)){
                     config.limit = Number.MAX_SAFE_INTEGER;
                 }
 


### PR DESCRIPTION
Just a little fix for `undefined` handling, otherwise we set always the `MAX_SAVE_INTEGER` value as default if you add a new policy 