### PR TITLE
Support Java 11

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,10 +30,10 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 10
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Set up Gren
         run: npm install github-release-notes -g
       - name: Set up NPM CLI Login

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build Project
         run: mvn clean install -Dinvoker.skip -Dmaven.javadoc.skip=true -Dmvn.skip.test=true -DskipTests=true -T1C -B
       - name: Run Tests (Servlet ES)

--- a/gateway/engine/beans/pom.xml
+++ b/gateway/engine/beans/pom.xml
@@ -28,13 +28,16 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
-    
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
     <!-- Test -->
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
-    <scope>test</scope>
-</dependency>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/gateway/engine/core/pom.xml
+++ b/gateway/engine/core/pom.xml
@@ -58,6 +58,10 @@
       <groupId>jakarta.xml.ws</groupId>
       <artifactId>jakarta.xml.ws-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.sun.xml.messaging.saaj</groupId>
+      <artifactId>saaj-impl</artifactId>
+    </dependency>
 
     <!-- Test Only Dependencies -->
     <dependency>

--- a/gateway/engine/core/pom.xml
+++ b/gateway/engine/core/pom.xml
@@ -54,6 +54,10 @@
       <groupId>com.unboundid</groupId>
       <artifactId>unboundid-ldapsdk</artifactId>
     </dependency>
+    <dependency>
+      <groupId>jakarta.xml.ws</groupId>
+      <artifactId>jakarta.xml.ws-api</artifactId>
+    </dependency>
 
     <!-- Test Only Dependencies -->
     <dependency>

--- a/manager/api/jpa/pom.xml
+++ b/manager/api/jpa/pom.xml
@@ -66,6 +66,10 @@
       <groupId>commons-dbutils</groupId>
       <artifactId>commons-dbutils</artifactId>
     </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/manager/pom.xml
+++ b/manager/pom.xml
@@ -46,6 +46,14 @@
       <artifactId>elasticsearch</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>jakarta.xml.ws</groupId>
+      <artifactId>jakarta.xml.ws-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
   </dependencies>
   <modules>
     <module>api</module>

--- a/pom.xml
+++ b/pom.xml
@@ -164,8 +164,8 @@
     <version.org.skyscreamer.jsonassert>1.5.0</version.org.skyscreamer.jsonassert>
     <version.org.redisson>3.9.1</version.org.redisson>
     <version.jakarta.annotation>1.3.5</version.jakarta.annotation>
-<!--    <version.javax.xml.bind>2.3.1</version.javax.xml.bind>-->
     <version.jakarta.xml>2.3.3</version.jakarta.xml>
+    <version.com.sun.xml.messaging.saaj>1.5.2</version.com.sun.xml.messaging.saaj>
   </properties>
 
   <dependencyManagement>
@@ -1156,6 +1156,11 @@
         <groupId>jakarta.xml.ws</groupId>
         <artifactId>jakarta.xml.ws-api</artifactId>
         <version>${version.jakarta.xml}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.messaging.saaj</groupId>
+        <artifactId>saaj-impl</artifactId>
+        <version>${version.com.sun.xml.messaging.saaj}</version>
       </dependency>
 
       <!-- Vert.x -->

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,9 @@
     <version.pl.allegro.tech.embedded-elastic>2.5.0</version.pl.allegro.tech.embedded-elastic>
     <version.org.skyscreamer.jsonassert>1.5.0</version.org.skyscreamer.jsonassert>
     <version.org.redisson>3.9.1</version.org.redisson>
+    <version.jakarta.annotation>1.3.5</version.jakarta.annotation>
+<!--    <version.javax.xml.bind>2.3.1</version.javax.xml.bind>-->
+    <version.jakarta.xml>2.3.3</version.jakarta.xml>
   </properties>
 
   <dependencyManagement>
@@ -1138,6 +1141,21 @@
         <groupId>com.jcabi</groupId>
         <artifactId>jcabi-http</artifactId>
         <version>${version.com.jcbai}</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.annotation</groupId>
+        <artifactId>jakarta.annotation-api</artifactId>
+        <version>${version.jakarta.annotation}</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.xml.bind</groupId>
+        <artifactId>jakarta.xml.bind-api</artifactId>
+        <version>${version.jakarta.xml}</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.xml.ws</groupId>
+        <artifactId>jakarta.xml.ws-api</artifactId>
+        <version>${version.jakarta.xml}</version>
       </dependency>
 
       <!-- Vert.x -->


### PR DESCRIPTION
I added some missing maven dependencies to support the build on java 11.
Unfortunately I could not modify the github verify.yml to switch to java 11.

I compiled it locally with the adopt-openj9-11.

See also the update on the apiman plugins here:
https://github.com/apiman/apiman-plugins/pull/102