### PR TITLE
Passes through cache TTL to underlying backing store

### DIFF
--- a/gateway/engine/ispn/src/main/java/io/apiman/gateway/engine/ispn/InfinispanBackingStore.java
+++ b/gateway/engine/ispn/src/main/java/io/apiman/gateway/engine/ispn/InfinispanBackingStore.java
@@ -18,6 +18,8 @@ package io.apiman.gateway.engine.ispn;
 import io.apiman.gateway.engine.storage.store.IBackingStore;
 import org.infinispan.Cache;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Store provider for components backed by an Infinispan cache.
  */
@@ -31,6 +33,11 @@ public class InfinispanBackingStore implements IBackingStore {
     @Override
     public void put(String key, Object value) {
         cache.put(key, value);
+    }
+
+    @Override
+    public void put(String key, Object value, long ttl) {
+        cache.put(key, value, ttl, TimeUnit.SECONDS);
     }
 
     @SuppressWarnings("unchecked")

--- a/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/component/AbstractCacheStoreComponent.java
+++ b/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/component/AbstractCacheStoreComponent.java
@@ -68,7 +68,7 @@ public abstract class AbstractCacheStoreComponent extends AbstractStorageCompone
         entry.setExpiresOn(System.currentTimeMillis() + (timeToLive * 1000));
         entry.setHead(JSON_MAPPER.writeValueAsString(jsonObject));
         try {
-            getStore().put(cacheKey, entry);
+            getStore().put(cacheKey, entry, timeToLive);
         } catch (Throwable e) {
             LOGGER.error("Error writing cache entry with key: {}", cacheKey, e);
         }
@@ -110,7 +110,7 @@ public abstract class AbstractCacheStoreComponent extends AbstractStorageCompone
                 if (!aborted) {
                     entry.setData(Base64.encodeBase64String(data.getBytes()));
                     try {
-                        getStore().put(cacheKey, entry);
+                        getStore().put(cacheKey, entry, timeToLive);
                     } catch (Throwable e) {
                         LOGGER.error("Error writing binary cache entry with key: {}", cacheKey, e);
                     }

--- a/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/store/IBackingStore.java
+++ b/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/store/IBackingStore.java
@@ -25,7 +25,18 @@ public interface IBackingStore {
      * @param key   the item's key
      * @param value the item's value
      */
-    void put(String key, Object value);
+    default void put(String key, Object value) {
+        put(key, value, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Insert an item into the store, with a given TTL.
+     *
+     * @param key   the item's key
+     * @param value the item's value
+     * @param ttl   the TTL in seconds
+     */
+    void put(String key, Object value, long ttl);
 
     /**
      * Fetch an item from the store.

--- a/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/store/MapBackingStore.java
+++ b/gateway/engine/storage-common/src/main/java/io/apiman/gateway/engine/storage/store/MapBackingStore.java
@@ -19,6 +19,8 @@ import java.util.Map;
 
 /**
  * A backing store that uses a {@link Map}.
+ *
+ * Note: this implementation never evicts entries from its map, meaning that it will grow infinitely.
  */
 public class MapBackingStore implements IBackingStore {
     private final Map<String, Object> map;
@@ -28,7 +30,7 @@ public class MapBackingStore implements IBackingStore {
     }
 
     @Override
-    public void put(String key, Object value) {
+    public void put(String key, Object value, long ttl) {
         map.put(key, value);
     }
 


### PR DESCRIPTION
Passes through the cache TTL to underlying backing store.

### Rationale

Some backing stores require that the TTL be set on a per entry basis. Not setting them per entry, for some implementations, means that no TTL is set and entries persist forever 🤦 

### Implementation notes

This change flows through to the relevant implementations that support it; in particular ISPN and Redis. Note: the non-production `Map` based implementation never supported expiry, and this change doesn't affect the semantics.