### PR TITLE
refactor(es): revert waitUntil index refresh strategy. Use immediate.

### DIFF
--- a/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/EsRegistry.java
+++ b/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/EsRegistry.java
@@ -95,7 +95,7 @@ public class EsRegistry extends AbstractEsComponent implements IRegistry {
             IndexRequest indexRequest = new IndexRequest(getIndexPrefix() + EsConstants.INDEX_APIS)
                     .id(id)
                     .source(JSON_MAPPER.writeValueAsBytes(api), XContentType.JSON)
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
+                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
             IndexResponse response = getClient().index(indexRequest, RequestOptions.DEFAULT);
 
@@ -121,7 +121,7 @@ public class EsRegistry extends AbstractEsComponent implements IRegistry {
         try {
             DeleteRequest deleteRequest = new DeleteRequest(getIndexPrefix() + EsConstants.INDEX_APIS)
                     .id(id)
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
+                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
             DeleteResponse response = getClient().delete(deleteRequest, RequestOptions.DEFAULT);
 
@@ -148,7 +148,7 @@ public class EsRegistry extends AbstractEsComponent implements IRegistry {
             IndexRequest indexRequest = new IndexRequest(getIndexPrefix() + EsConstants.INDEX_CLIENTS)
                     .source(JSON_MAPPER.writeValueAsBytes(client), XContentType.JSON)
                     .id(id)
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
+                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
             IndexResponse response = getClient().index(indexRequest, RequestOptions.DEFAULT);
 
@@ -214,7 +214,7 @@ public class EsRegistry extends AbstractEsComponent implements IRegistry {
 
             DeleteRequest deleteRequest = new DeleteRequest(getIndexPrefix() + EsConstants.INDEX_CLIENTS)
                     .id(id)
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
+                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
             DeleteResponse response = getClient().delete(deleteRequest, RequestOptions.DEFAULT);
             if (response.status().equals(RestStatus.OK)) {

--- a/manager/api/es/src/main/java/io/apiman/manager/api/es/EsStorage.java
+++ b/manager/api/es/src/main/java/io/apiman/manager/api/es/EsStorage.java
@@ -1985,7 +1985,7 @@ public class EsStorage extends AbstractEsComponent implements IStorage, IStorage
             String fullIndexName = getFullIndexName(type);
 
             IndexRequest indexRequest = new IndexRequest(fullIndexName).id(id).source(json, XContentType.JSON);
-            // Force an immediate reindex to avoid horrible slowness
+            // Force an immediate reindex to avoid slowness waiting for ES to refresh.
             indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
             IndexResponse indexResponse = getClient().index(indexRequest, RequestOptions.DEFAULT);
@@ -2052,7 +2052,7 @@ public class EsStorage extends AbstractEsComponent implements IStorage, IStorage
     private void deleteEntity(String type, String id) throws StorageException {
         try {
             final DeleteRequest deleteRequest = new DeleteRequest(getFullIndexName(type), id);
-            // IMMEDIATE same as "wait_for" => Leave this request open until a refresh has made the contents of this request visible to search
+            // Force an immediate reindex to avoid slowness waiting for ES to refresh.
             deleteRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
             DeleteResponse response = getClient().delete(deleteRequest, RequestOptions.DEFAULT);
@@ -2078,7 +2078,7 @@ public class EsStorage extends AbstractEsComponent implements IStorage, IStorage
             String doc = Strings.toString(source);
             String fullIndexName = getFullIndexName(type);
             IndexRequest indexRequest = new IndexRequest(fullIndexName).id(id).source(doc, XContentType.JSON);
-            // IMMEDIATE same as "wait_for" => Leave this request open until a refresh has made the contents of this request visible to search
+            // Force an immediate reindex to avoid slowness waiting for ES to refresh.
             indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             getClient().index(indexRequest, RequestOptions.DEFAULT);
         } catch (Exception e) {

--- a/manager/api/es/src/main/java/io/apiman/manager/api/es/EsStorage.java
+++ b/manager/api/es/src/main/java/io/apiman/manager/api/es/EsStorage.java
@@ -1985,8 +1985,8 @@ public class EsStorage extends AbstractEsComponent implements IStorage, IStorage
             String fullIndexName = getFullIndexName(type);
 
             IndexRequest indexRequest = new IndexRequest(fullIndexName).id(id).source(json, XContentType.JSON);
-            // WAIT_UNTIL same as "wait_for" => Leave this request open until a refresh has made the contents of this request visible to search
-            indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
+            // Force an immediate reindex to avoid horrible slowness
+            indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
             IndexResponse indexResponse = getClient().index(indexRequest, RequestOptions.DEFAULT);
 
@@ -2052,8 +2052,8 @@ public class EsStorage extends AbstractEsComponent implements IStorage, IStorage
     private void deleteEntity(String type, String id) throws StorageException {
         try {
             final DeleteRequest deleteRequest = new DeleteRequest(getFullIndexName(type), id);
-            // WAIT_UNTIL same as "wait_for" => Leave this request open until a refresh has made the contents of this request visible to search
-            deleteRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
+            // IMMEDIATE same as "wait_for" => Leave this request open until a refresh has made the contents of this request visible to search
+            deleteRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
             DeleteResponse response = getClient().delete(deleteRequest, RequestOptions.DEFAULT);
             if (!response.status().equals(RestStatus.OK)) {
@@ -2078,8 +2078,8 @@ public class EsStorage extends AbstractEsComponent implements IStorage, IStorage
             String doc = Strings.toString(source);
             String fullIndexName = getFullIndexName(type);
             IndexRequest indexRequest = new IndexRequest(fullIndexName).id(id).source(doc, XContentType.JSON);
-            // WAIT_UNTIL same as "wait_for" => Leave this request open until a refresh has made the contents of this request visible to search
-            indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
+            // IMMEDIATE same as "wait_for" => Leave this request open until a refresh has made the contents of this request visible to search
+            indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             getClient().index(indexRequest, RequestOptions.DEFAULT);
         } catch (Exception e) {
             throw new StorageException(e);


### PR DESCRIPTION
Let's try this out... We can likely pick and choose which is appropriate.