### PR TITLE
Rollback ddl files and force update of gateway password

### DIFF
--- a/distro/data/src/main/resources/bootstrap/default-gateway.json
+++ b/distro/data/src/main/resources/bootstrap/default-gateway.json
@@ -1,6 +1,6 @@
 {
   "Metadata": {
-    "exportedOn": "2020-08-11T12:00:00Z",
+    "exportedOn": "2020-10-22T12:00:00Z",
     "apimanVersion": "${version}"
   },
   "Gateways": [

--- a/distro/data/src/main/resources/ddls/apiman_h2.ddl
+++ b/distro/data/src/main/resources/ddls/apiman_h2.ddl
@@ -212,9 +212,6 @@ ALTER TABLE api_defs ADD CONSTRAINT UK_api_defs_1 UNIQUE (api_version_id);
 -- Changeset c:/Users/ewittman/git/apiman/apiman/distro/ddl/src/main/liquibase/current/110-apiman-manager-api.db.unique.constraints.changelog.xml::addUniqueConstraint-7::apiman
 ALTER TABLE contracts ADD CONSTRAINT UK_contracts_1 UNIQUE (clientv_id, apiv_id);
 
--- Changeset c:/Users/ewittman/git/apiman/apiman/distro/ddl/src/main/liquibase/current/110-apiman-manager-api.db.unique.constraints.changelog.xml::addUniqueConstraint-7::apiman
-ALTER TABLE client_versions ADD CONSTRAINT UK_client_versions_2 UNIQUE (apikey);
-
 -- Changeset c:/Users/ewittman/git/apiman/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-1::apiman
 CREATE INDEX IDX_auditlog_1 ON auditlog(who);
 

--- a/distro/data/src/main/resources/ddls/apiman_mysql5.ddl
+++ b/distro/data/src/main/resources/ddls/apiman_mysql5.ddl
@@ -214,9 +214,6 @@ ALTER TABLE api_defs ADD CONSTRAINT UK_api_defs_1 UNIQUE (api_version_id);
 --  Changeset c:/Users/ewittman/git/apiman/apiman/distro/ddl/src/main/liquibase/current/110-apiman-manager-api.db.unique.constraints.changelog.xml::addUniqueConstraint-7::apiman
 ALTER TABLE contracts ADD CONSTRAINT UK_contracts_1 UNIQUE (clientv_id, apiv_id);
 
---  Changeset c:/Users/ewittman/git/apiman/apiman/distro/ddl/src/main/liquibase/current/110-apiman-manager-api.db.unique.constraints.changelog.xml::addUniqueConstraint-8::apiman
-ALTER TABLE client_versions ADD CONSTRAINT UK_client_versions_2 UNIQUE (apikey);
-
 --  Changeset c:/Users/ewittman/git/apiman/apiman/distro/ddl/src/main/liquibase/current/200-apiman-manager-api.db.indexes.changelog.xml::createIndex-1::apiman
 CREATE INDEX IDX_auditlog_1 ON auditlog(who);
 


### PR DESCRIPTION
With the commit of the devportal, I pushed some broken ddls (probably from my testing testing phase).
The change of the date in the initial data will force an update of the gateway password.