### PR TITLE
build(parent): force junit4 as default for surefire plugin

### DIFF
--- a/manager/pom.xml
+++ b/manager/pom.xml
@@ -16,21 +16,6 @@
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <modules>
     <module>api</module>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -913,7 +913,20 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${version.surefire.plugin}</version>
+          <dependencies>
+            <dependency>
+              <groupId>junit</groupId>
+              <artifactId>junit</artifactId>
+              <version>${version.junit}</version>
+            </dependency>
+          </dependencies>
           <configuration>
+            <properties>
+              <property>
+                <name>junit</name>
+                <value>true</value>
+              </property>
+            </properties>
             <systemPropertyVariables>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
             </systemPropertyVariables>


### PR DESCRIPTION
Ensure that TestNG does not barge in at any point transitively.

Also seems that junit5 dependencies declared in unnecessarily in certain places were causing some tests not to run.

I tried extensively to follow the instructions/examples from the surefire examples, but they didn't seem to work for me 🤷🏻‍♂️.

In future we should just move to JUnit 5.