### PR TITLE
Avoid url encoding resource access in LocalFileRegistry

### DIFF
--- a/gateway/engine/filesystem/src/main/java/io/apiman/gateway/engine/filesystem/LocalFileRegistry.java
+++ b/gateway/engine/filesystem/src/main/java/io/apiman/gateway/engine/filesystem/LocalFileRegistry.java
@@ -71,6 +71,8 @@ public class LocalFileRegistry extends InMemoryRegistry {
                         } catch (Exception e) {
                             throw new RuntimeException("Error reading registry from file: " + registryFile, e);
                         }
+                    } else {
+                        System.err.println("Local registry file does not exists under path " + registryFile.getAbsolutePath());
                     }
                     map = registryMap;
                 }

--- a/gateway/engine/filesystem/src/test/java/io/apiman/gateway/engine/filesystem/LocalFileRegistryTest.java
+++ b/gateway/engine/filesystem/src/test/java/io/apiman/gateway/engine/filesystem/LocalFileRegistryTest.java
@@ -4,6 +4,7 @@ import io.apiman.gateway.engine.beans.Api;
 import org.junit.Test;
 
 import java.io.File;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
@@ -62,7 +63,12 @@ public class LocalFileRegistryTest {
     @Test
     public void readExistingRegistry() {
         final Map<String, String> config = new HashMap<String, String>() {{
-            put(CONFIG_REGISTRY_PATH, LocalFileRegistryTest.class.getResource("/populated-registry.json").getPath());
+            try {
+                put(CONFIG_REGISTRY_PATH, LocalFileRegistryTest.class.getResource("/populated-registry.json").toURI().getPath());
+            } catch (URISyntaxException e) {
+                System.err.println("Cannot access populated-registry.json resource");
+                e.printStackTrace();
+            }
         }};
 
         final LocalFileRegistry registry = new LocalFileRegistry(config);


### PR DESCRIPTION
We discovered that the LocalFileRegistryTest cannot properly load resources in a project path with signs which get url encoded within the class.getResource method (see [stackoverflow](https://stackoverflow.com/questions/8928661/how-to-avoid-getting-url-encoded-paths-from-url-getfile/8928965)).

We found this out on our jenkins system which creates under some circumstances a workspace folder with an @ symbol in the path (see [jenkins issue](https://issues.jenkins-ci.org/browse/JENKINS-30231)).