### PR TITLE
build(deps): bump OkHttp from 2.4.0 to 2.7.5

### DIFF
--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/ok/HttpURLConnectionImpl.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/ok/HttpURLConnectionImpl.java
@@ -117,7 +117,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
   }
 
   @Override public final void disconnect() {
-    // Calling disconnect() before a connection exists should have no effect.
+    // Calling cancel() before a connection exists should have no effect.
     if (httpEngine == null) return;
 
     httpEngine.cancel();

--- a/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/ok/HttpURLConnectionImpl.java
+++ b/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/ok/HttpURLConnectionImpl.java
@@ -38,12 +38,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import okio.BufferedSink;
-import okio.Sink;
-
-import com.squareup.okhttp.Connection;
 import com.squareup.okhttp.Handshake;
 import com.squareup.okhttp.Headers;
+import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.Request;
@@ -52,7 +49,6 @@ import com.squareup.okhttp.Response;
 import com.squareup.okhttp.Route;
 import com.squareup.okhttp.internal.Internal;
 import com.squareup.okhttp.internal.Platform;
-import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.HttpDate;
 import com.squareup.okhttp.internal.http.HttpEngine;
 import com.squareup.okhttp.internal.http.HttpMethod;
@@ -61,6 +57,9 @@ import com.squareup.okhttp.internal.http.RequestException;
 import com.squareup.okhttp.internal.http.RetryableSink;
 import com.squareup.okhttp.internal.http.RouteException;
 import com.squareup.okhttp.internal.http.StatusLine;
+import com.squareup.okhttp.internal.http.StreamAllocation;
+import okio.BufferedSink;
+import okio.Sink;
 
 /**
  * This implementation uses HttpEngine to send requests and receive responses.
@@ -121,7 +120,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
     // Calling disconnect() before a connection exists should have no effect.
     if (httpEngine == null) return;
 
-    httpEngine.disconnect();
+    httpEngine.cancel();
 
     // This doesn't close the stream because doing so would require all stream
     // access to be synchronized. It's expected that the thread using the
@@ -256,9 +255,11 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
     return sink.outputStream();
   }
 
-  @Override public final Permission getPermission() throws IOException {
+  @Override public final Permission getPermission() {
     String hostName = getURL().getHost();
-    int hostPort = Util.getEffectivePort(getURL());
+    int hostPort = url.getPort() != -1
+          ? url.getPort()
+          : HttpUrl.defaultPort(url.getProtocol());
     if (usingProxy()) {
       InetSocketAddress proxyAddress = (InetSocketAddress) client.getProxy().address();
       hostName = proxyAddress.getHostName();
@@ -318,7 +319,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
     }
   }
 
-  private HttpEngine newHttpEngine(String method, Connection connection,
+  private HttpEngine newHttpEngine(String method, StreamAllocation connection,
       RetryableSink requestBody, Response priorResponse) {
     // OkHttp's Call API requires a placeholder body; the real body will be streamed separately.
     RequestBody placeholderBody = HttpMethod.requiresRequestBody(method)
@@ -361,8 +362,16 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       engineClient = client.clone().setCache(null);
     }
 
-    return new HttpEngine(engineClient, request, bufferRequestBody, true, false, connection, null,
-        requestBody, priorResponse);
+    return new HttpEngine(
+        engineClient,
+        request,
+        bufferRequestBody,
+        true,
+        false,
+        connection,
+        requestBody,
+        priorResponse
+    );
   }
 
   private String defaultUserAgent() {
@@ -391,7 +400,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       Request followUp = httpEngine.followUpRequest();
 
       if (followUp == null) {
-        httpEngine.releaseConnection();
+        httpEngine.releaseStreamAllocation();
         return httpEngine;
       }
 
@@ -415,13 +424,12 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
         throw new HttpRetryException("Cannot retry streamed HTTP body", responseCode);
       }
 
-      if (!httpEngine.sameConnection(followUp.url())) {
-        httpEngine.releaseConnection();
+      if (!httpEngine.sameConnection(HttpUrl.get(followUp.url()))) {
+        httpEngine.releaseStreamAllocation();
       }
 
-      Connection connection = httpEngine.close();
-      httpEngine = newHttpEngine(followUp.method(), connection, (RetryableSink) requestBody,
-          response);
+      StreamAllocation connection = httpEngine.close();
+      httpEngine = newHttpEngine(followUp.method(), connection, (RetryableSink) requestBody, response);
     }
   }
 
@@ -433,7 +441,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
   private boolean execute(boolean readResponse) throws IOException {
     try {
       httpEngine.sendRequest();
-      route = httpEngine.getRoute();
+      route = httpEngine.getConnection().getRoute();
       handshake = httpEngine.getConnection() != null
           ? httpEngine.getConnection().getHandshake()
           : null;

--- a/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/components/jdbc/JdbcTestSuite.java
+++ b/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/components/jdbc/JdbcTestSuite.java
@@ -64,7 +64,7 @@ public class JdbcTestSuite {
      */
     @BeforeClass
     public static void setupH2() throws SQLException {
-        h2Server = Server.createTcpServer().start();
+        h2Server = Server.createTcpServer("-ifNotExists").start();
     }
 
     @AfterClass

--- a/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/components/jdbc/SpecHelpers.java
+++ b/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/components/jdbc/SpecHelpers.java
@@ -62,7 +62,7 @@ public interface SpecHelpers {
         IJdbcClient client = component.createStandalone(options);
 
         client.connect(explodeOnFailure(context, async, connectionResult -> {
-            System.out.println("Successfully connected!");
+            System.out.println("Dropping everything in the DB!");
             IJdbcConnection connection = connectionResult;
             connection.execute(explodeOnFailure(context, async,
                     onSuccess -> {

--- a/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/components/jdbc/suitetests/CreateTableTest.java
+++ b/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/components/jdbc/suitetests/CreateTableTest.java
@@ -66,7 +66,7 @@ public class CreateTableTest {
         client.connect(explodeOnFailure(context, async, connectionResult -> {
                 System.out.println("Successfully connected!");
                 IJdbcConnection connection = connectionResult;
-                String createTableSql = "create table APIMAN\n" +
+                String createTableSql = "create table APIMAN_FOO_BAR\n" +
                         "    (PLACE_ID integer NOT NULL,\n" +
                         "    COUNTRY varchar(40) NOT NULL,\n" +
                         "    CITY varchar(20) NOT NULL,\n" +

--- a/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/components/jdbc/suitetests/QueryTest.java
+++ b/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/components/jdbc/suitetests/QueryTest.java
@@ -79,7 +79,7 @@ public class QueryTest {
                         "    BYTEARRAY varbinary(100) NOT NULL,\n" +
                         "    PRIMARY KEY (ID));";
                 String insertSql = "insert into APIMAN (ID, STRING, SHORT, INTEGER, LONG, DOUBLE, BOOLEAN, DATETIME, BYTEARRAY)\n" +
-                        "     VALUES  (1, 'Voltigeur', 11, 9001009, 101010101, 3.14159, true, '1976-06-29 00:00:00', 31), ";
+                        "     VALUES  (1, 'Voltigeur', 11, 9001009, 101010101, 3.14159, TRUE, '1976-06-29 00:00:00', 31); ";
                 connection.execute(
                         explodeOnFailure(context, async, onSuccess1 -> {
                             connection.execute(

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <version.com.fasterxml.jackson>2.10.0</version.com.fasterxml.jackson>
     <version.com.h2database>1.3.173</version.com.h2database>
     <version.com.lmax>3.4.2</version.com.lmax>
-    <version.com.squareup.okhttp>2.4.0</version.com.squareup.okhttp>
+    <version.com.squareup.okhttp>2.7.4</version.com.squareup.okhttp>
     <version.com.squareup.okio>1.4.0</version.com.squareup.okio>
     <version.com.unboundid.unboundid-ldapsdk>5.1.3</version.com.unboundid.unboundid-ldapsdk>
     <version.commons-beanutils>1.9.4</version.commons-beanutils>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 
     <!-- Dependency Versions -->
     <version.com.fasterxml.jackson>2.10.0</version.com.fasterxml.jackson>
-    <version.com.h2database>1.3.173</version.com.h2database>
+    <version.com.h2database>1.4.200</version.com.h2database>
     <version.com.lmax>3.4.2</version.com.lmax>
     <version.com.squareup.okhttp>2.7.4</version.com.squareup.okhttp>
     <version.com.squareup.okio>1.4.0</version.com.squareup.okio>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <version.com.fasterxml.jackson>2.10.0</version.com.fasterxml.jackson>
     <version.com.h2database>1.4.200</version.com.h2database>
     <version.com.lmax>3.4.2</version.com.lmax>
-    <version.com.squareup.okhttp>2.7.4</version.com.squareup.okhttp>
+    <version.com.squareup.okhttp>2.7.5</version.com.squareup.okhttp>
     <version.com.squareup.okio>1.4.0</version.com.squareup.okio>
     <version.com.unboundid.unboundid-ldapsdk>5.1.3</version.com.unboundid.unboundid-ldapsdk>
     <version.commons-beanutils>1.9.4</version.commons-beanutils>


### PR DESCRIPTION
This is a slightly risky update because the internal OkHttp model was changed quite significantly between 2.4.0 and 2.7.5 to be more streaming-oriented. I'm not 100% sure I've selected appropriately equivalent methods. We should test this well before merging in.

The next stage will be bumping all the way up to the very latest OkHttp (or whatever we deem appropriate), but I suspect that will take a bit longer!