### PR TITLE
feat(distro-tomcat): use log4j2 by default to enable easy unified JSON logging

### DIFF
--- a/distro/tomcat/pom.xml
+++ b/distro/tomcat/pom.xml
@@ -14,29 +14,55 @@
   <dependencies>
     <!-- The Tomcat 8 version of APIMan -->
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>io.apiman</groupId>
       <artifactId>apiman-manager-api-war-tomcat8</artifactId>
       <type>war</type>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>io.apiman</groupId>
       <artifactId>apiman-manager-ui-war-tomcat8</artifactId>
       <type>war</type>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>io.apiman</groupId>
       <artifactId>apiman-gateway-platforms-war-tomcat8-api</artifactId>
       <type>war</type>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>io.apiman</groupId>
       <artifactId>apiman-gateway-platforms-war-tomcat8-gateway</artifactId>
       <type>war</type>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>io.apiman</groupId>
       <artifactId>apiman-distro-data</artifactId>
     </dependency>
+    <!-- log4j2 bits  -->
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-common-logging-log4j2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-appserver</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <!-- end logging -->
   </dependencies>
 
   <build>

--- a/distro/tomcat/src/main/assembly/overlay.xml
+++ b/distro/tomcat/src/main/assembly/overlay.xml
@@ -7,6 +7,22 @@
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>
   <dependencySets>
+    <!-- log4j2 logging -->
+    <dependencySet>
+      <outputDirectory>log4j2/lib</outputDirectory>
+      <includes>
+        <include>org.apache.logging.log4j:log4j-api</include>
+        <include>org.apache.logging.log4j:log4j-core</include>
+        <include>org.apache.logging.log4j:log4j-appserver</include>
+        <include>com.lmax:disruptor</include>
+        <include>com.fasterxml.jackson.core:jackson-databind</include>
+        <include>com.fasterxml.jackson.core:jackson-core</include>
+        <include>com.fasterxml.jackson.core:jackson-annotations</include>
+      </includes>
+      <directoryMode>0755</directoryMode>
+      <fileMode>0755</fileMode>
+    </dependencySet>
+
     <!-- apiman-manager -->
     <dependencySet>
       <outputDirectory>webapps</outputDirectory>

--- a/distro/tomcat/src/main/resources/overlay/bin/setenv.sh
+++ b/distro/tomcat/src/main/resources/overlay/bin/setenv.sh
@@ -1,0 +1,8 @@
+# See: https://logging.apache.org/log4j/2.x/log4j-appserver/index.html
+CLASSPATH=$CATALINA_HOME/log4j2/lib/*:$CATALINA_HOME/log4j2/conf
+# Set the log4j2 delegate in Apiman; use the logging config file that we create in our overlay.
+# This means we can control Tomcat and Apiman logging from the same place.
+CATALINA_OPTS="$CATALINA_OPTS -Dapiman.logger-delegate=log4j2 -Dlog4j.configurationFile=$CATALINA_HOME/log4j2/conf/log4j2-tomcat.xml"
+# Force use of async logging, which will utilise lmax disruptor for higher performance logging.
+# See: https://logging.apache.org/log4j/2.x/manual/async.html
+CATALINA_OPTS="$CATALINA_OPTS -Dorg.apache.logging.log4j.core.async.AsyncLoggerContextSelector=log4j2.contextSelector"

--- a/distro/tomcat/src/main/resources/overlay/log4j2/conf/log4j2-tomcat.xml
+++ b/distro/tomcat/src/main/resources/overlay/log4j2/conf/log4j2-tomcat.xml
@@ -10,13 +10,20 @@ See more detail at: https://logging.apache.org/log4j/2.x/manual/async.html
   <Appenders>
     <!-- Async Loggers will auto-flush in batches, so switch off immediateFlush. -->
     <RandomAccessFile name="RandomAccessFile" fileName="apiman-gateway.log" immediateFlush="false" append="false">
-<!--      <PatternLayout>-->
-<!--        <Pattern>%d %p %c{1.} [%t] %m %ex%n</Pattern>-->
-<!--      </PatternLayout>-->
-      <JSONLayout/>
+      <PatternLayout>
+        <Pattern>%d %p %c{1.} [%t] %m %ex%n</Pattern>
+      </PatternLayout>
+      <!-- JSON logging can be enabled by changing to JSONLayout. See https://logging.apache.org/log4j/log4j-2.2/manual/layouts.html#JSONLayout -->
+      <!-- <JSONLayout /> -->
     </RandomAccessFile>
     <Console name="Console-Appender" target="SYSTEM_OUT" immediateFlush="false">
-      <JSONLayout/>
+      <PatternLayout>
+        <pattern>
+          [%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n
+        </pattern>
+      </PatternLayout>
+      <!-- JSON logging can be enabled by changing to JSONLayout. See https://logging.apache.org/log4j/log4j-2.2/manual/layouts.html#JSONLayout -->
+      <!-- <JSONLayout /> -->
     </Console>
   </Appenders>
   <Loggers>

--- a/distro/tomcat/src/main/resources/overlay/log4j2/conf/log4j2-tomcat.xml
+++ b/distro/tomcat/src/main/resources/overlay/log4j2/conf/log4j2-tomcat.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Ensure you set the system property to make all loggers asynchronous.
+-DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
+This is done automatically if you are using the provided shell script.
+
+See more detail at: https://logging.apache.org/log4j/2.x/manual/async.html
+-->
+<Configuration status="WARN">
+  <Appenders>
+    <!-- Async Loggers will auto-flush in batches, so switch off immediateFlush. -->
+    <RandomAccessFile name="RandomAccessFile" fileName="apiman-gateway.log" immediateFlush="false" append="false">
+<!--      <PatternLayout>-->
+<!--        <Pattern>%d %p %c{1.} [%t] %m %ex%n</Pattern>-->
+<!--      </PatternLayout>-->
+      <JSONLayout/>
+    </RandomAccessFile>
+    <Console name="Console-Appender" target="SYSTEM_OUT" immediateFlush="false">
+      <JSONLayout/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <!-- apiman package only logging -->
+    <AsyncLogger level="${sys:apiman.gateway-logLevel:-info}" name="io.apiman" additivity="false">
+      <AppenderRef ref="RandomAccessFile"/>
+      <AppenderRef ref="Console-Appender"/>
+    </AsyncLogger>
+    <!-- You can add your own loggers with separate levels, etc. -->
+    <!-- <AsyncLogger level="info" name="com.example.yourpackage" additivity="false">
+      <AppenderRef ref="RandomAccessFile"/>
+      <AppenderRef ref="Console-Appender"/>
+    </AsyncLogger> -->
+    <!-- Root/Global file logging config -->
+    <AsyncRoot level="${sys:apiman.gateway-logLevel:-info}" includeLocation="false">
+      <AppenderRef ref="RandomAccessFile"/>
+      <AppenderRef ref="Console-Appender"/>
+    </AsyncRoot>
+  </Loggers>
+</Configuration>

--- a/distro/tomcat/src/main/resources/overlay/log4j2/conf/log4j2-tomcat.xml
+++ b/distro/tomcat/src/main/resources/overlay/log4j2/conf/log4j2-tomcat.xml
@@ -28,7 +28,7 @@ See more detail at: https://logging.apache.org/log4j/2.x/manual/async.html
   </Appenders>
   <Loggers>
     <!-- apiman package only logging -->
-    <AsyncLogger level="${sys:apiman.gateway-logLevel:-info}" name="io.apiman" additivity="false">
+    <AsyncLogger level="${sys:apiman-logLevel:-info}" name="io.apiman" additivity="false">
       <AppenderRef ref="RandomAccessFile"/>
       <AppenderRef ref="Console-Appender"/>
     </AsyncLogger>
@@ -38,7 +38,7 @@ See more detail at: https://logging.apache.org/log4j/2.x/manual/async.html
       <AppenderRef ref="Console-Appender"/>
     </AsyncLogger> -->
     <!-- Root/Global file logging config -->
-    <AsyncRoot level="${sys:apiman.gateway-logLevel:-info}" includeLocation="false">
+    <AsyncRoot level="${sys:apiman.apiman-logLevel:-info}" includeLocation="false">
       <AppenderRef ref="RandomAccessFile"/>
       <AppenderRef ref="Console-Appender"/>
     </AsyncRoot>

--- a/distro/tomcat/src/main/resources/overlay/log4j2/conf/log4j2-tomcat.xml
+++ b/distro/tomcat/src/main/resources/overlay/log4j2/conf/log4j2-tomcat.xml
@@ -9,7 +9,7 @@ See more detail at: https://logging.apache.org/log4j/2.x/manual/async.html
 <Configuration status="WARN">
   <Appenders>
     <!-- Async Loggers will auto-flush in batches, so switch off immediateFlush. -->
-    <RandomAccessFile name="RandomAccessFile" fileName="apiman-gateway.log" immediateFlush="false" append="false">
+    <RandomAccessFile name="RandomAccessFile" fileName="apiman.log" immediateFlush="false" append="false">
       <PatternLayout>
         <Pattern>%d %p %c{1.} [%t] %m %ex%n</Pattern>
       </PatternLayout>

--- a/pom.xml
+++ b/pom.xml
@@ -1006,6 +1006,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-appserver</artifactId>
+        <version>${version.org.apache.logging.log4j}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
         <version>${version.org.apache.logging.log4j}</version>
       </dependency>


### PR DESCRIPTION
Note, I've left the JSON logging option enabled so it's easier for people to try out, but we'll ship with human-readable. I'll do a commit before we merge changing it back to 'default'.