### PR TITLE
Importer should log file name

### DIFF
--- a/manager/api/export-import/src/main/java/io/apiman/manager/api/exportimport/manager/ExportImportManager.java
+++ b/manager/api/export-import/src/main/java/io/apiman/manager/api/exportimport/manager/ExportImportManager.java
@@ -72,7 +72,7 @@ public class ExportImportManager {
 
     private void doImport() {
         IImportReader reader = eiFactories.get(config.getProvider()).createReader(config, importLogger);
-        importDispatcher.start();
+        importDispatcher.start(config.getJsonFile());
         reader.setDispatcher(importDispatcher);
         try {
             reader.read();

--- a/manager/api/export-import/src/main/java/io/apiman/manager/api/exportimport/manager/StorageImportDispatcher.java
+++ b/manager/api/export-import/src/main/java/io/apiman/manager/api/exportimport/manager/StorageImportDispatcher.java
@@ -109,9 +109,9 @@ public class StorageImportDispatcher implements IImportReaderDispatcher {
     /**
      * Starts the import.
      */
-    public void start() {
+    public void start(String fileName) {
         logger.info("----------------------------"); //$NON-NLS-1$
-        logger.info(Messages.i18n.format("StorageImportDispatcher.StartingImport")); //$NON-NLS-1$
+        logger.info(Messages.i18n.format("StorageImportDispatcher.StartingImport") + fileName); //$NON-NLS-1$
         currentMetadata.setImportedOn(new Date());
         currentMetadata.setApimanVersionAtImport(version.getVersionString());
 

--- a/manager/api/export-import/src/main/resources/io/apiman/manager/api/exportimport/i18n/messages.properties
+++ b/manager/api/export-import/src/main/resources/io/apiman/manager/api/exportimport/i18n/messages.properties
@@ -1,4 +1,4 @@
-StorageImportDispatcher.StartingImport=Starting apiman data import.
+StorageImportDispatcher.StartingImport=Starting apiman data import: 
 StorageImportDispatcher.ImportingClient=\ \ Importing a client: 
 StorageImportDispatcher.ImportingClientContract=Importing a client contract.
 StorageImportDispatcher.ImportingClientPolicy=\ \ \ \ \ \ Importing a client policy: 

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/SystemResourceImpl.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/SystemResourceImpl.java
@@ -268,7 +268,7 @@ public class SystemResourceImpl implements ISystemResource {
 
                 try {
                     importer.setLogger(logger);
-                    importer.start();
+                    importer.start(migratedImportFile.getAbsolutePath());
                     reader.setDispatcher(importer);
                     reader.read();
                 } catch (Exception e) {

--- a/manager/api/war/src/main/java/io/apiman/manager/api/war/WarApiManagerBootstrapperServlet.java
+++ b/manager/api/war/src/main/java/io/apiman/manager/api/war/WarApiManagerBootstrapperServlet.java
@@ -102,7 +102,7 @@ public class WarApiManagerBootstrapperServlet extends HttpServlet {
 
         try {
             importer.setLogger(logger);
-            importer.start();
+            importer.start(file.getAbsolutePath());
             reader.setDispatcher(importer);
             reader.read();
         } catch (Exception e) {

--- a/manager/test/api/src/test/resources/test-plan-data/import/001_import.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/import/001_import.resttest
@@ -370,7 +370,7 @@ Content-Type: application/json
 Content-Type: text/plain;charset=utf-8
 
 INFO: ----------------------------
-INFO: Starting apiman data import.
+INFO: Starting apiman data import: .*apiman_import_migrated.*.json
 INFO: Importing a user: importeduser
 INFO: Importing a gateway: The Gateway
 INFO: Importing an organization: Organization 1

--- a/manager/test/api/src/test/resources/test-plan-data/import/002_import-again.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/import/002_import-again.resttest
@@ -370,5 +370,5 @@ Content-Type: application/json
 Content-Type: text/plain;charset=utf-8
 
 INFO: ----------------------------
-INFO: Starting apiman data import.
+INFO: Starting apiman data import: .*apiman_import_migrated.*.json
 INFO: Import not needed.

--- a/manager/test/api/src/test/resources/test-plan-data/import/003_import-with-developer.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/import/003_import-with-developer.resttest
@@ -31,7 +31,7 @@ Content-Type: application/json
 Content-Type: text/plain;charset=utf-8
 
 INFO: ----------------------------
-INFO: Starting apiman data import.
+INFO: Starting apiman data import: .*apiman_import_migrated.*.json
 INFO: Importing a developer: Developer1
 INFO: Importing a developer: Developer2
 INFO: Publishing APIs to the gateway.

--- a/manager/test/api/src/test/resources/test-plan-data/migrate/001_import-1.2.2.Final.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/migrate/001_import-1.2.2.Final.resttest
@@ -1600,7 +1600,7 @@ INFO: Migrating Policy Def: "JSONP Policy"
 INFO: Migrating Organization: "Test"
 INFO: Migrating Organization: "Foo"
 INFO: ----------------------------
-INFO: Starting apiman data import.
+INFO: Starting apiman data import: .*apiman_import_migrated.*.json
 INFO: Importing a user: admin
 INFO: Importing a gateway: The Gateway
 INFO: Importing a plugin: io.apiman.plugins/apiman-plugins-log-policy/1.2.2.Final
@@ -1623,7 +1623,7 @@ INFO: Importing a policy definition: Time Restricted Access Policy
 INFO: Importing a policy definition: Log Headers Policy
 INFO: Importing a policy definition: JSONP Policy
 INFO: Importing an organization: Test
-INFO:   Importing a role membership: admin+OrganizationOwner=>Test
+INFO:   Importing a role membership: admin\+OrganizationOwner=>Test
 INFO:   Importing a plan: Gold
 INFO:     Importing a plan version: 1.0
 INFO:       Importing a plan policy: Rate Limiting Policy
@@ -1674,7 +1674,7 @@ INFO:   Importing an audit entry: 98
 INFO:   Importing an audit entry: 99
 INFO:   Importing an audit entry: 101
 INFO: Importing an organization: Foo
-INFO:   Importing a role membership: admin+OrganizationOwner=>Foo
+INFO:   Importing a role membership: admin\+OrganizationOwner=>Foo
 INFO:   Importing a plan: Good
 INFO:     Importing a plan version: 1.0
 INFO:       Importing a plan policy: Caching Policy

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
     <version.javax.enterprise>1.2</version.javax.enterprise>
     <version.joda-time>2.7</version.joda-time>
     <version.junit>4.13.2</version.junit>
+    <version.org.assertj>3.19.0</version.org.assertj>
     <version.org.junit.jupiter>5.4.2</version.org.junit.jupiter>
     <version.org.apache.commons.commons-lang3>3.3.2</version.org.apache.commons.commons-lang3>
     <version.org.apache.directory.server>2.0.0.AM25</version.org.apache.directory.server>
@@ -1236,6 +1237,11 @@
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-all</artifactId>
         <version>${version.org.hamcrest}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${version.org.assertj}</version>
       </dependency>
       <dependency>
         <groupId>org.skyscreamer</groupId>

--- a/test/common/pom.xml
+++ b/test/common/pom.xml
@@ -23,6 +23,10 @@
       <groupId>io.apiman</groupId>
       <artifactId>apiman-gateway-engine-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
     <!-- Required Third Party Libs -->
     <dependency>
       <groupId>xmlunit</groupId>

--- a/test/common/src/main/java/io/apiman/test/common/util/TestPlanRunner.java
+++ b/test/common/src/main/java/io/apiman/test/common/util/TestPlanRunner.java
@@ -34,8 +34,6 @@ import java.text.MessageFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
@@ -47,7 +45,6 @@ import org.custommonkey.xmlunit.ElementNameQualifier;
 import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Assert;
-import org.junit.ComparisonFailure;
 import org.mvel2.MVEL;
 import org.mvel2.integration.PropertyHandler;
 import org.mvel2.integration.PropertyHandlerFactory;
@@ -63,6 +60,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.jcabi.http.Request;
 import com.jcabi.http.Response;
 import com.jcabi.http.request.ApacheRequest;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Runs a test plan.
@@ -468,11 +467,9 @@ public class TestPlanRunner {
             String expected = restTest.getExpectedResponsePayload();
 
             if (expected != null) {
-                Pattern pattern = Pattern.compile(expected);
-                Matcher matcher = pattern.matcher(actual);
-                if (!matcher.matches()) {
-                    throw new ComparisonFailure("Response payload (text/plain) mismatch.\n", expected, actual);
-                }
+                assertThat(actual)
+                    .withFailMessage("Response payload (text/plain) mismatch. Expected %s != %s\n", expected, actual)
+                    .matches(expected);
             }
         } catch (Exception e) {
             throw new Error(e);


### PR DESCRIPTION
### Changes to the Importer
The importer now logs the filename at startup.


### Changes to the test framework
To test variable content in text payloads, regular expressions were enabled.

For this jUnits AssertEqual was replaced by the Java regex compiler.
In rest tests with text payload, special characters must be escaped for the regex compiler.