### PR TITLE
test: Autostart Elastic Testcontainer for Vert.x ES integration tests

### DIFF
--- a/common/es/src/main/java/io/apiman/common/es/util/AbstractClientFactory.java
+++ b/common/es/src/main/java/io/apiman/common/es/util/AbstractClientFactory.java
@@ -38,9 +38,9 @@ public abstract class AbstractClientFactory {
 
     private static IApimanLogger logger = new DefaultDelegateFactory().createLogger(AbstractClientFactory.class);
 
-    protected static Map<String, RestHighLevelClient> clients = new HashMap<>();
+    protected static final Map<String, RestHighLevelClient> clients = new HashMap<>();
 
-    protected static Set<String> createdIndices = new HashSet<String>();
+    protected static final Set<String> createdIndices = new HashSet<>();
 
     /**
      * Clears all the clients from the cache.  Useful for unit testing.

--- a/common/es/src/main/java/io/apiman/common/es/util/DefaultEsClientFactory.java
+++ b/common/es/src/main/java/io/apiman/common/es/util/DefaultEsClientFactory.java
@@ -92,12 +92,12 @@ public class DefaultEsClientFactory extends AbstractClientFactory implements IEs
      */
     private RestHighLevelClient createEsClient(Map<String, String> config, String indexNamePrefix, List<String> defaultIndices) {
         String host = config.get("client.host"); //$NON-NLS-1$
-        Integer port = NumberUtils.toInt(config.get("client.port"), 9200); //$NON-NLS-1$
+        int port = NumberUtils.toInt(config.get("client.port"), 9200); //$NON-NLS-1$
         String protocol = config.get("client.protocol"); //$NON-NLS-1$
         String initialize = config.get("client.initialize"); //$NON-NLS-1$
         String username = config.get("client.username"); //$NON-NLS-1$
         String password = config.get("client.password"); //$NON-NLS-1$
-        Integer timeout = NumberUtils.toInt(config.get("client.timeout"), 10000); //$NON-NLS-1$
+        int timeout = NumberUtils.toInt(config.get("client.timeout"), 10000); //$NON-NLS-1$
 
         long pollingTime = NumberUtils.toLong(config.get("client.polling.time"), 600); //$NON-NLS-1$
 

--- a/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/EsResetter.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/EsResetter.java
@@ -51,7 +51,7 @@ public class EsResetter extends AbstractEsComponent implements Resetter {
             // and subtly horrible things will happen, and you'll waste a whole day debugging it! :-)
             DefaultEsClientFactory.clearClientCache();
 
-            final RestHighLevelClient client = getClient();
+            final RestHighLevelClient client = super.getClient();
             deleteIndices(client, latch);
 
             client.indices().flush(new FlushRequest(), RequestOptions.DEFAULT);

--- a/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/Vertx3GatewayEsServerFactory.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/Vertx3GatewayEsServerFactory.java
@@ -1,0 +1,89 @@
+package io.apiman.gateway.test.junit.vertx3;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.apiman.common.es.util.EsConstants;
+import io.apiman.test.common.resttest.IGatewayTestServer;
+import io.apiman.test.common.resttest.IGatewayTestServerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+/**
+ * Starts and stops an Elasticsearch-based Vert.x 3 test server
+ */
+public class Vertx3GatewayEsServerFactory implements IGatewayTestServerFactory {
+
+    private static final Logger logger = LoggerFactory.getLogger(Vertx3GatewayEsServerFactory.class);
+
+    @Override
+    public IGatewayTestServer createGatewayTestServer() {
+        return new Vertx3EsServer();
+    }
+
+    private static final class Vertx3EsServer extends Vertx3GatewayTestServer {
+        private final ElasticsearchContainer testContainer = new ElasticsearchContainer(
+            "docker.elastic.co/elasticsearch/elasticsearch-oss:" + EsConstants.getEsVersion()
+        );
+
+        static final String TEST_CONTAINERS_PORT_ENV_VAR = "test.TEST_CONTAINERS_ES_PORT";
+
+        // Start this early to ensure that we've injected the port into the environment before anything
+        // interesting happens.
+        {
+            if (!testContainer.isRunning()) {
+                logger.info("Starting testcontainer...");
+                testContainer.start();
+            }
+
+            logger.info("Setting ES test-containers port sys property {} to: {} ",
+                TEST_CONTAINERS_PORT_ENV_VAR, testContainer.getFirstMappedPort());
+
+            // In conf-es.json this will be substituted at run time
+            System.setProperty(
+                TEST_CONTAINERS_PORT_ENV_VAR,
+                String.valueOf(testContainer.getFirstMappedPort())
+            );
+        }
+
+        public Vertx3EsServer() {
+            super( false);
+        }
+
+        @Override
+        public void configure(JsonNode config) {
+            super.configure(config);
+        }
+
+        @Override
+        public String getApiEndpoint() {
+            return super.getApiEndpoint();
+        }
+
+        @Override
+        public String getGatewayEndpoint() {
+            return super.getGatewayEndpoint();
+        }
+
+        @Override
+        public String getEchoTestEndpoint() {
+            return super.getEchoTestEndpoint();
+        }
+
+        @Override
+        public void start() {
+            super.start();
+        }
+
+        @Override
+        public void stop() {
+            super.stop();
+            // We could stop the container here, but to avoid extremely slow tests we just flush the indices
+            // please refer to ESResetter
+        }
+
+        @Override
+        public void next(String endpoint) {
+            super.next(endpoint);
+        }
+    }
+}

--- a/gateway/test/src/test/resources/test-configs/vertx3-es.json
+++ b/gateway/test/src/test/resources/test-configs/vertx3-es.json
@@ -1,5 +1,5 @@
 {
-    "factory" : "io.apiman.gateway.test.junit.vertx3.Vertx3GatewayTestServerFactory",
+    "factory" : "io.apiman.gateway.test.junit.vertx3.Vertx3GatewayEsServerFactory",
     "config" : "vertx3/conf-es.json",
     "resetter" : "io.apiman.gateway.test.junit.vertx3.EsResetter"   
 }

--- a/gateway/test/src/test/resources/vertx3/conf-es.json
+++ b/gateway/test/src/test/resources/vertx3/conf-es.json
@@ -17,7 +17,7 @@
         "type": "${test.foo.es.type}",
         "cluster-name": "elasticsearch",
         "host": "localhost",
-        "port": 19250,
+        "port": "${test.TEST_CONTAINERS_ES_PORT}",
         "initialize": true,
         "polling": {
           "time": 60,
@@ -93,7 +93,7 @@
             "type": "es",
             "cluster-name": "elasticsearch",
             "host": "localhost",
-            "port": 19250,
+            "port": "${test.TEST_CONTAINERS_ES_PORT}",
             "initialize": true,
             "polling": {
               "time": 60,
@@ -110,7 +110,7 @@
             "type": "es",
             "cluster-name": "elasticsearch",
             "host": "localhost",
-            "port": 19250,
+            "port": "${test.TEST_CONTAINERS_ES_PORT}",
             "initialize": true,
             "polling": {
               "time": 60,


### PR DESCRIPTION
Rather than relying on a background ES instance, a factory manages the lifecycle of an Elasticsearch Testcontainer with randomised ports for the Vert.x Gateway integration testsuite.

This means that the environment does not need an ES instance running when executing these integration tests from Maven, IDE, CI, etc.

Run as `mvn test -Dapiman.gateway-test.config=vertx3-es`

Fixes #1010