### PR TITLE
Fix for API definition forbidden (http 401) when access from manager.

### DIFF
--- a/manager/api/war/wildfly8/src/main/webapp/WEB-INF/web.xml
+++ b/manager/api/war/wildfly8/src/main/webapp/WEB-INF/web.xml
@@ -101,7 +101,6 @@
     <web-resource-collection>
       <web-resource-name>apiman</web-resource-name>
       <url-pattern>/organizations/*</url-pattern>
-      <http-method>GET</http-method>
       <http-method>POST</http-method>
       <http-method>PUT</http-method>
       <http-method>DELETE</http-method>

--- a/manager/ui/war/plugins/api-manager/css/apiman.css
+++ b/manager/ui/war/plugins/api-manager/css/apiman.css
@@ -1245,10 +1245,12 @@ div.admin-page .admin-content .apiman-summaryrow .emphasis {
   border-bottom: 1px solid rgb(238, 238, 238);
 }
 
-.modal-header .modal-danger
+.modal-danger
 {
   background-color: #B42000;
+  color: white;
 }
+
 
 .modal-body {
   padding: 25px;

--- a/manager/ui/war/plugins/api-manager/css/apiman.css
+++ b/manager/ui/war/plugins/api-manager/css/apiman.css
@@ -1092,7 +1092,8 @@ ol.breadcrumb {
 }
 
 .error-page {
-  margin-top: 30px;
+  margin-top: 5%;
+
 }
 .error-page .title {
   font-size: 18px;

--- a/manager/ui/war/plugins/api-manager/html/api/api-def.html
+++ b/manager/ui/war/plugins/api-manager/html/api/api-def.html
@@ -69,6 +69,7 @@
                            name="definitionUrl"
                            class="apiman-form-control form-control"
                            type="text"
+                           ng-disabled="selectedDefinitionType.value == 'None'"
                     >
                     <span class="input-group-btn">
                       <div apiman-permission="apiEdit"
@@ -78,7 +79,7 @@
                         <button type="button" class="btn btn-default"
                                 ng-click="updateDefinitionFromUrl()"
                                 style="margin-left: 5px"
-                                ng-disabled="updatedApiDefinitionUrl == null"
+                                ng-disabled="updatedApiDefinitionUrl == null || selectedDefinitionType.value == 'None'"
                                 apiman-i18n-key="load-definition">Load Definition
                         </button>
                       </div>
@@ -131,6 +132,7 @@
         </div>
         <!-- /Content -->
       </div>
+      <div ng-include="'plugins/api-manager/html/modals/errorModal.html'"></div>
     </div> <!-- /container -->
   </div>
   </body>

--- a/manager/ui/war/plugins/api-manager/html/api/api-def.html
+++ b/manager/ui/war/plugins/api-manager/html/api/api-def.html
@@ -99,7 +99,7 @@
                           ng-blur="blur=true;focus=false;"
                           data-field="data"
                           class="apiman-form-control form-control apiman-form-data top-spacer"
-                          ng-disabled="isEntityDisabled()">
+                          ng-disabled="isEntityDisabled() || selectedDefinitionType.value == 'None'">
                 </textarea>
               </div>
 

--- a/manager/ui/war/plugins/api-manager/html/api/api-def.html
+++ b/manager/ui/war/plugins/api-manager/html/api/api-def.html
@@ -111,7 +111,7 @@
                 <button type="button" class="btn btn-default" ng-mousedown="downloadDefinition()"
                         ng-disabled="isDirty || !apiDefinition" apiman-i18n-key="download">Download
                 </button>
-                <button ng-disabled="!isDirty  || updatedApiDefinition.length == 0"
+                <button ng-disabled="!isDirty  || updatedApiDefinition.length == 0 || selectedDefinitionType.value == 'None'"
                         ng-mousedown="saveApi()"
                         apiman-action-btn=""
                         class="btn btn-primary"

--- a/manager/ui/war/plugins/api-manager/html/modals/errorModal.html
+++ b/manager/ui/war/plugins/api-manager/html/modals/errorModal.html
@@ -1,0 +1,20 @@
+<!-- Error Modal -->
+<script type="text/ng-template" id="errorModal.html">
+        <div class="modal-header modal-danger">
+          <h3 class="modal-title">{{ title }}</h3>
+        </div>
+        <div class="row modal-body">
+        <div class="col-sm-2">
+            <i class="fa fa-warning" style="font-size:48px;color:red"></i>
+        </div>
+        <div class="col-sm-10">
+          {{ message }}
+        </div>
+    </div>
+        <div class="modal-footer">
+          <button class="btn btn-danger"
+                  type="button"
+                  ng-click="ok()"
+                  apiman-i18n-key="ok">OK</button>
+        </div>
+      </script>

--- a/manager/ui/war/plugins/api-manager/ts/api/api-def.ts
+++ b/manager/ui/war/plugins/api-manager/ts/api/api-def.ts
@@ -3,8 +3,8 @@
 module Apiman {
 
  export var ApiDefController = _module.controller('Apiman.ApiDefController',
-        ['$q', '$rootScope', '$scope', '$location', 'PageLifecycle', 'ApiEntityLoader', 'OrgSvcs', 'Logger', '$routeParams', 'ApiDefinitionSvcs', 'Configuration', 'EntityStatusSvc', 'CurrentUser',
-        ($q, $rootScope, $scope, $location, PageLifecycle, ApiEntityLoader, OrgSvcs, Logger, $routeParams, ApiDefinitionSvcs, Configuration, EntityStatusSvc, CurrentUser) => {
+        ['$q', '$rootScope', '$scope', '$location', 'Modals', 'PageLifecycle', 'ApiEntityLoader', 'OrgSvcs', 'Logger', '$routeParams', 'ApiDefinitionSvcs', 'Configuration', 'EntityStatusSvc', 'CurrentUser',
+        ($q, $rootScope, $scope, $location, Modals, PageLifecycle, ApiEntityLoader, OrgSvcs, Logger, $routeParams, ApiDefinitionSvcs, Configuration, EntityStatusSvc, CurrentUser) => {
             var params = $routeParams;
 
             $scope.organizationId = params.org;
@@ -45,6 +45,7 @@ module Apiman {
                         $scope.saveButton.state = 'complete';
                     },
                     function(error) {
+                        Modals.rpcerror(error,null,null);
                         Logger.error("Error updating definition: {0}", error);
                         $scope.saveButton.state = 'error';
                     });
@@ -80,6 +81,7 @@ module Apiman {
                         $scope.updatedApiDefinition = definition;
                     },
                     function(error) {
+                        Modals.rpcerror(error,null,null);
                         Logger.error("Error loading definition: {0}", error);
                     });
             };
@@ -155,6 +157,7 @@ module Apiman {
                         $scope.saveButton.state = 'complete';
                     },
                     function(error) {
+                        Modals.rpcerror(error,null,null);
                         Logger.error("Error updating definition: {0}", error);
                         $scope.saveButton.state = 'error';
                     })

--- a/manager/ui/war/plugins/api-manager/ts/api/api-def.ts
+++ b/manager/ui/war/plugins/api-manager/ts/api/api-def.ts
@@ -2,186 +2,217 @@
 /// <reference path="../rpc.ts"/>
 module Apiman {
 
- export var ApiDefController = _module.controller('Apiman.ApiDefController',
+    export var ApiDefController = _module.controller('Apiman.ApiDefController',
         ['$q', '$rootScope', '$scope', '$location', 'Modals', 'PageLifecycle', 'ApiEntityLoader', 'OrgSvcs', 'Logger', '$routeParams', 'ApiDefinitionSvcs', 'Configuration', 'EntityStatusSvc', 'CurrentUser',
-        ($q, $rootScope, $scope, $location, Modals, PageLifecycle, ApiEntityLoader, OrgSvcs, Logger, $routeParams, ApiDefinitionSvcs, Configuration, EntityStatusSvc, CurrentUser) => {
-            var params = $routeParams;
+            ($q, $rootScope, $scope, $location, Modals, PageLifecycle, ApiEntityLoader, OrgSvcs, Logger, $routeParams, ApiDefinitionSvcs, Configuration, EntityStatusSvc, CurrentUser) => {
+                var params = $routeParams;
 
-            $scope.organizationId = params.org;
-            $scope.tab = 'def';
-            $scope.version = params.version;
-            $scope.showMetrics = Configuration.ui.metrics;
-            $scope.textAreaHeight = '100';
+                $scope.organizationId = params.org;
+                $scope.tab = 'def';
+                $scope.version = params.version;
+                $scope.showMetrics = Configuration.ui.metrics;
+                $scope.textAreaHeight = '100';
 
-            $scope.typeOptions = [
-                { "label" : "No API Definition",     "value" : "None" },
-                { "label" : "Swagger (JSON)",        "value" : "SwaggerJSON" },
-                { "label" : "Swagger (YAML)",        "value" : "SwaggerYAML" },
-                { "label" : "WSDL",                  "value" : "WSDL" }
-            ];
+                $scope.typeOptions = [
+                    { "label": "No API Definition", "value": "None" },
+                    { "label": "Swagger (JSON)", "value": "SwaggerJSON" },
+                    { "label": "Swagger (YAML)", "value": "SwaggerYAML" },
+                    { "label": "WSDL", "value": "WSDL" }
+                ];
 
-            var selectType = function(newType) {
-                angular.forEach($scope.typeOptions, function(option) {
-                    if (option.value == newType) {
-                        $scope.selectedDefinitionType = option;
+                var selectType = function (newType) {
+                    angular.forEach($scope.typeOptions, function (option) {
+                        if (option.value == newType) {
+                            $scope.selectedDefinitionType = option;
+                        }
+                    });
+                };
+
+                selectType('None');
+
+                $scope.isEntityDisabled = EntityStatusSvc.isEntityDisabled;
+
+                let isValidDefinition = function (data, definitionType) {
+                    switch (definitionType) {
+                        case 'SwaggerJSON':
+                            try {
+                                $.parseJSON(data);
+                                return true;
+                            }
+                            catch (error) {
+                                return false;
+                            }
+                        case 'WSDL':
+                            try {
+                                $.parseXML(data);
+                                return true;
+                            }
+                            catch (error) {
+                                return false;
+                            }
+                            default:
+                                return true;
+                    }
+                }
+
+                $scope.saveApi = function () {
+                    console.log('$scope.selectedDefinitionType.value: ' + $scope.selectedDefinitionType.value);
+                    $scope.saveButton.state = 'in-progress';
+
+                    if (isValidDefinition($scope.updatedApiDefinition, $scope.selectedDefinitionType.value) == false)
+                    {
+                        Modals.error('Invalid API Definition!','The specified API definition is not a valid ' + $scope.selectedDefinitionType.value, null);
+                        $scope.saveButton.state = 'error';
+                        return;
+                    }
+
+                    ApiDefinitionSvcs.updateApiDefinition(params.org, params.api, params.version,
+                        $scope.updatedApiDefinition, $scope.selectedDefinitionType.value,
+                        function (definition) {
+                            Logger.debug("Updated the api definition!");
+                            $scope.apiDefinition = $scope.updatedApiDefinition;
+                            $scope.definitionType = $scope.selectedDefinitionType.value;
+                            $rootScope.isDirty = false;
+                            $scope.saveButton.state = 'complete';
+                        },
+                        function (error) {
+                            Modals.rpcerror(error, null, null);
+                            Logger.error("Error updating definition: {0}", error);
+                            $scope.saveButton.state = 'error';
+                        });
+                };
+
+
+                $scope.$on('afterdrop', function (event, data) {
+                    let newValue = data.value;
+
+                    if (newValue) {
+                        if (newValue.lastIndexOf('{', 0) === 0) {
+                            $scope.$apply(function () {
+                                selectType('SwaggerJSON');
+                            });
+                        } else if (newValue.lastIndexOf('<', 0) === 0) {
+                            $scope.$apply(function () {
+                                selectType('WSDL');
+                            });
+                        } else {
+                            $scope.$apply(function () {
+                                selectType('SwaggerYAML');
+                            });
+                        }
                     }
                 });
-            };
 
-            selectType('None');
+                var pageData = ApiEntityLoader.getCommonData($scope, $location);
 
-            $scope.isEntityDisabled = EntityStatusSvc.isEntityDisabled;
-
-            $scope.saveApi = function() {
-                console.log('$scope.selectedDefinitionType.value: ' + $scope.selectedDefinitionType.value);
-                $scope.saveButton.state = 'in-progress';
-
-                ApiDefinitionSvcs.updateApiDefinition(params.org, params.api, params.version,
-                    $scope.updatedApiDefinition, $scope.selectedDefinitionType.value,
-                    function(definition) {
-                        Logger.debug("Updated the api definition!");
-                        $scope.apiDefinition = $scope.updatedApiDefinition;
-                        $rootScope.isDirty = false;
-                        $scope.saveButton.state = 'complete';
-                    },
-                    function(error) {
-                        Modals.rpcerror(error,null,null);
-                        Logger.error("Error updating definition: {0}", error);
-                        $scope.saveButton.state = 'error';
-                    });
-            };
-
-
-            $scope.$on('afterdrop', function(event, data) {
-                let newValue = data.value;
-
-                if (newValue) {
-                    if (newValue.lastIndexOf('{', 0) === 0) {
-                        $scope.$apply(function() {
-                            selectType('SwaggerJSON');
+                var loadDefinition = function () {
+                    ApiDefinitionSvcs.getApiDefinition(params.org, params.api, params.version,
+                        function (definition) {
+                            $scope.apiDefinition = definition;
+                            $scope.updatedApiDefinition = definition;
+                        },
+                        function (error) {
+                            Modals.rpcerror(error, null, null);
+                            Logger.error("Error loading definition: {0}", error);
                         });
-                    } else if (newValue.lastIndexOf('<', 0) === 0) {
-                        $scope.$apply(function() {
-                            selectType('WSDL');
-                        });
-                    } else {
-                        $scope.$apply(function() {
-                            selectType('SwaggerYAML');
-                        });
+                };
+
+                let loadDefinitionUrl = function () {
+                    $scope.apimanDefinitionUrl = ApiDefinitionSvcs.getApimanDefinitionUrl(params.org, params.api, params.version)
+                };
+
+                var checkDirty = function () {
+                    if ($scope.version) {
+                        var dirty = false;
+
+                        Logger.debug("Model def type: {1}   UI Def type: {0}", $scope.definitionType, $scope.selectedDefinitionType.value);
+
+                        if ($scope.apiDefinition != $scope.updatedApiDefinition) {
+                            Logger.debug("**** dirty because of api def");
+                            dirty = true;
+                        }
+
+                        if ($scope.selectedDefinitionType.value != $scope.definitionType) {
+                            Logger.debug("**** dirty because of def type: {0} != {1}", $scope.selectedDefinitionType.value, $scope.definitionType);
+                            dirty = true;
+                        }
+
+                        $rootScope.isDirty = dirty;
                     }
-                }
-            });
+                };
 
-            var pageData = ApiEntityLoader.getCommonData($scope, $location);
+                $scope.$watch('updatedApi', checkDirty, true);
 
-            var loadDefinition = function() {
-                ApiDefinitionSvcs.getApiDefinition(params.org, params.api, params.version,
-                    function(definition) {
-                        $scope.apiDefinition = definition;
-                        $scope.updatedApiDefinition = definition;
-                    },
-                    function(error) {
-                        Modals.rpcerror(error,null,null);
-                        Logger.error("Error loading definition: {0}", error);
-                    });
-            };
-
-            let loadDefinitionUrl = function () {
-                $scope.apimanDefinitionUrl = ApiDefinitionSvcs.getApimanDefinitionUrl(params.org, params.api, params.version)
-            };
-
-            var checkDirty = function() {
-                if ($scope.version) {
-                    var dirty = false;
-
-                    Logger.debug("Model def type: {1}   UI Def type: {0}", $scope.definitionType, $scope.selectedDefinitionType.value);
-
-                    if ($scope.apiDefinition != $scope.updatedApiDefinition) {
-                        Logger.debug("**** dirty because of api def");
-                        dirty = true;
+                $scope.$watch('updatedApiDefinition', function (newValue, oldValue) {
+                    if (!newValue && !oldValue) {
+                        return;
                     }
 
-                    if ($scope.selectedDefinitionType.value != $scope.definitionType) {
-                        Logger.debug("**** dirty because of def type: {0} != {1}", $scope.selectedDefinitionType.value, $scope.definitionType);
-                        dirty = true;
+                    checkDirty();
+                });
+
+                $scope.$watch('selectedDefinitionType', checkDirty, true);
+
+                $scope.reset = function () {
+                    selectType($scope.definitionType);
+                    $scope.updatedApiDefinition = $scope.apiDefinition;
+                    $scope.updatedApiDefinitionUrl = $scope.version.definitionUrl;
+                    $rootScope.isDirty = false;
+                };
+
+                $scope.downloadDefinition = function () {
+                    let element = document.createElement('a');
+                    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent($scope.apiDefinition));
+                    let fileName = $scope.api.id + '-' + $scope.version.version + '-' + $scope.definitionType;
+                    let fileExtension = '.json';
+                    if ($scope.definitionType == 'SwaggerYAML') {
+                        fileExtension = '.yaml';
+                    } else if ($scope.definitionType == 'WSDL') {
+                        fileExtension = '.xml';
+                    }
+                    element.setAttribute('download', fileName + fileExtension);
+                    element.style.display = 'none';
+                    document.body.appendChild(element);
+                    element.click();
+                    document.body.removeChild(element);
+                };
+
+                $scope.updateDefinitionFromUrl = function () {
+                    let definitionUrl = $scope.updatedApiDefinitionUrl;
+                    let definitionType = $scope.selectedDefinitionType.value;
+                    ApiDefinitionSvcs.updateApiDefinitionFromUrl(params.org, params.api, params.version, definitionUrl, definitionType,
+                        function () {
+                            Logger.debug("Updated the api definition!");
+                            loadDefinition();
+                            $rootScope.isDirty = false;
+                            $scope.saveButton.state = 'complete';
+                        },
+                        function (error) {
+                            Modals.rpcerror(error, null, null);
+                            Logger.error("Error updating definition: {0}", error);
+                            $scope.saveButton.state = 'error';
+                        })
+
+                };
+
+                PageLifecycle.loadPage('ApiDef', 'apiView', pageData, $scope, function () {
+                    $scope.definitionType = $scope.version.definitionType;
+                    $scope.updatedApiDefinitionUrl = $scope.version.definitionUrl;
+
+                    if (!$scope.definitionType) {
+                        $scope.definitionType = 'None';
                     }
 
-                    $rootScope.isDirty = dirty;
-                }
-            };
-
-            $scope.$watch('updatedApi', checkDirty, true);
-
-            $scope.$watch('updatedApiDefinition', function(newValue, oldValue) {
-                if (!newValue && !oldValue) {
-                    return;
-                }
-
-                checkDirty();
-            });
-
-            $scope.$watch('selectedDefinitionType', checkDirty, true);
-
-            $scope.reset = function() {
-                selectType($scope.definitionType);
-                $scope.updatedApiDefinition = $scope.apiDefinition;
-                $scope.updatedApiDefinitionUrl = $scope.version.definitionUrl;
-                $rootScope.isDirty = false;
-            };
-
-            $scope.downloadDefinition = function () {
-                let element = document.createElement('a');
-                element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent($scope.apiDefinition));
-                let fileName = $scope.api.id + '-' + $scope.version.version + '-' + $scope.definitionType;
-                let fileExtension = '.json';
-                if ($scope.definitionType == 'SwaggerYAML') {
-                    fileExtension = '.yaml';
-                } else if ($scope.definitionType == 'WSDL') {
-                    fileExtension = '.xml';
-                }
-                element.setAttribute('download', fileName + fileExtension);
-                element.style.display = 'none';
-                document.body.appendChild(element);
-                element.click();
-                document.body.removeChild(element);
-            };
-
-            $scope.updateDefinitionFromUrl = function () {
-                let definitionUrl = $scope.updatedApiDefinitionUrl;
-                let definitionType = $scope.selectedDefinitionType.value;
-                ApiDefinitionSvcs.updateApiDefinitionFromUrl(params.org, params.api, params.version, definitionUrl, definitionType,
-                    function() {
-                        Logger.debug("Updated the api definition!");
+                    if ($scope.version.definitionType && $scope.version.definitionType != 'None' && $scope.version.definitionType != 'External') {
                         loadDefinition();
-                        $rootScope.isDirty = false;
-                        $scope.saveButton.state = 'complete';
-                    },
-                    function(error) {
-                        Modals.rpcerror(error,null,null);
-                        Logger.error("Error updating definition: {0}", error);
-                        $scope.saveButton.state = 'error';
-                    })
+                        loadDefinitionUrl();
+                    } else {
+                        Logger.debug("Skipped loading api definition - None defined.");
+                    }
 
-            };
+                    $scope.reset();
 
-            PageLifecycle.loadPage('ApiDef', 'apiView', pageData, $scope, function() {
-                $scope.definitionType = $scope.version.definitionType;
-                $scope.updatedApiDefinitionUrl = $scope.version.definitionUrl;
-
-                if (!$scope.definitionType) {
-                    $scope.definitionType = 'None';
-                }
-
-                if ($scope.version.definitionType && $scope.version.definitionType != 'None' && $scope.version.definitionType != 'External') {
-                    loadDefinition();
-                    loadDefinitionUrl();
-                } else {
-                    Logger.debug("Skipped loading api definition - None defined.");
-                }
-
-                $scope.reset();
-
-                PageLifecycle.setPageTitle('api-def', [ $scope.api.name ]);
-            });
-        }]);
+                    PageLifecycle.setPageTitle('api-def', [$scope.api.name]);
+                });
+            }]);
 }

--- a/manager/ui/war/plugins/api-manager/ts/modals.ts
+++ b/manager/ui/war/plugins/api-manager/ts/modals.ts
@@ -5,7 +5,7 @@ module ApimanModals {
 
     export var Modals = _module.factory('Modals',
         ['Logger', '$uibModal',
-        (Logger, $uibModal) => {
+            (Logger, $uibModal) => {
                 return {
                     // Simple data entry dialog
                     ///////////////////////////
@@ -50,60 +50,135 @@ module ApimanModals {
                         });
 
                         modalInstance.result.then(yesCallback, noCallback);
+                    },
+                    // A standard error dialog
+                    /////////////////////////////////
+                    error: function (title, message, okCallBack) {
+                        var options = {
+                            title: title,
+                            message: message
+                        };
+
+                        var modalInstance = $uibModal.open({
+                            animation: true,
+                            templateUrl: 'errorModal.html',
+                            controller: 'ModalErrorCtrl',
+                            resolve: {
+                                options: function () {
+                                    return options;
+                                }
+                            }
+                        });
+
+                        modalInstance.result.then(okCallBack);
+                    },
+                    rpcerror: function (rpcdata, title, okCallBack) {
+                        var message = "";
+
+                        if (title == null) {
+                            title = "We ran into an error!"
+                        }
+
+                        if (rpcdata == null || rpcdata == undefined) {
+                            message = "An unspecified error occurred when calling the management api."
+                        }
+
+                        try 
+                        {
+                            switch (typeof(rpcdata)) {
+                                case "string":
+                                    message = JSON.parse(rpcdata).message;
+                                    break;
+    
+                                case "object":
+                                    message = rpcdata.message;
+                                    break;
+    
+                                default:
+                                    alert(typeof(rpcdata))
+                                    message = "An unspecified error occurred when calling the management api."
+                                    break;
+                            }
+    
+                        }
+                        catch(error)
+                        {
+                            message = "An unspecified error occurred when calling the management api."
+                        }
+                  
+                        var options = {
+                            title: title,
+                            message: message
+                            
+                        };
+
+                        var modalInstance = $uibModal.open({
+                            animation: true,
+                            templateUrl: 'errorModal.html',
+                            controller: 'ModalErrorCtrl',
+                            resolve: {
+                                options: function () {
+                                    return options;
+                                }
+                            }
+                        });
+
+                        modalInstance.result.then(okCallBack);
+
                     }
                 }
             }]);
 
 
-    export var ClientAppDeleteModalCtrl = _module.controller('ModalClientAppDeleteCtrl', 
+    export var ClientAppDeleteModalCtrl = _module.controller('ModalClientAppDeleteCtrl',
         function ($location, $rootScope, $scope, $uibModalInstance, OrgSvcs, Configuration, PageLifecycle, client, params) {
-        
-        $scope.confirmClientName = '';
-        $scope.client = client;
 
-        // Used for enabling/disabling the submit button
-        $scope.okayToDelete = false;
-        
-        $scope.typed = function () {
-            // For user convenience, compare lower case values so that check is not case-sensitive
-            $scope.okayToDelete = ($scope.confirmClientName.toLowerCase() === client.name.toLowerCase());
-        };
-        
-        // Yes, delete the API
-        $scope.yes = function () {
-            var deleteAction = {
-                entityId: client.id,
-                entityType: 'clients',
-                organizationId: params.org
+            $scope.confirmClientName = '';
+            $scope.client = client;
+
+            // Used for enabling/disabling the submit button
+            $scope.okayToDelete = false;
+
+            $scope.typed = function () {
+                // For user convenience, compare lower case values so that check is not case-sensitive
+                $scope.okayToDelete = ($scope.confirmClientName.toLowerCase() === client.name.toLowerCase());
             };
-            
-            OrgSvcs.remove(deleteAction).$promise.then(function(res) {
-                $scope.okayToDelete = false;
-                
-                setTimeout(function() {
+
+            // Yes, delete the API
+            $scope.yes = function () {
+                var deleteAction = {
+                    entityId: client.id,
+                    entityType: 'clients',
+                    organizationId: params.org
+                };
+
+                OrgSvcs.remove(deleteAction).$promise.then(function (res) {
+                    $scope.okayToDelete = false;
+
+                    setTimeout(function () {
+                        $uibModalInstance.close();
+
+                        // Redirect users to their list of APIs
+                        $location.path($rootScope.pluginName + '/users/' + Configuration.user.username + '/clients');
+                    }, 800);
+
+                    // We should display some type of Toastr/Growl notification to the user here
+                }, function (err) {
+                    $scope.okayToDelete = false;
                     $uibModalInstance.close();
-                    
-                    // Redirect users to their list of APIs
-                    $location.path($rootScope.pluginName + '/users/' + Configuration.user.username + '/clients');
-                }, 800);
-                
-                // We should display some type of Toastr/Growl notification to the user here
-            }, function(err) {
-                $scope.okayToDelete = false;
-                $uibModalInstance.close();
-                PageLifecycle.handleError(err);
-            });
-        };
-        
-        // No, do NOT delete the API
-        $scope.no = function () {
-            $uibModalInstance.dismiss('cancel');
-        };
-    });
+                    PageLifecycle.handleError(err);
+                });
+            };
+
+            // No, do NOT delete the API
+            $scope.no = function () {
+                $uibModalInstance.dismiss('cancel');
+            };
+        });
 
     export var ModalSelectApiCtrl = _module.controller('ModalSelectApiCtrl',
         ['$scope', '$uibModalInstance', 'ApimanSvcs', 'Logger', 'OrgSvcs', 'options',
-        ($scope, $uibModalInstance, ApimanSvcs, Logger, OrgSvcs, options) => {
+            ($scope, $uibModalInstance, ApimanSvcs, Logger, OrgSvcs, options) => {
 
                 $scope.options = options;
                 $scope.selectedApi = undefined;
@@ -119,7 +194,7 @@ module ApimanModals {
                     } else {
                         $scope.searchButton.state = 'in-progress';
 
-                        var body:any = {};
+                        var body: any = {};
                         body.filters = [];
 
                         body.filters.push({
@@ -157,8 +232,8 @@ module ApimanModals {
                         });
                     }
                 };
-                
-                $scope.$watch('selectedApiVersion', function(newValue) {
+
+                $scope.$watch('selectedApiVersion', function (newValue) {
                     Logger.info("===========> Api Version: {0}", newValue);
                 }, false);
 
@@ -199,7 +274,7 @@ module ApimanModals {
                         $scope.selectedApiVersion = undefined;
                     });
                 };
-                
+
                 $scope.onApiVersionSelected = function (apiVersion) {
                     Logger.info("===========> Called onApiVersionSelected: {0}", apiVersion);
                     $scope.selectedApiVersion = apiVersion;
@@ -218,13 +293,13 @@ module ApimanModals {
 
     export var ModalGetValueCtrl = _module.controller('ModalGetValueCtrl',
         ['$scope', '$uibModalInstance', 'Logger', 'options',
-        ($scope, $uibModalInstance, Logger, options) => {
+            ($scope, $uibModalInstance, Logger, options) => {
                 $scope.options = options;
                 $scope.title = $scope.options.title;
                 $scope.message = $scope.options.message;
                 $scope.label = $scope.options.label;
                 $scope.value = $scope.options.initialValue;
-                
+
                 $scope.ok = function () {
                     $uibModalInstance.close($scope.value);
                 };
@@ -238,7 +313,7 @@ module ApimanModals {
 
     export var ModalConfirmCtrl = _module.controller('ModalConfirmCtrl',
         ['$scope', '$uibModalInstance', 'Logger', 'options',
-        ($scope, $uibModalInstance, Logger, options) => {
+            ($scope, $uibModalInstance, Logger, options) => {
 
                 $scope.options = options;
                 $scope.title = $scope.options.title;
@@ -250,6 +325,21 @@ module ApimanModals {
 
                 $scope.cancel = function () {
                     $uibModalInstance.dismiss('cancel');
+                };
+            }
+        ]
+    );
+
+    export var ModalErrorCtrl = _module.controller('ModalErrorCtrl',
+        ['$scope', '$uibModalInstance', 'Logger', 'options',
+            ($scope, $uibModalInstance, Logger, options) => {
+
+                $scope.options = options;
+                $scope.title = $scope.options.title;
+                $scope.message = $scope.options.message;
+
+                $scope.ok = function () {
+                    $uibModalInstance.close();
                 };
             }
         ]


### PR DESCRIPTION
I faced this problem when trying to implement a soap web service for our legacy system, the apiman always returned 401 (with auth correct) when I tried to access the definition directly from the manager-ui the error still occurs and then I changed the web.xml deleting GET from organizations/* and it works, but I don't know if this is the correct/best solution.

Please, can you tell me your thoughts about it?