### PR TITLE
fix(vertx): Check response before writing

### DIFF
--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/DefaultPolicyErrorWriter.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/DefaultPolicyErrorWriter.java
@@ -15,6 +15,7 @@
  */
 package io.apiman.gateway.engine.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apiman.common.logging.DefaultDelegateFactory;
 import io.apiman.common.logging.IApimanLogger;
 import io.apiman.gateway.engine.IApiClientResponse;
@@ -23,13 +24,10 @@ import io.apiman.gateway.engine.beans.ApiRequest;
 import io.apiman.gateway.engine.beans.EngineErrorResponse;
 import io.apiman.gateway.engine.beans.exceptions.IStatusCode;
 
-import java.io.StringWriter;
-
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.StringWriter;
 
 /**
  * A default implementation of the error formatter.
@@ -67,7 +65,7 @@ public class DefaultPolicyErrorWriter implements IPolicyErrorWriter {
             isXml = true;
         }
         String message = createErrorMessage(request, error);
-        logger.error(message, error);
+        logger.error("DefaultPolicyErrorWriter: "+ message, error);
         response.setHeader("X-Gateway-Error", message);
 
         int statusCode = 500;

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/DefaultPolicyErrorWriter.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/DefaultPolicyErrorWriter.java
@@ -15,7 +15,6 @@
  */
 package io.apiman.gateway.engine.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apiman.common.logging.DefaultDelegateFactory;
 import io.apiman.common.logging.IApimanLogger;
 import io.apiman.gateway.engine.IApiClientResponse;
@@ -24,10 +23,13 @@ import io.apiman.gateway.engine.beans.ApiRequest;
 import io.apiman.gateway.engine.beans.EngineErrorResponse;
 import io.apiman.gateway.engine.beans.exceptions.IStatusCode;
 
+import java.io.StringWriter;
+
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
-import java.io.StringWriter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * A default implementation of the error formatter.

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/DefaultPolicyErrorWriter.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/impl/DefaultPolicyErrorWriter.java
@@ -65,7 +65,7 @@ public class DefaultPolicyErrorWriter implements IPolicyErrorWriter {
             isXml = true;
         }
         String message = createErrorMessage(request, error);
-        logger.error("DefaultPolicyErrorWriter: "+ message, error);
+        logger.error(message, error);
         response.setHeader("X-Gateway-Error", message);
 
         int statusCode = 500;

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/HttpConnector.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/HttpConnector.java
@@ -49,11 +49,8 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
 import java.io.UnsupportedEncodingException;
-import java.net.ConnectException;
-import java.net.NoRouteToHostException;
 import java.net.URI;
 import java.net.URLEncoder;
-import java.net.UnknownHostException;
 import java.util.Map.Entry;
 
 /**
@@ -318,7 +315,7 @@ class HttpConnector implements IApiConnectionResponse, IApiConnection {
         @Override
         public void handle(Throwable error) {
             ConnectorException ce = ErrorHandler.handleConnectionError(error);
-            logger.error(error.getMessage(), error);
+            logger.error("Connection Error: " + error.getMessage(), error);
 
             resultHandler.handle(AsyncResultImpl
                     .<IApiConnectionResponse> create(ce));


### PR DESCRIPTION
Hi together and a happy new year!

I did some little improvements on the vert.x part to prevent some unhandled exceptions that are thrown if we try to write to a closed response. So now there is a check if the response is closed and also I tried to reduce the duplicate lines of code here (by adding the class `DefaultApiClientResponse`).
This should prevent:
```java
[ERROR] 2020-06-04 12:34:52.346 [vert.x-eventloop-thread-2] ContextImpl - Unhandled exception
java.lang.IllegalStateException: Response has already been written
        at io.vertx.core.http.impl.HttpServerResponseImpl.checkValid(HttpServerResponseImpl.java:572) ~[apiman-gateway.jar:?]
        at io.vertx.core.http.impl.HttpServerResponseImpl.setChunked(HttpServerResponseImpl.java:138) ~[apiman-gateway.jar:?]
        at io.vertx.core.http.impl.HttpServerResponseImpl.setChunked(HttpServerResponseImpl.java:54) ~[apiman-gateway.jar:?]
        at io.apiman.gateway.platforms.vertx3.http.HttpPolicyAdapter.handleError(HttpPolicyAdapter.java:213) ~[apiman-gateway.jar:?]
        at io.apiman.gateway.platforms.vertx3.http.HttpPolicyAdapter.lambda$_execute$0(HttpPolicyAdapter.java:78) ~[apiman-gateway.jar:?]
        at io.vertx.core.http.impl.HttpServerRequestImpl.handleException(HttpServerRequestImpl.java:590) ~[apiman-gateway.jar:?]
        at io.vertx.core.http.impl.Http1xServerConnection.handleClosed(Http1xServerConnection.java:464) ~[apiman-gateway.jar:?]
        at io.vertx.core.net.impl.VertxHandler.lambda$channelInactive$5(VertxHandler.java:164) ~[apiman-gateway.jar:?]
        at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:320) ~[apiman-gateway.jar:?]
        at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:43) ~[apiman-gateway.jar:?]
        at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:188) ~[apiman-gateway.jar:?]
        at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:180) ~[apiman-gateway.jar:?]
        at io.vertx.core.net.impl.VertxHandler.channelInactive(VertxHandler.java:164) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224) ~[apiman-gateway.jar:?]
        at io.netty.channel.ChannelInboundHandlerAdapter.channelInactive(ChannelInboundHandlerAdapter.java:75) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224) ~[apiman-gateway.jar:?]
        at io.netty.handler.stream.ChunkedWriteHandler.channelInactive(ChunkedWriteHandler.java:141) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224) ~[apiman-gateway.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.channelInputClosed(ByteToMessageDecoder.java:360) ~[apiman-gateway.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.channelInactive(ByteToMessageDecoder.java:325) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224) ~[apiman-gateway.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.channelInputClosed(ByteToMessageDecoder.java:360) ~[apiman-gateway.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.channelInactive(ByteToMessageDecoder.java:325) ~[apiman-gateway.jar:?]
        at io.netty.handler.ssl.SslHandler.channelInactive(SslHandler.java:1050) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224) ~[apiman-gateway.jar:?]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelInactive(DefaultChannelPipeline.java:1429) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231) ~[apiman-gateway.jar:?]
        at io.netty.channel.DefaultChannelPipeline.fireChannelInactive(DefaultChannelPipeline.java:947) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannel$AbstractUnsafe$8.run(AbstractChannel.java:822) ~[apiman-gateway.jar:?]
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163) ~[apiman-gateway.jar:?]
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404) ~[apiman-gateway.jar:?]
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:462) ~[apiman-gateway.jar:?]
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:897) ~[apiman-gateway.jar:?]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[apiman-gateway.jar:?]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_201]
[ERROR] 2020-06-04 12:34:52.347 [vert.x-eventloop-thread-3] ContextImpl - Unhandled exception
java.lang.IllegalStateException: Response is closed
        at io.vertx.core.http.impl.HttpServerResponseImpl.checkValid(HttpServerResponseImpl.java:575) ~[apiman-gateway.jar:?]
        at io.vertx.core.http.impl.HttpServerResponseImpl.setChunked(HttpServerResponseImpl.java:138) ~[apiman-gateway.jar:?]
        at io.vertx.core.http.impl.HttpServerResponseImpl.setChunked(HttpServerResponseImpl.java:54) ~[apiman-gateway.jar:?]
        at io.apiman.gateway.platforms.vertx3.http.HttpPolicyAdapter.handleError(HttpPolicyAdapter.java:213) ~[apiman-gateway.jar:?]
        at io.apiman.gateway.platforms.vertx3.http.HttpPolicyAdapter.lambda$_execute$0(HttpPolicyAdapter.java:78) ~[apiman-gateway.jar:?]
        at io.vertx.core.http.impl.HttpServerRequestImpl.handleException(HttpServerRequestImpl.java:590) ~[apiman-gateway.jar:?]
        at io.vertx.core.http.impl.Http1xServerConnection.handleClosed(Http1xServerConnection.java:464) ~[apiman-gateway.jar:?]
        at io.vertx.core.net.impl.VertxHandler.lambda$channelInactive$5(VertxHandler.java:164) ~[apiman-gateway.jar:?]
        at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:320) ~[apiman-gateway.jar:?]
        at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:43) ~[apiman-gateway.jar:?]
        at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:188) ~[apiman-gateway.jar:?]
        at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:180) ~[apiman-gateway.jar:?]
        at io.vertx.core.net.impl.VertxHandler.channelInactive(VertxHandler.java:164) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224) ~[apiman-gateway.jar:?]
        at io.netty.channel.ChannelInboundHandlerAdapter.channelInactive(ChannelInboundHandlerAdapter.java:75) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224) ~[apiman-gateway.jar:?]
        at io.netty.handler.stream.ChunkedWriteHandler.channelInactive(ChunkedWriteHandler.java:141) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224) ~[apiman-gateway.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.channelInputClosed(ByteToMessageDecoder.java:360) ~[apiman-gateway.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.channelInactive(ByteToMessageDecoder.java:325) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224) ~[apiman-gateway.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.channelInputClosed(ByteToMessageDecoder.java:360) ~[apiman-gateway.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.channelInactive(ByteToMessageDecoder.java:325) ~[apiman-gateway.jar:?]
        at io.netty.handler.ssl.SslHandler.channelInactive(SslHandler.java:1050) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224) ~[apiman-gateway.jar:?]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelInactive(DefaultChannelPipeline.java:1429) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231) ~[apiman-gateway.jar:?]
        at io.netty.channel.DefaultChannelPipeline.fireChannelInactive(DefaultChannelPipeline.java:947) ~[apiman-gateway.jar:?]
        at io.netty.channel.AbstractChannel$AbstractUnsafe$8.run(AbstractChannel.java:822) ~[apiman-gateway.jar:?]
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163) ~[apiman-gateway.jar:?]
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404) ~[apiman-gateway.jar:?]
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:462) ~[apiman-gateway.jar:?]
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:897) ~[apiman-gateway.jar:?]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[apiman-gateway.jar:?]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_201]
```
Also, I changed the logging a little bit.
