### PR TITLE
FIX 932 : take basic authentication from userInfo to request the maven repository

### DIFF
--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/DefaultPluginRegistry.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/DefaultPluginRegistry.java
@@ -15,17 +15,6 @@
  */
 package io.apiman.gateway.engine.impl;
 
-import io.apiman.common.plugin.Plugin;
-import io.apiman.common.plugin.PluginClassLoader;
-import io.apiman.common.plugin.PluginCoordinates;
-import io.apiman.common.plugin.PluginSpec;
-import io.apiman.common.plugin.PluginUtils;
-import io.apiman.gateway.engine.IPluginRegistry;
-import io.apiman.gateway.engine.async.AsyncResultImpl;
-import io.apiman.gateway.engine.async.IAsyncResult;
-import io.apiman.gateway.engine.async.IAsyncResultHandler;
-import io.apiman.gateway.engine.i18n.Messages;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -36,6 +25,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -50,6 +40,17 @@ import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+
+import io.apiman.common.plugin.Plugin;
+import io.apiman.common.plugin.PluginClassLoader;
+import io.apiman.common.plugin.PluginCoordinates;
+import io.apiman.common.plugin.PluginSpec;
+import io.apiman.common.plugin.PluginUtils;
+import io.apiman.gateway.engine.IPluginRegistry;
+import io.apiman.gateway.engine.async.AsyncResultImpl;
+import io.apiman.gateway.engine.async.IAsyncResult;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.i18n.Messages;
 
 /**
  * A simple plugin registry that stores plugins in a temporary location.  This
@@ -387,6 +388,11 @@ public class DefaultPluginRegistry implements IPluginRegistry {
         OutputStream ostream = null;
         try {
             URLConnection connection = artifactUrl.openConnection();
+            // add the basic authentification contains in the Url
+            if (artifactUrl.getUserInfo() != null) {
+                String authStr = java.util.Base64.getEncoder().encodeToString(artifactUrl.getUserInfo().getBytes(StandardCharsets.UTF_8));
+                connection.addRequestProperty("Authorization", "Basic " + authStr);
+            }
             connection.connect();
             if (connection instanceof HttpURLConnection) {
                 HttpURLConnection httpConnection = (HttpURLConnection) connection;

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/engine/VertxPluginRegistry.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/engine/VertxPluginRegistry.java
@@ -15,6 +15,18 @@
  */
 package io.apiman.gateway.platforms.vertx3.engine;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+
 import io.apiman.gateway.engine.async.AsyncResultImpl;
 import io.apiman.gateway.engine.async.IAsyncResultHandler;
 import io.apiman.gateway.engine.impl.DefaultPluginRegistry;
@@ -27,19 +39,9 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.URL;
-import java.net.UnknownHostException;
-import java.nio.file.Files;
-import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Map;
 
 /**
  * A vertx implementation of the API Gateway's plugin registry. This version simply extends the default
@@ -154,7 +156,14 @@ public class VertxPluginRegistry extends DefaultPluginRegistry {
         request.exceptionHandler((Handler<Throwable>) error -> {
             handler.handle(AsyncResultImpl.create(error, File.class));
         });
-
+        
+        // add the basic authentification contains in the Url
+        if (artifactUrl.getUserInfo() != null) {
+            String authStr = java.util.Base64.getEncoder().encodeToString(artifactUrl.getUserInfo().getBytes(StandardCharsets.UTF_8));           
+            request.putHeader(HttpHeaders.AUTHORIZATION, "Basic " + authStr);
+        }
+        
+        
         request.end();
     }
 


### PR DESCRIPTION
Use the url syntaxe like http://user:password@maven.repository to make an authentification on private nexus.
Impacted in Servlet plateform and Vertx