### PR TITLE
build(deps): bump maven-dependency-plugin, hibernate, ant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
 
     <!-- Plugin Versions -->
-    <version.ant>1.10.9</version.ant>
+    <version.ant>1.10.10</version.ant>
     <version.antrun.plugin>1.7</version.antrun.plugin>
     <version.assembly.plugin>3.2.0</version.assembly.plugin>
     <version.buildhelper.plugin>3.2.0</version.buildhelper.plugin>
@@ -77,7 +77,7 @@
     <version.clean.plugin>3.1.0</version.clean.plugin>
     <version.com.qmino.miredot-plugin>1.6.2</version.com.qmino.miredot-plugin>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
-    <version.dependency.plugin>2.10</version.dependency.plugin>
+    <version.dependency.plugin>3.1.2</version.dependency.plugin>
     <version.deploy.plugin>2.8.2</version.deploy.plugin>
     <version.install.plugin>2.5.2</version.install.plugin>
     <version.jar.plugin>3.2.0</version.jar.plugin>
@@ -133,7 +133,7 @@
     <version.org.elasticsearch>7.12.0</version.org.elasticsearch>
     <version.org.hamcrest>1.3</version.org.hamcrest>
     <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
-    <version.org.hibernate>5.4.28.Final</version.org.hibernate>
+    <version.org.hibernate>5.4.30.Final</version.org.hibernate>
     <version.org.infinispan>8.2.12.Final</version.org.infinispan>
     <version.org.jboss.jandex>2.2.3.Final</version.org.jboss.jandex>
     <version.org.jboss.logging.jboss-logging>3.4.1.Final</version.org.jboss.logging.jboss-logging>


### PR DESCRIPTION
build(deps): bump maven-dependency-plugin from 2.10 to 3.1.2

Bumps [maven-dependency-plugin](https://github.com/apache/maven-dependency-plugin) from 2.10 to 3.1.2.
- [Release notes](https://github.com/apache/maven-dependency-plugin/releases)
- [Commits](https://github.com/apache/maven-dependency-plugin/compare/maven-dependency-plugin-2.10...maven-dependency-plugin-3.1.2)

build(deps): bump version.org.hibernate

Bumps `version.org.hibernate` from 5.4.28.Final to 5.4.30.Final.

Updates `hibernate-core` from 5.4.28.Final to 5.4.30.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/5.4.30/changelog.txt)
- [Commits](https://github.com/hibernate/hibernate-orm/compare/5.4.28...5.4.30)

Updates `hibernate-entitymanager` from 5.4.28.Final to 5.4.30.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/5.4.30/changelog.txt)
- [Commits](https://github.com/hibernate/hibernate-orm/compare/5.4.28...5.4.30)

build(deps): bump ant from 1.10.9 to 1.10.10

Bumps ant from 1.10.9 to 1.10.10.

Signed-off-by: dependabot[bot] <support@github.com>