### PR TITLE
Refactor: Allow to configure host for gateway testcontainer

### DIFF
--- a/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/Vertx3GatewayEsServerFactory.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/junit/vertx3/Vertx3GatewayEsServerFactory.java
@@ -26,6 +26,7 @@ public class Vertx3GatewayEsServerFactory implements IGatewayTestServerFactory {
         );
 
         static final String TEST_CONTAINERS_PORT_ENV_VAR = "test.TEST_CONTAINERS_ES_PORT";
+        static final String TEST_CONTAINERS_HOST_ENV_VAR = "test.TEST_CONTAINERS_ES_HOST";
 
         // Start this early to ensure that we've injected the port into the environment before anything
         // interesting happens.
@@ -38,10 +39,17 @@ public class Vertx3GatewayEsServerFactory implements IGatewayTestServerFactory {
             logger.info("Setting ES test-containers port sys property {} to: {} ",
                 TEST_CONTAINERS_PORT_ENV_VAR, testContainer.getFirstMappedPort());
 
+            logger.info("Setting ES test-containers host sys property {} to: {} ",
+                TEST_CONTAINERS_HOST_ENV_VAR, testContainer.getContainerIpAddress());
+
             // In conf-es.json this will be substituted at run time
             System.setProperty(
                 TEST_CONTAINERS_PORT_ENV_VAR,
                 String.valueOf(testContainer.getFirstMappedPort())
+            );
+
+            System.setProperty(TEST_CONTAINERS_HOST_ENV_VAR,
+                String.valueOf(testContainer.getContainerIpAddress())
             );
         }
 

--- a/gateway/test/src/test/resources/vertx3/conf-es.json
+++ b/gateway/test/src/test/resources/vertx3/conf-es.json
@@ -16,7 +16,7 @@
       "client": {
         "type": "${test.foo.es.type}",
         "cluster-name": "elasticsearch",
-        "host": "localhost",
+        "host": "${test.TEST_CONTAINERS_ES_HOST}",
         "port": "${test.TEST_CONTAINERS_ES_PORT}",
         "initialize": true,
         "polling": {
@@ -92,7 +92,7 @@
           "client": {
             "type": "es",
             "cluster-name": "elasticsearch",
-            "host": "localhost",
+            "host": "${test.TEST_CONTAINERS_ES_HOST}",
             "port": "${test.TEST_CONTAINERS_ES_PORT}",
             "initialize": true,
             "polling": {
@@ -109,7 +109,7 @@
           "client": {
             "type": "es",
             "cluster-name": "elasticsearch",
-            "host": "localhost",
+            "host": "${test.TEST_CONTAINERS_ES_HOST}",
             "port": "${test.TEST_CONTAINERS_ES_PORT}",
             "initialize": true,
             "polling": {


### PR DESCRIPTION
Just a little improvement that should allow running the tests also inside a docker container.