### PR TITLE
fix: refresh re-register / re-publish button after changes

### DIFF
--- a/manager/ui/war/plugins/api-manager/ts/api/api-def.ts
+++ b/manager/ui/war/plugins/api-manager/ts/api/api-def.ts
@@ -12,7 +12,7 @@ module Apiman {
             $scope.version = params.version;
             $scope.showMetrics = Configuration.ui.metrics;
             $scope.textAreaHeight = '100';
-
+            $scope.isEntityDisabled = EntityStatusSvc.isEntityDisabled;
             $scope.typeOptions = [
                 { "label" : "No API Definition",     "value" : "None" },
                 { "label" : "Swagger (JSON)",        "value" : "SwaggerJSON" },
@@ -27,10 +27,14 @@ module Apiman {
                     }
                 });
             };
-
             selectType('None');
 
-            $scope.isEntityDisabled = EntityStatusSvc.isEntityDisabled;
+            $scope.finishModification = function () {
+                $rootScope.isDirty = false;
+                $scope.saveButton.state = 'complete';
+                EntityStatusSvc.getEntity().modifiedOn = Date.now();
+                EntityStatusSvc.getEntity().modifiedBy = CurrentUser.getCurrentUser();
+            };
 
             $scope.saveApi = function() {
                 console.log('$scope.selectedDefinitionType.value: ' + $scope.selectedDefinitionType.value);
@@ -41,7 +45,7 @@ module Apiman {
                     function() {
                         Logger.debug("Updated the api definition!");
                         $scope.apiDefinition = $scope.updatedApiDefinition;
-                        finishModification();
+                        $scope.finishModification();
                     },
                     function(error) {
                         Logger.error("Error updating definition: {0}", error);
@@ -107,13 +111,6 @@ module Apiman {
                 }
             };
 
-            const finishModification = function() {
-                $rootScope.isDirty = false;
-                $scope.saveButton.state = 'complete';
-                EntityStatusSvc.getEntity().modifiedOn = Date.now();
-                EntityStatusSvc.getEntity().modifiedBy = CurrentUser.getCurrentUser();
-            };
-
             $scope.$watch('updatedApi', checkDirty, true);
 
             $scope.$watch('updatedApiDefinition', function(newValue, oldValue) {
@@ -157,7 +154,7 @@ module Apiman {
                     function() {
                         Logger.debug("Updated the api definition!");
                         loadDefinition();
-                        finishModification();
+                        $scope.finishModification();
                     },
                     function(error) {
                         Logger.error("Error updating definition: {0}", error);

--- a/manager/ui/war/plugins/api-manager/ts/api/api-def.ts
+++ b/manager/ui/war/plugins/api-manager/ts/api/api-def.ts
@@ -41,10 +41,7 @@ module Apiman {
                     function() {
                         Logger.debug("Updated the api definition!");
                         $scope.apiDefinition = $scope.updatedApiDefinition;
-                        $rootScope.isDirty = false;
-                        $scope.saveButton.state = 'complete';
-                        EntityStatusSvc.getEntity().modifiedOn = Date.now();
-                        EntityStatusSvc.getEntity().modifiedBy = CurrentUser.getCurrentUser();
+                        finishModification();
                     },
                     function(error) {
                         Logger.error("Error updating definition: {0}", error);
@@ -110,6 +107,13 @@ module Apiman {
                 }
             };
 
+            const finishModification = function() {
+                $rootScope.isDirty = false;
+                $scope.saveButton.state = 'complete';
+                EntityStatusSvc.getEntity().modifiedOn = Date.now();
+                EntityStatusSvc.getEntity().modifiedBy = CurrentUser.getCurrentUser();
+            };
+
             $scope.$watch('updatedApi', checkDirty, true);
 
             $scope.$watch('updatedApiDefinition', function(newValue, oldValue) {
@@ -153,8 +157,7 @@ module Apiman {
                     function() {
                         Logger.debug("Updated the api definition!");
                         loadDefinition();
-                        $rootScope.isDirty = false;
-                        $scope.saveButton.state = 'complete';
+                        finishModification();
                     },
                     function(error) {
                         Logger.error("Error updating definition: {0}", error);

--- a/manager/ui/war/plugins/api-manager/ts/api/api-def.ts
+++ b/manager/ui/war/plugins/api-manager/ts/api/api-def.ts
@@ -38,11 +38,13 @@ module Apiman {
 
                 ApiDefinitionSvcs.updateApiDefinition(params.org, params.api, params.version,
                     $scope.updatedApiDefinition, $scope.selectedDefinitionType.value,
-                    function(definition) {
+                    function() {
                         Logger.debug("Updated the api definition!");
                         $scope.apiDefinition = $scope.updatedApiDefinition;
                         $rootScope.isDirty = false;
                         $scope.saveButton.state = 'complete';
+                        EntityStatusSvc.getEntity().modifiedOn = Date.now();
+                        EntityStatusSvc.getEntity().modifiedBy = CurrentUser.getCurrentUser();
                     },
                     function(error) {
                         Logger.error("Error updating definition: {0}", error);

--- a/manager/ui/war/plugins/api-manager/ts/api/api-policies.ts
+++ b/manager/ui/war/plugins/api-manager/ts/api/api-policies.ts
@@ -68,8 +68,10 @@ module Apiman {
                         version: params.version,
                         policiesOrActivity: 'policies',
                         policyId: policy.id
-                    }, function(reply) {
+                    }, function() {
                         removePolicy(policy);
+                        EntityStatusSvc.getEntity().modifiedOn = Date.now();
+                        EntityStatusSvc.getEntity().modifiedBy = CurrentUser.getCurrentUser();
                     }, PageLifecycle.handleError);
                 }, function () {
                     //console.log('Modal dismissed at: ' + new Date());

--- a/manager/ui/war/plugins/api-manager/ts/client/client-policies.ts
+++ b/manager/ui/war/plugins/api-manager/ts/client/client-policies.ts
@@ -55,8 +55,18 @@ module Apiman {
                 });
     
                 modalInstance.result.then(function () {
-                    OrgSvcs.delete({ organizationId: params.org, entityType: 'clients', entityId: params.client, versionsOrActivity: 'versions', version: params.version, policiesOrActivity: 'policies', policyId: policy.id }, function(reply) {
+                    OrgSvcs.delete({
+                        organizationId: params.org,
+                        entityType: 'clients',
+                        entityId: params.client,
+                        versionsOrActivity: 'versions',
+                        version: params.version,
+                        policiesOrActivity: 'policies',
+                        policyId: policy.id
+                    }, function() {
                         removePolicy(policy);
+                        EntityStatusSvc.getEntity().modifiedOn = Date.now();
+                        EntityStatusSvc.getEntity().modifiedBy = CurrentUser.getCurrentUser();
                     }, PageLifecycle.handleError);
                 }, function () {
                     //console.log('Modal dismissed at: ' + new Date());


### PR DESCRIPTION
After removing a policy from a client/api or reloading the Re-Register/Re-Publish Button should be enabled without the need to reload the page

Therefore modifiedOn and modifiedBy need to be updated.