### PR TITLE
fix(distro-vertx): remove argument quotes breaking launch script

### DIFF
--- a/distro/vertx/src/main/resources/overlay/apiman-gateway.sh
+++ b/distro/vertx/src/main/resources/overlay/apiman-gateway.sh
@@ -52,8 +52,8 @@ if [ "$DEBUG_MODE" = "true" ]; then
 fi
 
 # Launch
-$JAVA "$JAVA_OPTS" \
-    "$APIMAN_GATEWAY_OPTS" \
+$JAVA $JAVA_OPTS \
+    $APIMAN_GATEWAY_OPTS \
     `# Explicitly tell Apiman to use log4j2` \
     -Dapiman.logger-delegate=log4j2 \
     `# Use Log4j2 by default.` \


### PR DESCRIPTION
Was prompted to add the quotes by shellcheck, but I think in this situation it was incorrect to use the recommended quotations because I want the arguments to expand.