### PR TITLE
feat(ui): add notifications to sidebar

### DIFF
--- a/manager/ui/war/plugins/api-manager/html/headers/community.include
+++ b/manager/ui/war/plugins/api-manager/html/headers/community.include
@@ -194,6 +194,15 @@
                     </ul>
                 </div>
             </li>
+             <!--Notifications-->
+            <li class="list-group-item" data-target="#admin-secondary">
+                <a href="{{ pluginName }}/notifications">
+                    <span class="fa fa-bell" data-toggle="tooltip" title="Notifications"></span>
+                    <span class="list-group-item-value" apiman-i18n-key="notifications">Notifications
+                        <span ng-show="userNotificationCount > 0">{{ '(' + userNotificationCount + ')'}}</span>
+                    </span>
+                </a>
+            </li>
         </ul>
     </div>
 </div>


### PR DESCRIPTION
Link to notifications page also placed in sidebar
Number of notifications is displayed if greater than 0

![notifications_sidebar](https://user-images.githubusercontent.com/19830745/142372069-a5b6869a-83f8-4cd4-88bc-5e781d349a03.png)

Closes: #1635