### PR TITLE
Fix for API definition forbidden (http 401) when access from manager

### DIFF
--- a/manager/api/war/wildfly8/src/main/webapp/WEB-INF/web.xml
+++ b/manager/api/war/wildfly8/src/main/webapp/WEB-INF/web.xml
@@ -101,7 +101,6 @@
     <web-resource-collection>
       <web-resource-name>apiman</web-resource-name>
       <url-pattern>/organizations/*</url-pattern>
-      <http-method>GET</http-method>
       <http-method>POST</http-method>
       <http-method>PUT</http-method>
       <http-method>DELETE</http-method>


### PR DESCRIPTION
I faced this problem when trying to implement a soap web service for our legacy system, the apiman always returned 401 (with auth correct) when I tried to access the definition directly from the manager-ui the error still occurs and then I changed the web.xml deleting GET from organizations/* and it works, but I don't know if this is the correct/best solution.

Please, can you tell me your thoughts about it?