### PR TITLE
Little ES improvement

### DIFF
--- a/common/es/src/main/java/io/apiman/common/es/util/DefaultEsClientFactory.java
+++ b/common/es/src/main/java/io/apiman/common/es/util/DefaultEsClientFactory.java
@@ -239,12 +239,6 @@ public class DefaultEsClientFactory extends AbstractClientFactory implements IEs
             String trustStorePath = config.get("client.truststore");
             String trustStorePassword = config.get("client.truststore.password");
 
-            Path trustStorePathObject = Paths.get(trustStorePath);
-            KeyStore truststore = KeyStore.getInstance("pkcs12");
-            try (InputStream is = Files.newInputStream(trustStorePathObject)) {
-                truststore.load(is, trustStorePassword.toCharArray());
-            }
-
             SSLContextBuilder sslContextBuilder = SSLContextBuilder.create();
 
             String trustCertificate = config.get("client.trust.certificate");


### PR DESCRIPTION
I probably found some unused code.
I think we can remove these lines because `truststore` is not used and a few lines below we initialize the SSL Context:
https://github.com/apiman/apiman/blob/56275fcfbfa014006c24d0acf211ef7c8ed39316/common/es/src/main/java/io/apiman/common/es/util/DefaultEsClientFactory.java#L243-L246