### PR TITLE
ci: Remove Maven build flag for parallel builds

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -62,7 +62,7 @@ jobs:
             ${{ runner.os }}-maven-
       
       - name: Build Project
-        run: mvn clean install -Dinvoker.skip -Dmaven.javadoc.skip=true -Dmvn.test.skip=true -DskipTests=true -T1C -B
+        run: mvn clean install -Dinvoker.skip -Dmaven.javadoc.skip=true -Dmvn.test.skip=true -DskipTests=true -B
 
       - name: Run platform-specific integration tests (${{ matrix.integration-suite.name }})
         run: mvn test install -Dinvoker.skip -Dmaven.javadoc.skip=true -B ${{ matrix.integration-suite.command }}


### PR DESCRIPTION
IMO this makes to log very hard to read if you are searching for errors because of an updated dependency.
Let me know what you think about this? :)