### PR TITLE
build(deps): bump elasticsearch, redisson, json-unit-assertj

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -86,7 +86,7 @@
     <version.org.apache.logging.log4j>2.14.1</version.org.apache.logging.log4j>
     <version.org.eclipse.jetty>9.4.41.v20210516</version.org.eclipse.jetty>
     <version.org.glassfish.javax.el>3.0.0</version.org.glassfish.javax.el>
-    <version.org.elasticsearch>7.13.0</version.org.elasticsearch>
+    <version.org.elasticsearch>7.13.1</version.org.elasticsearch>
     <version.org.hamcrest>1.3</version.org.hamcrest>
     <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.2</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
     <version.org.hibernate>5.5.0.Final</version.org.hibernate>
@@ -113,8 +113,8 @@
     <version.com.hazelcast>4.2</version.com.hazelcast>
     <version.com.jcbai>1.17.6</version.com.jcbai>
     <version.org.skyscreamer.jsonassert>1.5.0</version.org.skyscreamer.jsonassert>
-    <version.org.redisson>3.15.5</version.org.redisson>
-    <version.net.javacrumbs.json-unit>2.24.0</version.net.javacrumbs.json-unit>
+    <version.org.redisson>3.15.6</version.org.redisson>
+    <version.net.javacrumbs.json-unit>2.26.0</version.net.javacrumbs.json-unit>
 
     <!-- Sun and javax dependencies to maintain compatibility with Java 9+ module changes -->
     <version.com.sun.xml.ws>2.3.4</version.com.sun.xml.ws>


### PR DESCRIPTION
Rollup update of...

---

build(deps): bump version.org.elasticsearch in /parent

Bumps `version.org.elasticsearch` from 7.13.0 to 7.13.1.

Updates `elasticsearch` from 7.13.0 to 7.13.1
- [Release notes](https://github.com/elastic/elasticsearch/releases)
- [Commits](https://github.com/elastic/elasticsearch/compare/v7.13.0...v7.13.1)

Updates `elasticsearch-rest-high-level-client` from 7.13.0 to 7.13.1
- [Release notes](https://github.com/elastic/elasticsearch/releases)
- [Commits](https://github.com/elastic/elasticsearch/compare/v7.13.0...v7.13.1)

---
updated-dependencies:
- dependency-name: org.elasticsearch:elasticsearch
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.elasticsearch.client:elasticsearch-rest-high-level-client
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump redisson from 3.15.5 to 3.15.6 in /parent

Bumps [redisson](https://github.com/redisson/redisson) from 3.15.5 to 3.15.6.
- [Release notes](https://github.com/redisson/redisson/releases)
- [Changelog](https://github.com/redisson/redisson/blob/master/CHANGELOG.md)
- [Commits](https://github.com/redisson/redisson/compare/redisson-3.15.5...redisson-3.15.6)

---
updated-dependencies:
- dependency-name: org.redisson:redisson
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump json-unit-assertj from 2.24.0 to 2.26.0 in /parent

Bumps [json-unit-assertj](https://github.com/lukas-krecan/JsonUnit) from 2.24.0 to 2.26.0.
- [Release notes](https://github.com/lukas-krecan/JsonUnit/releases)
- [Commits](https://github.com/lukas-krecan/JsonUnit/compare/json-unit-parent-2.24.0...json-unit-parent-2.26.0)

Signed-off-by: dependabot[bot] <support@github.com>