### PR TITLE
Update keycloak to 10.0.2

### DIFF
--- a/manager/ui/war/src/main/java/io/apiman/manager/ui/server/beans/BearerTokenCredentialsBean.java
+++ b/manager/ui/war/src/main/java/io/apiman/manager/ui/server/beans/BearerTokenCredentialsBean.java
@@ -27,7 +27,7 @@ public class BearerTokenCredentialsBean implements Serializable {
     private static final long serialVersionUID = -876646690486553629L;
     
     private String token;
-    private int refreshPeriod; // in seconds
+    private long refreshPeriod; // in seconds
 
     /**
      * Constructor.
@@ -52,14 +52,14 @@ public class BearerTokenCredentialsBean implements Serializable {
     /**
      * @return the refreshPeriod
      */
-    public int getRefreshPeriod() {
+    public long getRefreshPeriod() {
         return refreshPeriod;
     }
 
     /**
      * @param refreshPeriod the refreshPeriod to set
      */
-    public void setRefreshPeriod(int refreshPeriod) {
+    public void setRefreshPeriod(long refreshPeriod) {
         this.refreshPeriod = refreshPeriod;
     }
     

--- a/manager/ui/war/src/main/java/io/apiman/manager/ui/server/kc/KeyCloakBearerTokenGenerator.java
+++ b/manager/ui/war/src/main/java/io/apiman/manager/ui/server/kc/KeyCloakBearerTokenGenerator.java
@@ -49,7 +49,7 @@ public class KeyCloakBearerTokenGenerator implements ITokenGenerator {
         if (session != null) {
             bean.setToken(session.getTokenString());
             int nowInSeconds = getCurrentTime();
-            int expiresInSeconds = session.getToken().getExpiration();
+            long expiresInSeconds = session.getToken().getExp();
 
             if (expiresInSeconds <= nowInSeconds) {
                 bean.setRefreshPeriod(1);

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
     <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.0_spec>
     <version.org.jboss.weld.weld>2.3.3.Final</version.org.jboss.weld.weld>
-    <version.org.keycloak>3.4.3.Final</version.org.keycloak>
+    <version.org.keycloak>10.0.2</version.org.keycloak>
     <version.org.mockito>1.9.5</version.org.mockito>
     <version.org.mvel>2.2.7.Final</version.org.mvel>
     <version.org.osgi>4.2.0</version.org.osgi>


### PR DESCRIPTION
We use keycloak in a much newer version (10.0.2) for a long period now.
So I think it's save to update to this version for the apiman project as well :)