### PR TITLE
Disable stacktrace for manager REST responses

### DIFF
--- a/common/plugin/pom.xml
+++ b/common/plugin/pom.xml
@@ -11,7 +11,16 @@
   <name>apiman-common-plugin</name>
 
   <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>apiman-common-config</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- Third Party libraries -->
+    <dependency>
+    <groupId>commons-configuration</groupId>
+    <artifactId>commons-configuration</artifactId>
+    </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>

--- a/distro/tomcat8/src/main/resources/overlay/conf/apiman.properties
+++ b/distro/tomcat8/src/main/resources/overlay/conf/apiman.properties
@@ -42,6 +42,9 @@ apiman-manager.security-context.type=default
 apiman-manager.config.features.org-create-admin-only=false
 apiman-manager-ui.org-create-admin-only=false
 
+# Set the option to true if the response of the manager rest api should contain stacktraces
+apiman-manager.config.features.rest-response-should-contain-stacktraces=false
+
 # API Manager storage settings.
 apiman-manager.storage.type=es
 apiman-manager.storage.es.client.protocol=${apiman.es.protocol}

--- a/distro/wildfly10/src/main/resources/overlay/standalone/configuration/apiman.properties
+++ b/distro/wildfly10/src/main/resources/overlay/standalone/configuration/apiman.properties
@@ -20,6 +20,13 @@ apiman.es.port=19200
 apiman.es.username=
 apiman.es.password=
 apiman.es.timeout=10000
+apiman.es.initialize=true
+apiman.es.keystore=
+apiman.es.keystore.password=
+apiman.es.truststore=
+apiman.es.truststore.password=
+apiman.es.trust.certificate=
+apiman.es.trust.host=
 
 # ---------------------------------------------------------------------
 # Some hibernate settings only useful when JPA is the storage.type.
@@ -49,7 +56,13 @@ apiman-manager.storage.jpa.initialize=true
 #apiman-manager.storage.es.client.username=${apiman.es.username}
 #apiman-manager.storage.es.client.password=${apiman.es.password}
 #apiman-manager.storage.es.client.timeout=${apiman.es.timeout}
-#apiman-manager.storage.es.client.initialize=true
+#apiman-manager.storage.es.client.initialize=${apiman.es.initialize}
+#apiman-manager.storage.es.client.keystore=${apiman.es.keystore}
+#apiman-manager.storage.es.client.keystore.password=${apiman.es.keystore.password}
+#apiman-manager.storage.es.client.truststore=${apiman.es.truststore}
+#apiman-manager.storage.es.client.truststore.password=${apiman.es.truststore.password}
+#apiman-manager.storage.es.client.trust.certificate=${apiman.es.trust.certificate}
+#apiman-manager.storage.es.client.trust.host=${apiman.es.trust.host}
 
 # API Manager metrics settings.
 apiman-manager.metrics.type=es
@@ -60,6 +73,12 @@ apiman-manager.metrics.es.client.port=${apiman.es.port}
 apiman-manager.metrics.es.client.username=${apiman.es.username}
 apiman-manager.metrics.es.client.password=${apiman.es.password}
 apiman-manager.metrics.es.client.timeout=${apiman.es.timeout}
+apiman-manager.metrics.es.client.keystore=${apiman.es.keystore}
+apiman-manager.metrics.es.client.keystore.password=${apiman.es.keystore.password}
+apiman-manager.metrics.es.client.truststore=${apiman.es.truststore}
+apiman-manager.metrics.es.client.truststore.password=${apiman.es.truststore.password}
+apiman-manager.metrics.es.client.trust.certificate=${apiman.es.trust.certificate}
+apiman-manager.metrics.es.client.trust.host=${apiman.es.trust.host}
 
 # API Manager API Catalog
 apiman-manager.api-catalog.type=io.apiman.manager.api.core.catalog.JsonApiCatalog
@@ -103,7 +122,11 @@ apiman-gateway.metrics.client.port=${apiman.es.port}
 apiman-gateway.metrics.client.username=${apiman.es.username}
 apiman-gateway.metrics.client.password=${apiman.es.password}
 apiman-gateway.metrics.client.timeout=${apiman.es.timeout}
-apiman-gateway.metrics.client.initialize=true
+apiman-gateway.metrics.client.initialize=${apiman.es.initialize}
+apiman-gateway.metrics.client.keystore=${apiman.es.keystore}
+apiman-gateway.metrics.client.keystore.password=${apiman.es.keystore.password}
+apiman-gateway.metrics.client.truststore=${apiman.es.truststore}
+apiman-gateway.metrics.client.truststore.password=${apiman.es.truststore.password}
 
 # ---------------------------------------------------------------------
 # SSL/TLS settings for the gateway connector(s).
@@ -151,7 +174,13 @@ apiman-gateway.registry.client.port=${apiman.es.port}
 apiman-gateway.registry.client.username=${apiman.es.username}
 apiman-gateway.registry.client.password=${apiman.es.password}
 apiman-gateway.registry.client.timeout=${apiman.es.timeout}
-apiman-gateway.registry.client.initialize=true
+apiman-gateway.registry.client.initialize=${apiman.es.initialize}
+apiman-gateway.registry.client.keystore=${apiman.es.keystore}
+apiman-gateway.registry.client.keystore.password=${apiman.es.keystore.password}
+apiman-gateway.registry.client.truststore=${apiman.es.truststore}
+apiman-gateway.registry.client.truststore.password=${apiman.es.truststore.password}
+apiman-gateway.registry.client.trust.certificate=${apiman.es.trust.certificate}
+apiman-gateway.registry.client.trust.host=${apiman.es.trust.host}
 #apiman-gateway.registry.cache-polling-interval=15
 
 # ---------------------------------------------------------------------
@@ -166,7 +195,13 @@ apiman-gateway.components.ISharedStateComponent.client.port=${apiman.es.port}
 apiman-gateway.components.ISharedStateComponent.client.username=${apiman.es.username}
 apiman-gateway.components.ISharedStateComponent.client.password=${apiman.es.password}
 apiman-gateway.components.ISharedStateComponent.client.timeout=${apiman.es.timeout}
-apiman-gateway.components.ISharedStateComponent.client.initialize=true
+apiman-gateway.components.ISharedStateComponent.client.initialize=${apiman.es.initialize}
+apiman-gateway.components.ISharedStateComponent.client.keystore=${apiman.es.keystore}
+apiman-gateway.components.ISharedStateComponent.client.keystore.password=${apiman.es.keystore.password}
+apiman-gateway.components.ISharedStateComponent.client.truststore=${apiman.es.truststore}
+apiman-gateway.components.ISharedStateComponent.client.truststore.password=${apiman.es.truststore.password}
+apiman-gateway.components.ISharedStateComponent.client.trust.certificate=${apiman.es.trust.certificate}
+apiman-gateway.components.ISharedStateComponent.client.trust.host=${apiman.es.trust.host}
 
 
 # ---------------------------------------------------------------------
@@ -181,7 +216,13 @@ apiman-gateway.components.IRateLimiterComponent.client.port=${apiman.es.port}
 apiman-gateway.components.IRateLimiterComponent.client.username=${apiman.es.username}
 apiman-gateway.components.IRateLimiterComponent.client.password=${apiman.es.password}
 apiman-gateway.components.IRateLimiterComponent.client.timeout=${apiman.es.timeout}
-apiman-gateway.components.IRateLimiterComponent.client.initialize=true
+apiman-gateway.components.IRateLimiterComponent.client.initialize=${apiman.es.initialize}
+apiman-gateway.components.IRateLimiterComponent.client.keystore=${apiman.es.keystore}
+apiman-gateway.components.IRateLimiterComponent.client.keystore.password=${apiman.es.keystore.password}
+apiman-gateway.components.IRateLimiterComponent.client.truststore=${apiman.es.truststore}
+apiman-gateway.components.IRateLimiterComponent.client.truststore.password=${apiman.es.truststore.password}
+apiman-gateway.components.IRateLimiterComponent.client.trust.certificate=${apiman.es.trust.certificate}
+apiman-gateway.components.IRateLimiterComponent.client.trust.host=${apiman.es.trust.host}
 
 # ---------------------------------------------------------------------
 # Cache Store Component Settings
@@ -195,7 +236,11 @@ apiman-gateway.components.ICacheStoreComponent.client.port=${apiman.es.port}
 apiman-gateway.components.ICacheStoreComponent.client.username=${apiman.es.username}
 apiman-gateway.components.ICacheStoreComponent.client.password=${apiman.es.password}
 apiman-gateway.components.ICacheStoreComponent.client.timeout=${apiman.es.timeout}
-apiman-gateway.components.ICacheStoreComponent.client.initialize=true
+apiman-gateway.components.ICacheStoreComponent.client.initialize=${apiman.es.initialize}
+apiman-gateway.components.ICacheStoreComponent.client.keystore=${apiman.es.keystore}
+apiman-gateway.components.ICacheStoreComponent.client.keystore.password=${apiman.es.keystore.password}
+apiman-gateway.components.ICacheStoreComponent.client.truststore=${apiman.es.truststore}
+apiman-gateway.components.ICacheStoreComponent.client.truststore.password=${apiman.es.truststore.password}
 
 # ---------------------------------------------------------------------
 # Execute Blocking Component Settings

--- a/distro/wildfly10/src/main/resources/overlay/standalone/configuration/apiman.properties
+++ b/distro/wildfly10/src/main/resources/overlay/standalone/configuration/apiman.properties
@@ -46,6 +46,9 @@ apiman-manager.security-context.type=keycloak
 apiman-manager.config.features.org-create-admin-only=false
 apiman-manager-ui.org-create-admin-only=false
 
+# Set the option to true if the response of the manager rest api should contain stacktraces
+apiman-manager.config.features.rest-response-should-contain-stacktraces=false
+
 # API Manager storage settings.
 apiman-manager.storage.type=jpa
 apiman-manager.storage.jpa.initialize=true

--- a/distro/wildfly11/src/main/resources/overlay/standalone/configuration/apiman.properties
+++ b/distro/wildfly11/src/main/resources/overlay/standalone/configuration/apiman.properties
@@ -46,6 +46,9 @@ apiman-manager.security-context.type=keycloak
 apiman-manager.config.features.org-create-admin-only=false
 apiman-manager-ui.org-create-admin-only=false
 
+# Set the option to true if the response of the manager rest api should contain stacktraces
+apiman-manager.config.features.rest-response-should-contain-stacktraces=false
+
 # API Manager storage settings.
 apiman-manager.storage.type=jpa
 apiman-manager.storage.jpa.initialize=true


### PR DESCRIPTION
The Manger REST API does always send the complete stacktrace:
```java
{
  "type": "NotAuthorizedException",
  "errorCode": -1,
  "message": "Access denied.",
  "moreInfoUrl": null,
  "stacktrace": "io.apiman.manager.api.rest.exceptions.NotAuthorizedException: Access denied.\n\tat io.apiman.manager.api.rest.exceptions.util.ExceptionFactory.notAuthorizedException(ExceptionFactory.java:55)\n\tat io.apiman.manager.api.security.impl.AbstractSecurityContext.checkAdminPermissions(AbstractSecurityContext.java:187)\n\tat 
...
```
We added the new option to enable this with `apiman-manager.config.features.rest-response-should-contain-stacktraces=false`, because most of the time you don't need the stacktrace.

Because the properties files from wildfly differ I added the missing content in a separate commit.