### PR TITLE
build(deps): batched minor and patch dependency updates

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -57,7 +57,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
 
     <!-- Plugin Versions -->
-    <version.ant>1.10.10</version.ant>
+    <version.ant>1.10.11</version.ant>
     <version.antrun.plugin>1.7</version.antrun.plugin>
     <version.assembly.plugin>3.3.0</version.assembly.plugin>
     <version.buildhelper.plugin>3.2.0</version.buildhelper.plugin>
@@ -85,7 +85,7 @@
     <version.shade.plugin>3.2.4</version.shade.plugin>
 
     <!-- Dependency Versions -->
-    <version.com.fasterxml.jackson>2.12.3</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson>2.12.4</version.com.fasterxml.jackson>
     <version.com.h2database>1.4.200</version.com.h2database>
     <version.com.lmax>3.4.4</version.com.lmax>
     <version.com.github.seancfoley.ipaddress>5.3.3</version.com.github.seancfoley.ipaddress>
@@ -98,7 +98,7 @@
     <version.commons-configuration>1.10</version.commons-configuration>
     <version.commons-dbcp>1.4</version.commons-dbcp>
     <version.commons-dbutils>1.7</version.commons-dbutils>
-    <version.commons-io>2.10.0</version.commons-io>
+    <version.commons-io>2.11.0</version.commons-io>
     <version.commons-logging>1.2</version.commons-logging>
     <version.commons-pool>1.6</version.commons-pool>
     <version.com.amazon.opendistroforelasticsearch>1.13.1</version.com.amazon.opendistroforelasticsearch>
@@ -112,38 +112,38 @@
     <version.org.junit.jupiter>5.7.2</version.org.junit.jupiter>
     <version.org.apache.commons.commons-lang3>3.12.0</version.org.apache.commons.commons-lang3>
     <version.org.apache.directory.server>2.0.0.AM25</version.org.apache.directory.server>
-    <version.org.apache.directory.api-all>2.0.1</version.org.apache.directory.api-all>
+    <version.org.apache.directory.api-all>2.1.0</version.org.apache.directory.api-all>
     <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
     <version.org.apache.httpcomponents.httpcore>4.4.14</version.org.apache.httpcomponents.httpcore>
     <version.org.apache.httpcomponents.httpasyncclient>4.1.4</version.org.apache.httpcomponents.httpasyncclient>
     <version.org.apache.logging.log4j>2.14.1</version.org.apache.logging.log4j>
     <version.org.eclipse.jetty>9.4.41.v20210516</version.org.eclipse.jetty>
     <version.org.glassfish.javax.el>3.0.0</version.org.glassfish.javax.el>
-    <version.org.elasticsearch>7.13.2</version.org.elasticsearch>
+    <version.org.elasticsearch>7.13.4</version.org.elasticsearch>
     <version.org.hamcrest>1.3</version.org.hamcrest>
     <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.2</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
-    <version.org.hibernate>5.5.2.Final</version.org.hibernate>
+    <version.org.hibernate>5.5.4.Final</version.org.hibernate>
     <version.org.infinispan>8.2.12.Final</version.org.infinispan>
     <version.org.jboss.jandex>2.3.0.Final</version.org.jboss.jandex>
     <version.org.jboss.logging.jboss-logging>3.4.2.Final</version.org.jboss.logging.jboss-logging>
     <version.org.jboss.resteasy>3.15.1.Final</version.org.jboss.resteasy>
     <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.1.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
     <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>2.0.1.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>
-    <version.org.jboss.weld.weld>3.1.7.SP1</version.org.jboss.weld.weld>
+    <version.org.jboss.weld.weld>3.1.8.Final</version.org.jboss.weld.weld>
     <version.org.keycloak>12.0.4</version.org.keycloak>
-    <version.org.mockito>3.11.1</version.org.mockito>
+    <version.org.mockito>3.11.2</version.org.mockito>
     <version.org.mvel>2.4.12.Final</version.org.mvel>
     <version.org.picketbox>5.1.0.Final</version.org.picketbox>
     <version.org.reflections>0.9.11</version.org.reflections>
-    <version.org.slf4j>1.7.30</version.org.slf4j>
-    <version.org.testcontainers>1.15.3</version.org.testcontainers>
+    <version.org.slf4j>1.7.32</version.org.slf4j>
+    <version.org.testcontainers>1.16.0</version.org.testcontainers>
     <version.io.netty>4.1.65.Final</version.io.netty>
     <version.io.swagger>1.6.2</version.io.swagger>
     <version.xmlunit>1.6</version.xmlunit>
     <version.io.vertx>3.9.8</version.io.vertx>
-    <version.net.openhft>0.12</version.net.openhft>
+    <version.net.openhft>0.15</version.net.openhft>
     <version.com.ibm.icu4j>69.1</version.com.ibm.icu4j>
-    <version.com.hazelcast>4.2</version.com.hazelcast>
+    <version.com.hazelcast>4.2.1</version.com.hazelcast>
     <version.com.jcbai>1.17.6</version.com.jcbai>
     <version.org.skyscreamer.jsonassert>1.5.0</version.org.skyscreamer.jsonassert>
     <version.org.redisson>3.15.6</version.org.redisson>

--- a/tools/i18n/pom.xml
+++ b/tools/i18n/pom.xml
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.13.1</version>
+      <version>1.14.1</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
Bumps `version.org.elasticsearch` from 7.13.2 to 7.13.4.

Updates `elasticsearch` from 7.13.2 to 7.13.4
- [Release notes](https://github.com/elastic/elasticsearch/releases)
- [Commits](https://github.com/elastic/elasticsearch/compare/v7.13.2...v7.13.4)

Updates `elasticsearch-rest-high-level-client` from 7.13.2 to 7.13.4
- [Release notes](https://github.com/elastic/elasticsearch/releases)
- [Commits](https://github.com/elastic/elasticsearch/compare/v7.13.2...v7.13.4)

---
updated-dependencies:
- dependency-name: org.elasticsearch:elasticsearch
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.elasticsearch.client:elasticsearch-rest-high-level-client
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump version.org.slf4j from 1.7.30 to 1.7.32 in /parent

Bumps `version.org.slf4j` from 1.7.30 to 1.7.32.

Updates `slf4j-api` from 1.7.30 to 1.7.32
- [Release notes](https://github.com/qos-ch/slf4j/releases)
- [Commits](https://github.com/qos-ch/slf4j/commits)

Updates `slf4j-log4j12` from 1.7.30 to 1.7.32
- [Release notes](https://github.com/qos-ch/slf4j/releases)
- [Commits](https://github.com/qos-ch/slf4j/commits)

---
updated-dependencies:
- dependency-name: org.slf4j:slf4j-api
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.slf4j:slf4j-log4j12
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump version.org.hibernate in /parent

Bumps `version.org.hibernate` from 5.5.2.Final to 5.5.4.Final.

Updates `hibernate-core` from 5.5.2.Final to 5.5.4.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/main/changelog.txt)
- [Commits](https://github.com/hibernate/hibernate-orm/compare/5.5.2...5.5.4)

Updates `hibernate-entitymanager` from 5.5.2.Final to 5.5.4.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/main/changelog.txt)
- [Commits](https://github.com/hibernate/hibernate-orm/compare/5.5.2...5.5.4)

---
updated-dependencies:
- dependency-name: org.hibernate:hibernate-core
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.hibernate:hibernate-entitymanager
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump version.org.jboss.weld.weld in /parent

Bumps `version.org.jboss.weld.weld` from 3.1.7.SP1 to 3.1.8.Final.

Updates `weld-se-core` from 3.1.7.SP1 to 3.1.8.Final

Updates `weld-servlet-core` from 3.1.7.SP1 to 3.1.8.Final

---
updated-dependencies:
- dependency-name: org.jboss.weld.se:weld-se-core
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.jboss.weld.servlet:weld-servlet-core
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump commons-io from 2.10.0 to 2.11.0 in /parent

Bumps commons-io from 2.10.0 to 2.11.0.

---
updated-dependencies:
- dependency-name: commons-io:commons-io
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump ant from 1.10.10 to 1.10.11 in /parent

Bumps ant from 1.10.10 to 1.10.11.

---
updated-dependencies:
- dependency-name: org.apache.ant:ant
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump jsoup from 1.13.1 to 1.14.1

Bumps [jsoup](https://github.com/jhy/jsoup) from 1.13.1 to 1.14.1.
- [Release notes](https://github.com/jhy/jsoup/releases)
- [Changelog](https://github.com/jhy/jsoup/blob/master/CHANGES)
- [Commits](https://github.com/jhy/jsoup/compare/jsoup-1.13.1...jsoup-1.14.1)

---
updated-dependencies:
- dependency-name: org.jsoup:jsoup
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump hazelcast from 4.2 to 4.2.1 in /parent

Bumps [hazelcast](https://github.com/hazelcast/hazelcast) from 4.2 to 4.2.1.
- [Release notes](https://github.com/hazelcast/hazelcast/releases)
- [Commits](https://github.com/hazelcast/hazelcast/compare/v4.2...v4.2.1)

---
updated-dependencies:
- dependency-name: com.hazelcast:hazelcast
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump version.com.fasterxml.jackson in /parent

Bumps `version.com.fasterxml.jackson` from 2.12.3 to 2.12.4.

Updates `jackson-annotations` from 2.12.3 to 2.12.4
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `jackson-core` from 2.12.3 to 2.12.4
- [Release notes](https://github.com/FasterXML/jackson-core/releases)
- [Commits](https://github.com/FasterXML/jackson-core/compare/jackson-core-2.12.3...jackson-core-2.12.4)

Updates `jackson-databind` from 2.12.3 to 2.12.4
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `jackson-dataformat-yaml` from 2.12.3 to 2.12.4
- [Release notes](https://github.com/FasterXML/jackson-dataformats-text/releases)
- [Commits](https://github.com/FasterXML/jackson-dataformats-text/compare/jackson-dataformats-text-2.12.3...jackson-dataformats-text-2.12.4)

Updates `jackson-dataformat-xml` from 2.12.3 to 2.12.4
- [Release notes](https://github.com/FasterXML/jackson-dataformat-xml/releases)
- [Commits](https://github.com/FasterXML/jackson-dataformat-xml/compare/jackson-dataformat-xml-2.12.3...jackson-dataformat-xml-2.12.4)

---
updated-dependencies:
- dependency-name: com.fasterxml.jackson.core:jackson-annotations
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: com.fasterxml.jackson.core:jackson-core
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: com.fasterxml.jackson.core:jackson-databind
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: com.fasterxml.jackson.dataformat:jackson-dataformat-yaml
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: com.fasterxml.jackson.dataformat:jackson-dataformat-xml
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump api-all from 2.0.1 to 2.1.0 in /parent

Bumps [api-all](https://github.com/apache/directory-ldap-api) from 2.0.1 to 2.1.0.
- [Release notes](https://github.com/apache/directory-ldap-api/releases)
- [Commits](https://github.com/apache/directory-ldap-api/compare/2.0.1...2.1.0)

---
updated-dependencies:
- dependency-name: org.apache.directory.api:api-all
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump mockito-core from 3.11.1 to 3.11.2 in /parent

Bumps [mockito-core](https://github.com/mockito/mockito) from 3.11.1 to 3.11.2.
- [Release notes](https://github.com/mockito/mockito/releases)
- [Commits](https://github.com/mockito/mockito/compare/v3.11.1...v3.11.2)

---
updated-dependencies:
- dependency-name: org.mockito:mockito-core
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump zero-allocation-hashing from 0.12 to 0.15 in /parent

Bumps [zero-allocation-hashing](https://github.com/OpenHFT/Zero-Allocation-Hashing) from 0.12 to 0.15.
- [Release notes](https://github.com/OpenHFT/Zero-Allocation-Hashing/releases)
- [Commits](https://github.com/OpenHFT/Zero-Allocation-Hashing/compare/zero-allocation-hashing-0.12...zero-allocation-hashing-0.15)

---
updated-dependencies:
- dependency-name: net.openhft:zero-allocation-hashing
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>