### PR TITLE
PollingEsRegistry overwrites EsRegistry indices on index creation

### DIFF
--- a/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/PollCachingEsRegistry.java
+++ b/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/PollCachingEsRegistry.java
@@ -30,7 +30,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.RequestOptions;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -189,7 +189,7 @@ public class PollCachingEsRegistry extends CachingEsRegistry {
                         Thread.sleep(pollIntervalMillis);
                         checkCacheVersion();
                     } catch (Exception e) {
-                        logger.warn(e.getMessage());
+                        logger.error(e.getMessage(), e);
                     }
 
                 }
@@ -228,20 +228,14 @@ public class PollCachingEsRegistry extends CachingEsRegistry {
     }
 
     /**
-     * @see AbstractEsComponent#getDefaultIndexPrefix()
-     */
-    @Override
-    protected String getDefaultIndexPrefix() {
-        return EsConstants.GATEWAY_INDEX_NAME;
-    }
-
-    /**
      * @see AbstractEsComponent#getDefaultIndices()
      * @return default indices
      */
     @Override
     protected List<String> getDefaultIndices() {
-        String[] indices = {EsConstants.INDEX_DATA_VERSION};
-        return Arrays.asList(indices);
+        List<String> indices = new ArrayList<String>();
+        indices.addAll(super.getDefaultIndices());
+        indices.add(EsConstants.INDEX_DATA_VERSION);
+        return indices;
     }
 }


### PR DESCRIPTION
We had found an issue with the `PollingEsRegistry` which overwrites the index creation of the `EsRegistry`. So indices are missing if the `PollingEsRegistry` is used instead of the `EsRegistry`