### PR TITLE
fix(manager-api): use correct configuration accessor for ESMetricsAccessor

### DIFF
--- a/common/config/src/main/java/io/apiman/common/config/options/exceptions/BadOptionConfigurationException.java
+++ b/common/config/src/main/java/io/apiman/common/config/options/exceptions/BadOptionConfigurationException.java
@@ -164,12 +164,7 @@ public class BadOptionConfigurationException extends IllegalArgumentException {
 
     @Override
     public String toString() {
-        return new StringJoiner(", ", BadOptionConfigurationException.class.getSimpleName() + "[", "]")
-            .add("expectedType='" + expectedType + "'")
-            .add("optionName='" + optionName + "'")
-            .add("actualValue='" + actualValue + "'")
-            .add("constraintFailureMessage='" + constraintFailureMessage + "'")
-            .toString();
+        return super.toString();
     }
 
     @Override

--- a/manager/api/war/src/main/java/io/apiman/manager/api/war/WarCdiFactory.java
+++ b/manager/api/war/src/main/java/io/apiman/manager/api/war/WarCdiFactory.java
@@ -135,10 +135,8 @@ public class WarCdiFactory {
     public static IMetricsAccessor provideMetricsAccessor(WarApiManagerConfig config,
                                                           @New NoOpMetricsAccessor noopMetrics, IPluginRegistry pluginRegistry) {
         IMetricsAccessor metrics;
-        if (EsUtils.isEsOrJest(config.getMetricsType())) { //$NON-NLS-1$
-            metrics = new EsMetricsAccessor(config.getStorageESClientFactoryConfig());
-        } else if (config.getMetricsType().equals(EsMetricsAccessor.class.getName())) {
-            metrics = new EsMetricsAccessor(config.getStorageESClientFactoryConfig());
+        if (EsUtils.isEsOrJest(config.getMetricsType()) || config.getMetricsType().equals(EsMetricsAccessor.class.getName())) { //$NON-NLS-1$
+            metrics = new EsMetricsAccessor(config.getMetricsESClientFactoryConfig());
         } else if ("noop".equals(config.getMetricsType())) { //$NON-NLS-1$
             metrics = noopMetrics;
         } else if (config.getMetricsType().equals(NoOpMetricsAccessor.class.getName())) {


### PR DESCRIPTION
`ESMetricsAccessor` should always use `config#getMetricsESClientFactoryConfig` *not*
`config#getStorageESClientFactoryConfig`.

Fixes #1346