### PR TITLE
build: ensure manager-test junit tests run by surefire even when testng on classpath

### DIFF
--- a/manager/test/api/pom.xml
+++ b/manager/test/api/pom.xml
@@ -9,6 +9,39 @@
   <artifactId>apiman-manager-test-api</artifactId>
   <name>apiman-manager-test-api</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.surefire.plugin}</version>
+        <dependencies>
+          <!-- Make sure we support JUnit 5 also (aka. Jupiter) -->
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit-platform</artifactId>
+            <version>${version.surefire.plugin}</version>
+          </dependency>
+          <!--
+            History repeating itself: another dep pulled in TestNG.
+            This then caused surefire not to run JUnit, but instead runs TestNG.
+            The result is a 'pass' with 0 tests run.
+            This is the official way to force surefire to run JUnit:
+            https://maven.apache.org/surefire/maven-surefire-plugin/examples/providers.html
+            -->
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit47</artifactId>
+            <version>${version.surefire.plugin}</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <failIfNoTests>true</failIfNoTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <!-- Project Dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <version.io.prometheus>0.0.13</version.io.prometheus>
     <version.javax.enterprise>1.2</version.javax.enterprise>
     <version.joda-time>2.7</version.joda-time>
-    <version.junit>4.13.1</version.junit>
+    <version.junit>4.13.2</version.junit>
     <version.org.junit.jupiter>5.4.2</version.org.junit.jupiter>
     <version.org.apache.commons.commons-lang3>3.3.2</version.org.apache.commons.commons-lang3>
     <version.org.apache.directory.server>2.0.0.AM25</version.org.apache.directory.server>


### PR DESCRIPTION
A dependency is pulling in TestNG (a different test framework). Maven-surefire-plugin decided to only run TestNG and not JUnit. This meant it "successfully" ran zero tests, hence all is green.

Thanks to @volkflo for noticing this gremlin.

I believe this occurred back in the distant past, and Eric fixed it using this same method. It came back to me as I was digging into it!

Fixes #998