### PR TITLE
fix(manager-api-jpa): include API version in query fetching API definition

### DIFF
--- a/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/JpaStorage.java
+++ b/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/JpaStorage.java
@@ -1168,13 +1168,18 @@ public class JpaStorage extends AbstractJpaStorage implements IStorage, IStorage
      * @see io.apiman.manager.api.core.IStorage#getApiDefinition(String, String, String)
      */
     @Override
-    public InputStream getApiDefinition(String orgId, String apiId, String version) throws StorageException {
+    public InputStream getApiDefinition(String orgId, String apiId, String apiVersion) throws StorageException {
         try {
             EntityManager entityManager = getActiveEntityManager();
-            String jpql = "SELECT v from ApiDefinitionBean v JOIN v.apiVersion av JOIN av.api api WHERE api.id = :apiId";
-            Query query = entityManager.createQuery(jpql);
-            query.setParameter("apiId", apiId);
-            ApiDefinitionBean apiDef = (ApiDefinitionBean) query.getSingleResult();
+            String jpql = "SELECT v from ApiDefinitionBean v "
+                                  + "JOIN v.apiVersion av "
+                                  + "JOIN av.api api "
+                                  + "WHERE api.id = :apiId "
+                                  + "AND av.version = :apiVersion";
+            TypedQuery<ApiDefinitionBean> query = entityManager.createQuery(jpql, ApiDefinitionBean.class)
+                    .setParameter("apiId", apiId)
+                    .setParameter("apiVersion", apiVersion);
+            ApiDefinitionBean apiDef = query.getSingleResult();
             return new ByteArrayInputStream(apiDef.getData());
         } catch (NoResultException e) {
             return null;


### PR DESCRIPTION
The #getApiDefinition JPA query used in export was mistakenly missing the API version part of the
WHERE/AND predicate. This meant that if two different API versions had schemas attached, then the
query would return multiple entries.

Fixes #1567