### PR TITLE
Push wildfly docker image on master build

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -46,3 +46,9 @@ jobs:
         run: mvn test install -Dinvoker.skip -Dmaven.javadoc.skip=true -B -Dapiman.gateway-test.config=vertx3-file
       - name: Run Tests (AMG 1)
         run: mvn test install -Dinvoker.skip -Dmaven.javadoc.skip=true -B -Dapiman.gateway-test.config=amg-1
+      - name: Build and Publish Docker Images
+        if: github.ref == 'refs/heads/master'
+        run: |
+          mvn clean package docker:build -P docker -DskipTests
+          echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+          docker push apiman/on-wildfly:latest

--- a/distro/wildfly/pom.xml
+++ b/distro/wildfly/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <docker.wildfly.version>wildfly</docker.wildfly.version>
     <docker.base-image>jboss/wildfly:20.0.1.Final</docker.base-image>
-    <docker.target-image-name>apiman/on-wildfly:master</docker.target-image-name>
+    <docker.target-image-name>apiman/on-wildfly:latest</docker.target-image-name>
     <docker.target-image-name.alias>wildfly-master</docker.target-image-name.alias>
   </properties>
 


### PR DESCRIPTION
I would like to push the docker image of wildfly on each master build.
I am not sure if this already works because I am not very familiar with github actions.

@EricWittmann Can you please take a look at it? :)