### PR TITLE
test: fix improper init of ManagerRestTester JUnit testrunner causing Sys props to overwrite one another

### DIFF
--- a/manager/api/core/src/test/java/io/apiman/manager/api/core/plugin/AbstractPluginRegistryTest.java
+++ b/manager/api/core/src/test/java/io/apiman/manager/api/core/plugin/AbstractPluginRegistryTest.java
@@ -61,7 +61,7 @@ public class AbstractPluginRegistryTest {
         }
 
         /**
-         * @see io.apiman.manager.api.core.plugin.AbstractPluginRegistry#downloadFromMavenRepo(java.io.File, io.apiman.common.plugin.PluginCoordinates, java.net.URL)
+         * @see io.apiman.manager.api.core.plugin.AbstractPluginRegistry#downloadFromMavenRepo(File, PluginCoordinates, URI) (java.io.File, io.apiman.common.plugin.PluginCoordinates, java.net.URL)
          */
         @Override
         protected boolean downloadFromMavenRepo(File pluginFile, PluginCoordinates coordinates,

--- a/manager/test/api/src/main/java/io/apiman/manager/test/junit/ManagerRestTester.java
+++ b/manager/test/api/src/main/java/io/apiman/manager/test/junit/ManagerRestTester.java
@@ -74,8 +74,13 @@ public class ManagerRestTester extends ParentRunner<TestInfo> {
      */
     public ManagerRestTester(Class<?> testClass) throws InitializationError {
         super(testClass);
+        loadTestPlans(super.getTestClass().getJavaClass());
+    }
+
+    @Override
+    protected Statement withBeforeClasses(Statement statement) {
         configureSystemProperties();
-        loadTestPlans(testClass);
+        return super.withBeforeClasses(statement);
     }
 
     /**
@@ -372,7 +377,7 @@ public class ManagerRestTester extends ParentRunner<TestInfo> {
     }
 
     /**
-     * Configure some proeprties.
+     * Configure some properties.
      */
     private void configureSystemProperties() {
         TestUtil.setProperty("apiman.test.gateway.endpoint", "http://localhost:" + getTestServerPort() + "/mock-gateway");
@@ -400,6 +405,7 @@ public class ManagerRestTester extends ParentRunner<TestInfo> {
      */
     private void resetSystemProperties() {
         for (String propName : resetSysProps) {
+            log("Clearing system property " + propName);
             System.clearProperty(propName);
         }
         resetSysProps.clear();

--- a/manager/test/api/src/main/java/io/apiman/manager/test/server/ApiManagerTestPluginRegistry.java
+++ b/manager/test/api/src/main/java/io/apiman/manager/test/server/ApiManagerTestPluginRegistry.java
@@ -21,6 +21,7 @@ import io.apiman.manager.api.core.plugin.AbstractPluginRegistry;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 
 import javax.enterprise.context.ApplicationScoped;
 
@@ -71,6 +72,18 @@ public class ApiManagerTestPluginRegistry extends AbstractPluginRegistry {
             return;
         }
         File testM2Dir = new File(testM2Path).getAbsoluteFile();
+
+        if (!testM2Dir.exists()) {
+            // Try to resolve via resources
+            testM2Dir = toAbsolutePathFromResources(testM2Path);
+
+            // If still no good, then...
+            if (!testM2Dir.exists()) {
+                System.err.println("apiman.test.m2-path is set as " + testM2Path +
+                    " but it does not seem to exist on the filesystem or Java resources");
+            }
+        }
+
         File pluginArtifactFile = new File(testM2Dir, PluginUtils.getMavenPath(coordinates));
         if (!pluginArtifactFile.isFile()) {
             return;
@@ -80,6 +93,11 @@ public class ApiManagerTestPluginRegistry extends AbstractPluginRegistry {
         } catch (IOException e) {
             pluginArtifactFile.delete();
         }
+    }
+
+    private static File toAbsolutePathFromResources(String resourcePath) {
+        URL resourceURL = ApiManagerTestPluginRegistry.class.getResource(resourcePath);
+        return FileUtils.toFile(resourceURL);
     }
 
 }

--- a/manager/test/api/src/test/java/io/apiman/manager/test/PluginsTest.java
+++ b/manager/test/api/src/test/java/io/apiman/manager/test/PluginsTest.java
@@ -30,11 +30,11 @@ import org.junit.runner.RunWith;
 @RunWith(ManagerRestTester.class)
 @ManagerRestTestPlan("test-plans/plugins-testPlan.xml")
 @RestTestSystemProperties({
-    "apiman.test.m2-path", "src/test/resources/test-plan-data/plugins/m2"
+    "apiman.test.m2-path", "/test-plan-data/plugins/m2"
 })
 @SuppressWarnings("nls")
 public class PluginsTest {
-    
+
     @BeforeClass
     public static void setup() {
         System.setProperty("apiman-manager.plugins.registries", PluginsTest.class.getResource("test-registry.json").toString());

--- a/manager/test/api/src/test/resources/test-plans/plugins-testPlan.xml
+++ b/manager/test/api/src/test/resources/test-plans/plugins-testPlan.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan">
+<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan" name="Test Apiman plugins">
 
   <!-- Make sure Plugins are working properly -->
   <testGroup name="Plugin Management">


### PR DESCRIPTION
… 

As I discovered through a tortuous process, multiple ManagerRestTester JUnit testrunner instances
were being initialised simultaneously. This meant that the code to set environment variables via
`@RestTestSystemProperties`, which is triggered in the constructor, was running in each
ManagerRestTester instance one after another(long before the test code ran). Hence, the environment
variables were overriding each other in surprising and confusing ways (i.e. dependent on
not-entirely-deterministic ordering).

This was compounded by (for whatever reason) CI running the tests in a different order to everyone
else's dev setup, which took a while to notice.

As a bonus, `@RestTestSystemProperties` can now be a reference to a Java resource instead of just a
file. If the file lookup fails, it will try the resource. If nothing is found, a message will be
printed to help diagnose any issues in this area.