### PR TITLE
build(deps): remove unused commons-lang v2 dep

### DIFF
--- a/common/config/pom.xml
+++ b/common/config/pom.xml
@@ -32,10 +32,6 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.picketbox</groupId>
       <artifactId>jboss-security-spi</artifactId>
       <scope>provided</scope>

--- a/common/config/src/main/java/io/apiman/common/config/SystemPropertiesConfiguration.java
+++ b/common/config/src/main/java/io/apiman/common/config/SystemPropertiesConfiguration.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.apache.commons.configuration.AbstractConfiguration;
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.SystemConfiguration;
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,6 @@
     <version.commons-dbcp>1.4</version.commons-dbcp>
     <version.commons-dbutils>1.7</version.commons-dbutils>
     <version.commons-io>2.8.0</version.commons-io>
-    <version.commons-lang>2.6</version.commons-lang>
     <version.commons-logging>1.2</version.commons-logging>
     <version.commons-pool>1.6</version.commons-pool>
     <version.com.amazon.opendistroforelasticsearch>1.13.1</version.com.amazon.opendistroforelasticsearch>
@@ -897,11 +896,6 @@
         <groupId>commons-pool</groupId>
         <artifactId>commons-pool</artifactId>
         <version>${version.commons-pool}</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>${version.commons-lang}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
We use commons-lang3 everywhere now. Seems this was just hanging around.