### PR TITLE
Fix #907 - broken plugin page

### DIFF
--- a/manager/ui/war/plugins/api-manager/html/admin/admin-export.html
+++ b/manager/ui/war/plugins/api-manager/html/admin/admin-export.html
@@ -10,12 +10,6 @@
         </div>
       </div>
       <div class="row">
-       <!-- Side Navigation -->
-       <!-- 
-         <div class="col-md-3">
-          <div ng-include="'plugins/api-manager/html/admin/admin_tabs.include'"></div>
-        </div>
-        -->
         <!-- Admin Content -->
         <div class="col-md-9 admin-content">
           <div class="container-fluid">

--- a/manager/ui/war/plugins/api-manager/html/admin/admin-gateways.html
+++ b/manager/ui/war/plugins/api-manager/html/admin/admin-gateways.html
@@ -15,12 +15,6 @@
         </div>
       </div>
       <div class="row">
-        <!-- Side Navigation -->
-        <!--
-        <div class="col-md-3">
-          <div ng-include="'plugins/api-manager/html/admin/admin_tabs.include'"></div>
-        </div>
-        -->
         <!-- Admin Content -->
         <div class="col-md-9 admin-content">
           <div class="container-fluid">

--- a/manager/ui/war/plugins/api-manager/html/admin/admin-plugins.html
+++ b/manager/ui/war/plugins/api-manager/html/admin/admin-plugins.html
@@ -31,8 +31,8 @@
 
             <div class="row">
               <ul class="nav nav-tabs">
-                <li class="active"><a href="#installed-plugins" data-toggle="tab" role="tab" apiman-i18n-key="installed-plugins">Installed Plugins</a></li>
-                <li><a href="#available-plugins" data-toggle="tab" role="tab" apiman-i18n-key="available-plugins">Available Plugins</a></li>
+                <li class="active"><a href="{{ pluginName }}/admin/plugins#installed-plugins" data-toggle="tab" role="tab" apiman-i18n-key="installed-plugins">Installed Plugins</a></li>
+                <li><a href="{{ pluginName }}/admin/plugins#available-plugins" data-toggle="tab" role="tab" apiman-i18n-key="available-plugins">Available Plugins</a></li>
               </ul>
             </div>
             

--- a/manager/ui/war/plugins/api-manager/html/admin/admin-plugins.html
+++ b/manager/ui/war/plugins/api-manager/html/admin/admin-plugins.html
@@ -14,12 +14,6 @@
         </div>
       </div>
       <div class="row">
-        <!-- Side Navigation -->
-        <!--
-        <div class="col-md-3">
-          <div ng-include="'plugins/api-manager/html/admin/admin_tabs.include'"></div>
-        </div>
-        -->
         <!-- Admin Content -->
         <div class="col-md-9 admin-content">
           <div class="container-fluid">

--- a/manager/ui/war/plugins/api-manager/html/admin/admin-policyDefs.html
+++ b/manager/ui/war/plugins/api-manager/html/admin/admin-policyDefs.html
@@ -16,12 +16,6 @@
         </div>
       </div>
       <div class="row">
-        <!-- Side Navigation -->
-        <!--
-        <div class="col-md-3">
-          <div ng-include="'plugins/api-manager/html/admin/admin_tabs.include'"></div>
-        </div>
-      -->
         <!-- Admin Content -->
         <div class="col-md-9 admin-content">
           <div class="container-fluid">

--- a/manager/ui/war/plugins/api-manager/html/admin/admin-roles.html
+++ b/manager/ui/war/plugins/api-manager/html/admin/admin-roles.html
@@ -16,12 +16,6 @@
         </div>
       </div>
       <div class="row">
-        <!-- Side Navigation -->
-        <!--
-        <div class="col-md-3">
-          <div ng-include="'plugins/api-manager/html/admin/admin_tabs.include'"></div>
-        </div>
-        -->
         <!-- Admin Content -->
         <div class="col-md-9 admin-content">
           <div class="container-fluid">

--- a/manager/ui/war/plugins/api-manager/html/admin/admin_tabs.include
+++ b/manager/ui/war/plugins/api-manager/html/admin/admin_tabs.include
@@ -1,7 +1,0 @@
-         <ul class="side-nav nav nav-pills nav-stacked">
-           <li ng-class="{ true: 'active' } [tab == 'roles']"><a data-field="toRoles" apiman-i18n-key="admin-nav.admin-roles" href="{{ pluginName }}/admin/roles">Roles</a></li>
-           <li ng-class="{ true: 'active' } [tab == 'policyDefs']"><a data-field="toPolicyDefs" apiman-i18n-key="admin-nav.policy-definitions" href="{{ pluginName }}/admin/policyDefs">Policy Definitions</a></li>
-           <li ng-class="{ true: 'active' } [tab == 'gateways']"><a data-field="toGateways" apiman-i18n-key="admin-nav.gateways" href="{{ pluginName }}/admin/gateways">Gateways</a></li>
-           <li ng-class="{ true: 'active' } [tab == 'plugins']"><a data-field="toPlugins" apiman-i18n-key="admin-nav.plugins" href="{{ pluginName }}/admin/plugins">Plugins</a></li>
-           <li ng-class="{ true: 'active' } [tab == 'export']"><a apiman-i18n-key="admin-nav.export" href="{{ pluginName }}/admin/export">Export/Import</a></li>
-         </ul>


### PR DESCRIPTION
Hi @EricWittmann,

I looked into the plugins page and reverted a commit from Marc from 2018.
This fixes the routing but breaks the design (two buttons instead of nice tabs).
I think the design is not that important for the moment.

The only problem now is that the 2.0.0 Plugins can not be found.
But I am not sure if this was caused by the release pipeline (they are uploaded to maven central?)?

![image](https://user-images.githubusercontent.com/13332383/93464634-c4244080-f8e9-11ea-98a3-fdce48a92a25.png)
 