### PR TITLE
403 issue on publishing API

### DIFF
--- a/distro/wildfly/src/main/resources/overlay/standalone/configuration/apiman.properties
+++ b/distro/wildfly/src/main/resources/overlay/standalone/configuration/apiman.properties
@@ -102,7 +102,7 @@ apiman-manager.metrics.datasource.jndi-location=${apiman-gateway.jdbc.jndi-locat
 
 # API Manager API Catalog
 apiman-manager.api-catalog.type=io.apiman.manager.api.core.catalog.JsonApiCatalog
-apiman-manager.api-catalog.catalog-url=https://rawgit.com/apiman/apiman-api-catalog/master/catalog.json
+apiman-manager.api-catalog.catalog-url=https://cdn.rawgit.com/apiman/apiman-api-catalog/master/catalog.json
 
 
 # API Gateway components


### PR DESCRIPTION
Fixing 403 issue when publishing API.

![image](https://user-images.githubusercontent.com/48411313/106732874-2d63e080-664c-11eb-8699-d6a4e68ae59c.png)

added cdn subdomain:

![image](https://user-images.githubusercontent.com/48411313/106733047-5e441580-664c-11eb-9c4e-0c49657304ce.png)
