### PR TITLE
fix(manager-api): policyDefinitionTemplate missing #equals and #hashCode

### DIFF
--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/policies/PolicyDefinitionTemplateBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/policies/PolicyDefinitionTemplateBean.java
@@ -15,6 +15,7 @@
  */
 package io.apiman.manager.api.beans.policies;
 
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
@@ -76,4 +77,20 @@ public class PolicyDefinitionTemplateBean {
         return "PolicyDefinitionTemplateBean [language=" + language + ", template=" + template + "]";
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PolicyDefinitionTemplateBean that = (PolicyDefinitionTemplateBean) o;
+        return Objects.equals(language, that.language) && Objects.equals(template, that.template);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(language, template);
+    }
 }

--- a/manager/api/es/src/test/java/io/apiman/manager/api/es/EsMarshallingTest.java
+++ b/manager/api/es/src/test/java/io/apiman/manager/api/es/EsMarshallingTest.java
@@ -40,6 +40,16 @@ import io.apiman.manager.api.beans.summary.PolicyFormType;
 import io.apiman.manager.api.beans.system.MetadataBean;
 import io.apiman.manager.api.es.beans.ApiDefinitionBean;
 import io.apiman.manager.api.es.beans.PoliciesBean;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Type;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.beanutils.BeanUtilsBean;
 import org.apache.commons.lang3.StringUtils;
@@ -47,11 +57,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Type;
-import java.util.*;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -256,7 +261,7 @@ public class EsMarshallingTest {
     public void testMarshallPolicyDefinitionBean() throws Exception {
         PolicyDefinitionBean bean = createBean(PolicyDefinitionBean.class);
         XContentBuilder builder = EsMarshalling.marshall(bean);
-        Assert.assertEquals("{\"id\":\"ID\",\"name\":\"NAME\",\"description\":\"DESCRIPTION\",\"form\":\"FORM\",\"formType\":\"Default\",\"icon\":\"ICON\",\"pluginId\":17,\"policyImpl\":\"POLICYIMPL\",\"deleted\":false,\"templates\":[{\"language\":\"LANGUAGE\",\"template\":\"TEMPLATE\"},{\"language\":\"LANGUAGE\",\"template\":\"TEMPLATE\"}]}", Strings.toString(builder));
+        Assert.assertEquals("{\"id\":\"ID\",\"name\":\"NAME\",\"description\":\"DESCRIPTION\",\"form\":\"FORM\",\"formType\":\"Default\",\"icon\":\"ICON\",\"pluginId\":17,\"policyImpl\":\"POLICYIMPL\",\"deleted\":false,\"templates\":[{\"language\":\"LANGUAGE\",\"template\":\"TEMPLATE\"}]}", Strings.toString(builder));
     }
 
     /**


### PR DESCRIPTION
PolicyDefinitionTemplate is referenced in a Set from PolicyDefinitionBean.
The lack of #equals and #hashCode can cause Hibernate to duplicate the templates and write them back to the the database under certain circumstances.

Once the bug is triggered, the templates will often double in size on each occasion, which causes exponential growth.

Fixes: #1566