### PR TITLE
build(deps): bump mockito-core, icu4j, jandex, & hibernate

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -89,16 +89,16 @@
     <version.org.elasticsearch>7.13.0</version.org.elasticsearch>
     <version.org.hamcrest>1.3</version.org.hamcrest>
     <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.2</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
-    <version.org.hibernate>5.4.32.Final</version.org.hibernate>
+    <version.org.hibernate>5.5.0.Final</version.org.hibernate>
     <version.org.infinispan>8.2.12.Final</version.org.infinispan>
-    <version.org.jboss.jandex>2.2.3.Final</version.org.jboss.jandex>
+    <version.org.jboss.jandex>2.3.0.Final</version.org.jboss.jandex>
     <version.org.jboss.logging.jboss-logging>3.4.2.Final</version.org.jboss.logging.jboss-logging>
     <version.org.jboss.resteasy>3.15.1.Final</version.org.jboss.resteasy>
     <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.1.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
     <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>2.0.1.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>
     <version.org.jboss.weld.weld>3.1.7.SP1</version.org.jboss.weld.weld>
     <version.org.keycloak>12.0.4</version.org.keycloak>
-    <version.org.mockito>3.10.0</version.org.mockito>
+    <version.org.mockito>3.11.0</version.org.mockito>
     <version.org.mvel>2.4.12.Final</version.org.mvel>
     <version.org.picketbox>5.1.0.Final</version.org.picketbox>
     <version.org.reflections>0.9.11</version.org.reflections>
@@ -109,7 +109,7 @@
     <version.xmlunit>1.6</version.xmlunit>
     <version.io.vertx>3.9.7</version.io.vertx>
     <version.net.openhft>0.12</version.net.openhft>
-    <version.com.ibm.icu4j>68.2</version.com.ibm.icu4j>
+    <version.com.ibm.icu4j>69.1</version.com.ibm.icu4j>
     <version.com.hazelcast>4.2</version.com.hazelcast>
     <version.com.jcbai>1.17.6</version.com.jcbai>
     <version.org.skyscreamer.jsonassert>1.5.0</version.org.skyscreamer.jsonassert>


### PR DESCRIPTION
Batched dependency updates.

---

build(deps): bump mockito-core from 3.10.0 to 3.11.0 in /parent

Bumps [mockito-core](https://github.com/mockito/mockito) from 3.10.0 to 3.11.0.
- [Release notes](https://github.com/mockito/mockito/releases)
- [Commits](https://github.com/mockito/mockito/compare/v3.10.0...v3.11.0)

---
updated-dependencies:
- dependency-name: org.mockito:mockito-core
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump icu4j from 68.2 to 69.1 in /parent

Bumps [icu4j](https://github.com/unicode-org/icu) from 68.2 to 69.1.
- [Release notes](https://github.com/unicode-org/icu/releases)
- [Commits](https://github.com/unicode-org/icu/commits)

---
updated-dependencies:
- dependency-name: com.ibm.icu:icu4j
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump jandex from 2.2.3.Final to 2.3.0.Final in /parent

Bumps jandex from 2.2.3.Final to 2.3.0.Final.

---
updated-dependencies:
- dependency-name: org.jboss:jandex
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump version.org.hibernate in /parent

Bumps `version.org.hibernate` from 5.4.32.Final to 5.5.0.Final.

Updates `hibernate-core` from 5.4.32.Final to 5.5.0.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/main/changelog.txt)
- [Commits](https://github.com/hibernate/hibernate-orm/compare/5.4.32...5.5.0)

Updates `hibernate-entitymanager` from 5.4.32.Final to 5.5.0.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/main/changelog.txt)
- [Commits](https://github.com/hibernate/hibernate-orm/compare/5.4.32...5.5.0)

---
updated-dependencies:
- dependency-name: org.hibernate:hibernate-core
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: org.hibernate:hibernate-entitymanager
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>