### PR TITLE
build(deps): elasticsearch, hibernate, commons-io, mockito, Maven dependency plugin

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -33,7 +33,7 @@
     <version.clean.plugin>3.1.0</version.clean.plugin>
     <version.com.qmino.miredot-plugin>1.6.2</version.com.qmino.miredot-plugin>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
-    <version.dependency.plugin>3.1.2</version.dependency.plugin>
+    <version.dependency.plugin>3.2.0</version.dependency.plugin>
     <version.deploy.plugin>2.8.2</version.deploy.plugin>
     <version.install.plugin>2.5.2</version.install.plugin>
     <version.jar.plugin>3.2.0</version.jar.plugin>
@@ -65,7 +65,7 @@
     <version.commons-configuration>1.10</version.commons-configuration>
     <version.commons-dbcp>1.4</version.commons-dbcp>
     <version.commons-dbutils>1.7</version.commons-dbutils>
-    <version.commons-io>2.9.0</version.commons-io>
+    <version.commons-io>2.10.0</version.commons-io>
     <version.commons-logging>1.2</version.commons-logging>
     <version.commons-pool>1.6</version.commons-pool>
     <version.com.amazon.opendistroforelasticsearch>1.13.1</version.com.amazon.opendistroforelasticsearch>
@@ -86,10 +86,10 @@
     <version.org.apache.logging.log4j>2.14.1</version.org.apache.logging.log4j>
     <version.org.eclipse.jetty>9.4.41.v20210516</version.org.eclipse.jetty>
     <version.org.glassfish.javax.el>3.0.0</version.org.glassfish.javax.el>
-    <version.org.elasticsearch>7.13.1</version.org.elasticsearch>
+    <version.org.elasticsearch>7.13.2</version.org.elasticsearch>
     <version.org.hamcrest>1.3</version.org.hamcrest>
     <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.2</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
-    <version.org.hibernate>5.5.0.Final</version.org.hibernate>
+    <version.org.hibernate>5.5.2.Final</version.org.hibernate>
     <version.org.infinispan>8.2.12.Final</version.org.infinispan>
     <version.org.jboss.jandex>2.3.0.Final</version.org.jboss.jandex>
     <version.org.jboss.logging.jboss-logging>3.4.2.Final</version.org.jboss.logging.jboss-logging>
@@ -98,7 +98,7 @@
     <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>2.0.1.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>
     <version.org.jboss.weld.weld>3.1.7.SP1</version.org.jboss.weld.weld>
     <version.org.keycloak>12.0.4</version.org.keycloak>
-    <version.org.mockito>3.11.0</version.org.mockito>
+    <version.org.mockito>3.11.1</version.org.mockito>
     <version.org.mvel>2.4.12.Final</version.org.mvel>
     <version.org.picketbox>5.1.0.Final</version.org.picketbox>
     <version.org.reflections>0.9.11</version.org.reflections>


### PR DESCRIPTION
build(deps): bump version.org.elasticsearch in /parent

Bumps `version.org.elasticsearch` from 7.13.1 to 7.13.2.

Updates `elasticsearch` from 7.13.1 to 7.13.2
- [Release notes](https://github.com/elastic/elasticsearch/releases)
- [Commits](https://github.com/elastic/elasticsearch/compare/v7.13.1...v7.13.2)

Updates `elasticsearch-rest-high-level-client` from 7.13.1 to 7.13.2
- [Release notes](https://github.com/elastic/elasticsearch/releases)
- [Commits](https://github.com/elastic/elasticsearch/compare/v7.13.1...v7.13.2)

---
updated-dependencies:
- dependency-name: org.elasticsearch:elasticsearch
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.elasticsearch.client:elasticsearch-rest-high-level-client
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump version.org.hibernate in /parent

Bumps `version.org.hibernate` from 5.5.0.Final to 5.5.2.Final.

Updates `hibernate-core` from 5.5.0.Final to 5.5.2.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/main/changelog.txt)
- [Commits](https://github.com/hibernate/hibernate-orm/compare/5.5.0...5.5.2)

Updates `hibernate-entitymanager` from 5.5.0.Final to 5.5.2.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/main/changelog.txt)
- [Commits](https://github.com/hibernate/hibernate-orm/compare/5.5.0...5.5.2)

---
updated-dependencies:
- dependency-name: org.hibernate:hibernate-core
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.hibernate:hibernate-entitymanager
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump commons-io from 2.9.0 to 2.10.0 in /parent

Bumps commons-io from 2.9.0 to 2.10.0.

---
updated-dependencies:
- dependency-name: commons-io:commons-io
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump mockito-core from 3.11.0 to 3.11.1 in /parent

Bumps [mockito-core](https://github.com/mockito/mockito) from 3.11.0 to 3.11.1.
- [Release notes](https://github.com/mockito/mockito/releases)
- [Commits](https://github.com/mockito/mockito/compare/v3.11.0...v3.11.1)

---
updated-dependencies:
- dependency-name: org.mockito:mockito-core
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump maven-dependency-plugin from 3.1.2 to 3.2.0 in /parent

Bumps [maven-dependency-plugin](https://github.com/apache/maven-dependency-plugin) from 3.1.2 to 3.2.0.
- [Release notes](https://github.com/apache/maven-dependency-plugin/releases)
- [Commits](https://github.com/apache/maven-dependency-plugin/compare/maven-dependency-plugin-3.1.2...maven-dependency-plugin-3.2.0)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-dependency-plugin
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>