### PR TITLE
build(deps): bump ant to 1.10.9 & manage version in root pom

### DIFF
--- a/manager/ui/war/pom.xml
+++ b/manager/ui/war/pom.xml
@@ -186,13 +186,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant</artifactId>
-            <version>1.8.2</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>transform-indexhtml</id>

--- a/manager/ui/war/tomcat8/pom.xml
+++ b/manager/ui/war/tomcat8/pom.xml
@@ -76,13 +76,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant</artifactId>
-            <version>1.8.2</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>transform-indexhtml</id>

--- a/manager/ui/war/wildfly8/pom.xml
+++ b/manager/ui/war/wildfly8/pom.xml
@@ -64,13 +64,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant</artifactId>
-            <version>1.8.2</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>transform-indexhtml</id>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
     <!-- Plugin Versions -->
+    <version.ant>1.10.9</version.ant>
     <version.antrun.plugin>1.7</version.antrun.plugin>
     <version.assembly.plugin>3.2.0</version.assembly.plugin>
     <version.buildhelper.plugin>1.9.1</version.buildhelper.plugin>
@@ -1264,6 +1265,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
           <version>${version.antrun.plugin}</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.ant</groupId>
+              <artifactId>ant</artifactId>
+              <version>${version.ant}</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/tools/server-all/pom.xml
+++ b/tools/server-all/pom.xml
@@ -70,14 +70,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.7</version>
-            <dependencies>
-              <dependency>
-                <groupId>org.apache.ant</groupId>
-                <artifactId>ant</artifactId>
-                <version>1.8.2</version>
-              </dependency>
-            </dependencies>
             <executions>
               <execution>
                 <id>run-wildfly</id>


### PR DESCRIPTION
Fixes #1005

Also fixes some security-related issues with Ant, but it does not appear they are relevant for our use-cases, as we only use Ant during build time (no runtime stuff). 

In theory, there are also some permissions changes it could make in $TMP, but they would require some real contortion to exploit. 

Anyway, better to fix it and not wonder :-).