### PR TITLE
Changed gateway and gateway-api url from https to http.

### DIFF
--- a/distro/data/src/main/resources/bootstrap/default-gateway.json
+++ b/distro/data/src/main/resources/bootstrap/default-gateway.json
@@ -13,7 +13,7 @@
       "modifiedBy": "admin",
       "modifiedOn": "2018-05-09T12:00:00Z",
       "type": "REST",
-      "configuration": "{\"endpoint\":\"${apiman.gateway-endpoint:https://localhost:8443/apiman-gateway-api}\",\"username\":\"${apiman.gateway-endpoint.username:apimanager}\",\"password\":\"${apiman.gateway-endpoint.password:apiman123!}\"}"
+      "configuration": "{\"endpoint\":\"${apiman.gateway-endpoint:http://localhost:8080/apiman-gateway-api}\",\"username\":\"${apiman.gateway-endpoint.username:apimanager}\",\"password\":\"${apiman.gateway-endpoint.password:apiman123!}\"}"
     }
   ]
 }


### PR DESCRIPTION
I made this change to allow .net developers to add a reference to APIMAN managed API direct from visual studio. I realized that the Wildfly (i didn't test on tomcat) thrusts in any certificate  ` ATTENTION: SSLSessionStrategy will trust *any* certificate. This is extremely unsafe for production. ` but if access comes from outside of Wildfly (e.g from vs) the user got an error because the server root certificate is not thrust by the client and all requests result in an SSL error.