### PR TITLE
feat(manager-api-notifications): add i18n support for notifications

### DIFF
--- a/common/util/src/main/java/io/apiman/common/util/AbstractMessages.java
+++ b/common/util/src/main/java/io/apiman/common/util/AbstractMessages.java
@@ -33,15 +33,23 @@ import java.util.TreeMap;
  */
 public class AbstractMessages {
 
-    private static final List<String> FORMATS = Collections.unmodifiableList(Collections.singletonList("java.properties")); //$NON-NLS-1$
+    private static final List<String> FORMATS = Collections.singletonList("java.properties"); //$NON-NLS-1$
 
-    private static Map<String, ResourceBundle> bundles = new HashMap<>();
+    private static final Map<String, ResourceBundle> bundles = new HashMap<>();
 
-    private Class<? extends AbstractMessages> clazz;
-    private static ThreadLocal<Locale> tlocale = new ThreadLocal<>();
+    private final Class<? extends AbstractMessages> clazz;
+    private static final ThreadLocal<Locale> tlocale = new ThreadLocal<>();
+
+    /**
+     * Set the message locale.
+     */
     public static void setLocale(Locale locale) {
         tlocale.set(locale);
     }
+
+    /**
+     * Clear the message locale.
+     */
     public static void clearLocale() {
         tlocale.set(null);
     }
@@ -98,7 +106,7 @@ public class AbstractMessages {
      * thread local value, if set, or else the system default locale.
      * @return the locale
      */
-    public Locale getLocale() {
+    public static Locale getLocale() {
         if (tlocale.get() != null) {
             return tlocale.get();
         } else {

--- a/common/util/src/main/java/io/apiman/common/util/JsonUtil.java
+++ b/common/util/src/main/java/io/apiman/common/util/JsonUtil.java
@@ -2,6 +2,7 @@ package io.apiman.common.util;
 
 import java.io.UncheckedIOException;
 import java.util.Collection;
+import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -9,11 +10,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
+import com.fasterxml.jackson.databind.type.MapType;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import org.checkerframework.checker.units.qual.K;
 
 import static com.fasterxml.jackson.core.json.JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER;
 import static com.fasterxml.jackson.core.json.JsonReadFeature.ALLOW_JAVA_COMMENTS;
@@ -72,11 +75,28 @@ public class JsonUtil {
         }
     }
 
+    public static <T> T toPojo(String payload, Class<T> klazz) {
+        try {
+            return OM.readValue(payload, klazz);
+        } catch (JsonProcessingException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
     @SuppressWarnings("unchecked")
     public static <T, C extends Collection<T>> C toPojo(String payload, Class<T> klazz, Class<? extends Collection> collectionKlazz) {
         try {
             CollectionType type = OM.getTypeFactory().constructCollectionType(collectionKlazz, klazz);
             return (C) OM.readValue(payload, type);
+        } catch (JsonProcessingException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static <K, V, C extends Map<K, V>> C toPojo(String payload, Class<K> keyKlazz, Class<V> objectKlazz, Class<? extends Map> mapKlazz) {
+        try {
+            MapType type = OM.getTypeFactory().constructMapType(mapKlazz, keyKlazz, objectKlazz);
+            return OM.readValue(payload, type);
         } catch (JsonProcessingException e) {
             throw new UncheckedIOException(e);
         }

--- a/distro/data/src/main/resources/ddls/apiman_h2.ddl
+++ b/distro/data/src/main/resources/ddls/apiman_h2.ddl
@@ -362,3 +362,5 @@ ALTER TABLE api_tag ADD CONSTRAINT FK2h64maqscweorti1hta9josl2 FOREIGN KEY (tag_
 -- Changeset src/main/liquibase/current/20211002-154432-apiman3-dev-portal-2-initial.changelog.xml::1633542267834-16::msavy (generated)
 ALTER TABLE api_tag ADD CONSTRAINT FKlpr8yu65omneju5297uqthb6k FOREIGN KEY (api_id, org_id) REFERENCES apis (id, organization_id);
 
+-- Changeset src/main/liquibase/current/20211206-add-locale-to-user-profile.xml::add-locale-to-use-profile::msavy marc@blackparrotlabs.io (manual changeset)
+ALTER TABLE users ADD locale VARCHAR(255);

--- a/distro/data/src/main/resources/ddls/apiman_mssql15.ddl
+++ b/distro/data/src/main/resources/ddls/apiman_mssql15.ddl
@@ -474,3 +474,6 @@ ALTER TABLE api_tag ADD CONSTRAINT FK2h64maqscweorti1hta9josl2 FOREIGN KEY (tag_
 ALTER TABLE api_tag ADD CONSTRAINT FKlpr8yu65omneju5297uqthb6k FOREIGN KEY (api_id, org_id) REFERENCES apis (id, organization_id)
     GO
 
+-- Changeset src/main/liquibase/current/20211206-add-locale-to-user-profile.xml::add-locale-to-use-profile::msavy marc@blackparrotlabs.io (manual changeset)
+ALTER TABLE users ADD locale varchar(255)
+    GO

--- a/distro/data/src/main/resources/ddls/apiman_mysql8.ddl
+++ b/distro/data/src/main/resources/ddls/apiman_mysql8.ddl
@@ -360,3 +360,5 @@ ALTER TABLE api_tag ADD CONSTRAINT FK2h64maqscweorti1hta9josl2 FOREIGN KEY (tag_
 --  Changeset src/main/liquibase/current/20211002-154432-apiman3-dev-portal-2-initial.changelog.xml::1633542267834-16::msavy (generated)
 ALTER TABLE api_tag ADD CONSTRAINT FKlpr8yu65omneju5297uqthb6k FOREIGN KEY (api_id, org_id) REFERENCES apis (id, organization_id);
 
+--  Changeset src/main/liquibase/current/20211206-add-locale-to-user-profile.xml::add-locale-to-use-profile::msavy marc@blackparrotlabs.io (manual changeset)
+ALTER TABLE users ADD locale VARCHAR(255) NULL;

--- a/distro/data/src/main/resources/ddls/apiman_oracle19.ddl
+++ b/distro/data/src/main/resources/ddls/apiman_oracle19.ddl
@@ -355,3 +355,5 @@ ALTER TABLE api_tag ADD CONSTRAINT FK2h64maqscweorti1hta9josl2 FOREIGN KEY (tag_
 -- Changeset src/main/liquibase/current/20211002-154432-apiman3-dev-portal-2-initial.changelog.xml::1633542267834-16::msavy (generated)
 ALTER TABLE api_tag ADD CONSTRAINT FKlpr8yu65omneju5297uqthb6k FOREIGN KEY (api_id, org_id) REFERENCES apis (id, organization_id);
 
+-- Changeset src/main/liquibase/current/20211206-add-locale-to-user-profile.xml::add-locale-to-use-profile::msavy marc@blackparrotlabs.io (manual changeset)
+ALTER TABLE users ADD locale VARCHAR2(255);

--- a/distro/data/src/main/resources/ddls/apiman_postgresql9.ddl
+++ b/distro/data/src/main/resources/ddls/apiman_postgresql9.ddl
@@ -358,6 +358,9 @@ ALTER TABLE api_tag ADD CONSTRAINT "FK2h64maqscweorti1hta9josl2" FOREIGN KEY (ta
 -- Changeset src/main/liquibase/current/20211002-154432-apiman3-dev-portal-2-initial.changelog.xml::1633542267834-16::msavy (generated)
 ALTER TABLE api_tag ADD CONSTRAINT "FKlpr8yu65omneju5297uqthb6k" FOREIGN KEY (api_id, org_id) REFERENCES apis (id, organization_id);
 
+-- Changeset src/main/liquibase/current/20211206-add-locale-to-user-profile.xml::add-locale-to-use-profile::msavy marc@blackparrotlabs.io (manual changeset)
+ALTER TABLE users ADD locale VARCHAR(255);
+
 -- Manual bits
 CREATE OR REPLACE FUNCTION inttobool(num int, val bool) RETURNS bool AS '
     BEGIN

--- a/distro/ddl/src/main/liquibase/current/20211206-add-locale-to-user-profile.xml
+++ b/distro/ddl/src/main/liquibase/current/20211206-add-locale-to-user-profile.xml
@@ -1,0 +1,8 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet id="add-locale-to-use-profile" author="msavy marc@blackparrotlabs.io (manual changeset)">
+        <addColumn tableName="users">
+            <column name="locale" type="VARCHAR(255)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/distro/tomcat/src/main/resources/overlay/conf/apiman.properties
+++ b/distro/tomcat/src/main/resources/overlay/conf/apiman.properties
@@ -60,6 +60,9 @@ apiman-manager-ui.org-create-admin-only=false
 # Set the option to true if the response of the manager rest api should contain stacktraces
 apiman-manager.config.features.rest-response-should-contain-stacktraces=false
 
+# Enable or disable the Apiman notifications subsystem.
+apiman-manager.config.notifications.enable=true
+
 # API Manager storage settings.
 apiman-manager.storage.type=jpa
 apiman-manager.storage.jpa.initialize=true

--- a/distro/tomcat/src/main/resources/overlay/conf/email-notification-templates.json
+++ b/distro/tomcat/src/main/resources/overlay/conf/email-notification-templates.json
@@ -1,0 +1,10 @@
+{
+  "en": {
+    "apiman.account.signup.approval.request": {
+      "subject": "Action required: New account signup {event.userId} needs activation",
+      "htmlBody": "Hi {notification.recipient.fullName}",
+      "plainBody": "Hi {notification.recipient.fullName}",
+      "category": "USER_ADMINISTRATION"
+    }
+  }
+}

--- a/distro/wildfly/src/main/resources/overlay/standalone/configuration/apiman.properties
+++ b/distro/wildfly/src/main/resources/overlay/standalone/configuration/apiman.properties
@@ -60,6 +60,9 @@ apiman-manager-ui.org-create-admin-only=false
 # Set the option to true if the response of the manager rest api should contain stacktraces
 apiman-manager.config.features.rest-response-should-contain-stacktraces=false
 
+# Enable or disable the Apiman notifications subsystem.
+apiman-manager.config.notifications.enable=true
+
 # API Manager storage settings.
 apiman-manager.storage.type=jpa
 apiman-manager.storage.jpa.initialize=true

--- a/distro/wildfly/src/main/resources/overlay/standalone/configuration/email-notification-templates.json
+++ b/distro/wildfly/src/main/resources/overlay/standalone/configuration/email-notification-templates.json
@@ -1,0 +1,10 @@
+{
+  "en": {
+    "apiman.account.signup.approval.request": {
+      "subject": "Action required: New account signup {event.userId} needs activation",
+      "htmlBody": "Hi {notification.recipient.fullName}",
+      "plainBody": "Hi {notification.recipient.fullName}",
+      "category": "USER_ADMINISTRATION"
+    }
+  }
+}

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apis/ApiVersionBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apis/ApiVersionBean.java
@@ -125,8 +125,7 @@ public class ApiVersionBean implements Serializable, Cloneable {
     @Nationalized
     @Lob // <-- may not be necessary? // varchar -> nvarchar
     private String extendedDescription; // Markdown extended description
-    //@ElementCollection
-    //Set<ApiFeatureEntity> keyFeatures;
+
     /**
      * Constructor.
      */

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/CurrentUserBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/CurrentUserBean.java
@@ -57,6 +57,7 @@ public class CurrentUserBean extends UserBean {
         setFullName(user.getFullName());
         setJoinedOn(user.getJoinedOn());
         setUsername(user.getUsername());
+        setLocale(user.getLocale());
     }
 
     /* (non-Javadoc)

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/UpdateUserBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/UpdateUserBean.java
@@ -17,6 +17,8 @@
 package io.apiman.manager.api.beans.idm;
 
 import java.io.Serializable;
+import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * The bean used when updating a user.
@@ -29,6 +31,7 @@ public class UpdateUserBean implements Serializable {
 
     private String fullName;
     private String email;
+    private String locale;
 
     /**
      * Constructor.
@@ -64,12 +67,47 @@ public class UpdateUserBean implements Serializable {
         this.email = email;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
+    /**
+     * @return the preferred locale
      */
+    public String getLocale() {
+        return locale;
+    }
+
+    /**
+     * This should be a valid IANA language subtag (e.g. en, en-GB, de, etc).
+     *
+     * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Locale.html">Java Locale</a>
+     * @see <a href="https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry">IANA subtag registry</a>
+     * @param locale the user's preferred locale
+     */
+    public void setLocale(String locale) {
+        this.locale = locale;
+    }
+
     @Override
-    @SuppressWarnings("nls")
     public String toString() {
-        return "UpdateUserBean [fullName=" + fullName + ", email=" + email + "]";
+        return new StringJoiner(", ", UpdateUserBean.class.getSimpleName() + "[", "]")
+                .add("fullName='" + fullName + "'")
+                .add("email='" + email + "'")
+                .add("locale='" + locale + "'")
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UpdateUserBean that = (UpdateUserBean) o;
+        return Objects.equals(fullName, that.fullName) && Objects.equals(email, that.email) && Objects.equals(locale, that.locale);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fullName, email, locale);
     }
 }

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/UserBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/UserBean.java
@@ -18,7 +18,7 @@ package io.apiman.manager.api.beans.idm;
 
 import java.io.Serializable;
 import java.util.Date;
-
+import java.util.Locale;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -41,9 +41,12 @@ public class UserBean implements Serializable {
     private String username;
     @Column(name = "full_name")
     private String fullName;
+    @Column(name = "email")
     private String email;
     @Column(name = "joined_on", updatable=false)
     private Date joinedOn;
+    @Column(name = "locale") // TODO: maybe should be required and we can fix through import migration?
+    private String locale;
 
     // Used only when returning information about the current user
     @Transient
@@ -154,6 +157,27 @@ public class UserBean implements Serializable {
      */
     public void setAdmin(boolean admin) {
         this.admin = admin;
+    }
+
+    /**
+     * Get locale language tag
+     *
+     * @see Locale#toLanguageTag()
+     * @return the locale
+     */
+    public String getLocale() {
+        return locale;
+    }
+
+    /**
+     * Set locale
+     *
+     * @param locale the locale language tag
+     * @see Locale#toLanguageTag()
+     */
+    public UserBean setLocale(String locale) {
+        this.locale = locale;
+        return this;
     }
 
     /* (non-Javadoc)

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/UserBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/UserBean.java
@@ -19,6 +19,7 @@ package io.apiman.manager.api.beans.idm;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Locale;
+import java.util.StringJoiner;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -175,18 +176,19 @@ public class UserBean implements Serializable {
      * @param locale the locale language tag
      * @see Locale#toLanguageTag()
      */
-    public UserBean setLocale(String locale) {
+    public void setLocale(String locale) {
         this.locale = locale;
-        return this;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
-    @SuppressWarnings("nls")
     public String toString() {
-        return "UserBean [username=" + username + ", fullName=" + fullName + ", email=" + email
-                + ", joinedOn=" + joinedOn + ", admin=" + admin + "]";
+        return new StringJoiner(", ", UserBean.class.getSimpleName() + "[", "]")
+                .add("username='" + username + "'")
+                .add("fullName='" + fullName + "'")
+                .add("email='" + email + "'")
+                .add("joinedOn=" + joinedOn)
+                .add("locale='" + locale + "'")
+                .add("admin=" + admin)
+                .toString();
     }
 }

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/UserDto.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/idm/UserDto.java
@@ -1,5 +1,6 @@
 package io.apiman.manager.api.beans.idm;
 
+import java.util.Locale;
 import java.util.Objects;
 import java.util.StringJoiner;
 import javax.validation.constraints.NotBlank;
@@ -16,6 +17,8 @@ public class UserDto {
     private String fullName;
     @NotBlank
     private String email;
+    @NotBlank
+    private Locale locale = Locale.getDefault();
 
     public UserDto() {
     }
@@ -56,6 +59,15 @@ public class UserDto {
         return this;
     }
 
+    public Locale getLocale() {
+        return locale;
+    }
+
+    public UserDto setLocale(Locale locale) {
+        this.locale = locale;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -76,10 +88,11 @@ public class UserDto {
     @Override
     public String toString() {
         return new StringJoiner(", ", UserDto.class.getSimpleName() + "[", "]")
-             .add("id='" + id + "'")
-             .add("username='" + username + "'")
-             .add("fullName='" + fullName + "'")
-             .add("email='" + email + "'")
-             .toString();
+                .add("id='" + id + "'")
+                .add("username='" + username + "'")
+                .add("fullName='" + fullName + "'")
+                .add("email='" + email + "'")
+                .add("locale=" + locale)
+                .toString();
     }
 }

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/notifications/EmailNotificationTemplate.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/notifications/EmailNotificationTemplate.java
@@ -23,6 +23,9 @@ public class EmailNotificationTemplate {
 
     // @Column(name = "notification_template_body", nullable = false, length = 10000)
     // @NotBlank
+
+    private String locale;
+
     private String htmlBody;
 
     private String plainBody;
@@ -93,6 +96,15 @@ public class EmailNotificationTemplate {
     public EmailNotificationTemplate setCategory(
          NotificationCategory category) {
         this.category = category;
+        return this;
+    }
+
+    public String getLocale() {
+        return locale;
+    }
+
+    public EmailNotificationTemplate setLocale(String locale) {
+        this.locale = locale;
         return this;
     }
 

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/SimpleEmail.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/SimpleEmail.java
@@ -5,6 +5,7 @@ import io.apiman.manager.api.beans.idm.UserDto;
 import io.apiman.manager.api.beans.notifications.EmailNotificationTemplate;
 
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
 import java.util.StringJoiner;
 import javax.validation.constraints.NotBlank;
@@ -23,14 +24,16 @@ import org.jetbrains.annotations.Nullable;
 public class SimpleEmail {
     private String toName;
     private String toEmail;
+    private Locale locale;
     private Map<String, String> headers;
     private EmailNotificationTemplate template;
     private Map<String, Object> templateVariables;
 
-    SimpleEmail(String toName, String toEmail, Map<String, String> headers, EmailNotificationTemplate template,
-         Map<String, Object> templateVariables) {
+    SimpleEmail(String toName, String toEmail, Locale locale, Map<String, String> headers, EmailNotificationTemplate template,
+                Map<String, Object> templateVariables) {
         this.toName = toName;
         this.toEmail = toEmail;
+        this.locale = locale;
         this.headers = headers;
         this.template = template;
         this.templateVariables = templateVariables;
@@ -58,6 +61,13 @@ public class SimpleEmail {
      */
     public String getToEmail() {
         return toEmail;
+    }
+
+    /**
+     * Get email locale (useful for i18n).
+     */
+    public Locale getLocale() {
+        return locale;
     }
 
     /**
@@ -99,6 +109,8 @@ public class SimpleEmail {
         @NotBlank
         private String toEmail;
         @NotNull
+        private Locale locale;
+        @NotNull
         private Map<String, String> headers = Collections.emptyMap();
         @NotNull
         private EmailNotificationTemplate template;
@@ -134,11 +146,20 @@ public class SimpleEmail {
             return this;
         }
 
+
         /**
          * Set email template.
          */
         public Builder setTemplate(EmailNotificationTemplate template) {
             this.template = template;
+            return this;
+        }
+
+        /**
+         * Locale to use for email (e.g. template i18n).
+         */
+        public Builder setLocale(Locale locale) {
+            this.locale = locale;
             return this;
         }
 
@@ -165,9 +186,10 @@ public class SimpleEmail {
             if (userDto != null) {
                 this.toName = userDto.getFullName();
                 this.toEmail = userDto.getEmail();
+                this.locale = userDto.getLocale();
             }
             beanValidate(this);
-            return new SimpleEmail(toName, toEmail, headers, template, templateVariables);
+            return new SimpleEmail(toName, toEmail, locale, headers, template, templateVariables);
         }
 
         @Override
@@ -175,6 +197,7 @@ public class SimpleEmail {
             return new StringJoiner(", ", Builder.class.getSimpleName() + "[", "]")
                  .add("toName='" + toName + "'")
                  .add("toEmail='" + toEmail + "'")
+                 .add("locale='" + locale + "'")
                  .add("headers=" + headers)
                  .add("template=" + template)
                  .add("templateVariables=" + templateVariables)

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/handlers/AccountSignupApprovalEmailNotification.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/handlers/AccountSignupApprovalEmailNotification.java
@@ -37,14 +37,15 @@ public class AccountSignupApprovalEmailNotification implements INotificationHand
         NotificationDto<AccountSignupEvent> signupNotification = (NotificationDto<AccountSignupEvent>) rawNotification;
         Map<String, Object> templateMap = buildTemplateMap(signupNotification);
 
-        EmailNotificationTemplate template = mailNotificationService
-             .findTemplateFor(signupNotification.getReason())
-             .or(() -> mailNotificationService.findTemplateFor(signupNotification.getCategory()))
-             .orElseThrow();
-
         // Beware, for this instance, the user might not actually exist in Apiman (yet or at all) as it could have come
         // from the underlying IDM -- be careful if calling for Apiman's members, etc.
         UserDto recipient = rawNotification.getRecipient();
+
+        EmailNotificationTemplate template = mailNotificationService
+             .findTemplateFor(signupNotification.getReason(), recipient.getLocale())
+             .or(() -> mailNotificationService.findTemplateFor(signupNotification.getCategory(), recipient.getLocale()))
+             .orElseThrow();
+
         var mail = SimpleEmail
              .builder()
              .setRecipient(recipient)

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/handlers/AccountSignupApprovalEmailNotification.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/handlers/AccountSignupApprovalEmailNotification.java
@@ -43,7 +43,6 @@ public class AccountSignupApprovalEmailNotification implements INotificationHand
 
         EmailNotificationTemplate template = mailNotificationService
              .findTemplateFor(signupNotification.getReason(), recipient.getLocale())
-             .or(() -> mailNotificationService.findTemplateFor(signupNotification.getCategory(), recipient.getLocale()))
              .orElseThrow();
 
         var mail = SimpleEmail

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/handlers/ClientAppRegisteredEmailNotification.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/handlers/ClientAppRegisteredEmailNotification.java
@@ -36,14 +36,13 @@ public class ClientAppRegisteredEmailNotification implements INotificationHandle
         NotificationDto<ClientVersionStatusEvent> notification = (NotificationDto<ClientVersionStatusEvent>) raw;
 
         Map<String, Object> templateMap = buildTemplateMap(notification);
-        ClientVersionStatusEvent event = notification.getPayload();
+        UserDto recipient = notification.getRecipient();
 
         EmailNotificationTemplate template = mailNotificationService
-             .findTemplateFor(notification.getReason())
-             .or(() -> mailNotificationService.findTemplateFor(notification.getCategory()))
+             .findTemplateFor(notification.getReason(), recipient.getLocale())
+             .or(() -> mailNotificationService.findTemplateFor(notification.getCategory(), recipient.getLocale()))
              .orElseThrow();
 
-        UserDto recipient = notification.getRecipient();
         var mail = SimpleEmail
              .builder()
              .setRecipient(recipient)

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/handlers/ClientAppRegisteredEmailNotification.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/handlers/ClientAppRegisteredEmailNotification.java
@@ -40,7 +40,6 @@ public class ClientAppRegisteredEmailNotification implements INotificationHandle
 
         EmailNotificationTemplate template = mailNotificationService
              .findTemplateFor(notification.getReason(), recipient.getLocale())
-             .or(() -> mailNotificationService.findTemplateFor(notification.getCategory(), recipient.getLocale()))
              .orElseThrow();
 
         var mail = SimpleEmail

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/handlers/ContractApprovalEmailNotification.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/handlers/ContractApprovalEmailNotification.java
@@ -36,7 +36,6 @@ public class ContractApprovalEmailNotification implements INotificationHandler {
 
         EmailNotificationTemplate template = mailNotificationService
              .findTemplateFor(notification.getReason(), recipient.getLocale())
-             .or(() -> mailNotificationService.findTemplateFor(notification.getCategory(), recipient.getLocale()))
              .orElseThrow();
 
         var mail = SimpleEmail

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/handlers/ContractApprovalEmailNotification.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/handlers/ContractApprovalEmailNotification.java
@@ -32,13 +32,13 @@ public class ContractApprovalEmailNotification implements INotificationHandler {
     public void handle(NotificationDto<? extends IVersionedApimanEvent> notif) {
         NotificationDto<ContractApprovalEvent> notification = (NotificationDto<ContractApprovalEvent>) notif;
         Map<String, Object> templateMap = buildTemplateMap(notification);
+        UserDto recipient = notification.getRecipient();
 
         EmailNotificationTemplate template = mailNotificationService
-             .findTemplateFor(notification.getReason())
-             .or(() -> mailNotificationService.findTemplateFor(notification.getCategory()))
+             .findTemplateFor(notification.getReason(), recipient.getLocale())
+             .or(() -> mailNotificationService.findTemplateFor(notification.getCategory(), recipient.getLocale()))
              .orElseThrow();
 
-        UserDto recipient = notification.getRecipient();
         var mail = SimpleEmail
              .builder()
              .setRecipient(recipient)

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/handlers/ContractApprovalRequestEmailNotification.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/handlers/ContractApprovalRequestEmailNotification.java
@@ -11,7 +11,6 @@ import io.apiman.manager.api.notifications.producers.ContractApprovalRequestNoti
 import io.apiman.manager.api.providers.eager.EagerLoaded;
 
 import java.util.Map;
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -20,7 +19,7 @@ import javax.inject.Inject;
  */
 @EagerLoaded
 @ApplicationScoped
-public class ContractApprovalRequestEmailNotification implements INotificationHandler  {
+public class ContractApprovalRequestEmailNotification implements INotificationHandler {
 
     private SimpleMailNotificationService mailNotificationService;
 
@@ -43,13 +42,13 @@ public class ContractApprovalRequestEmailNotification implements INotificationHa
     }
 
     private void approvalRequiredNotification(NotificationDto<ContractCreatedEvent> signupNotification) {
+        UserDto recipient = signupNotification.getRecipient();
         EmailNotificationTemplate template = mailNotificationService
-             .findTemplateFor(signupNotification.getReason())
-             .or(() -> mailNotificationService.findTemplateFor(signupNotification.getCategory()))
+             .findTemplateFor(signupNotification.getReason(), recipient.getLocale())
+             .or(() -> mailNotificationService.findTemplateFor(signupNotification.getCategory(), recipient.getLocale()))
              .orElseThrow();
 
         Map<String, Object> templateMap = buildTemplateMap(signupNotification);
-        UserDto recipient = signupNotification.getRecipient();
 
         var mail = SimpleEmail
              .builder()

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/handlers/ContractApprovalRequestEmailNotification.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/notifications/email/handlers/ContractApprovalRequestEmailNotification.java
@@ -45,7 +45,6 @@ public class ContractApprovalRequestEmailNotification implements INotificationHa
         UserDto recipient = signupNotification.getRecipient();
         EmailNotificationTemplate template = mailNotificationService
              .findTemplateFor(signupNotification.getReason(), recipient.getLocale())
-             .or(() -> mailNotificationService.findTemplateFor(signupNotification.getCategory(), recipient.getLocale()))
              .orElseThrow();
 
         Map<String, Object> templateMap = buildTemplateMap(signupNotification);

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/UserResourceImpl.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/UserResourceImpl.java
@@ -127,7 +127,9 @@ public class UserResourceImpl implements IUserResource, DataAccessUtilMixin {
                     user.setEmail(""); //$NON-NLS-1$
                 }
                 user.setJoinedOn(new Date());
-
+                if (securityContext.getLocale() != null && user.getLocale() != null) {
+                    user.setLocale(securityContext.getLocale().toLanguageTag());
+                }
                 storage.createUser(user);
                 userBootstrapper.bootstrapUser(user, storage);
 

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/UserResourceImpl.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/UserResourceImpl.java
@@ -127,7 +127,7 @@ public class UserResourceImpl implements IUserResource, DataAccessUtilMixin {
                     user.setEmail(""); //$NON-NLS-1$
                 }
                 user.setJoinedOn(new Date());
-                if (securityContext.getLocale() != null && user.getLocale() != null) {
+                if (securityContext.getLocale() != null && user.getLocale() == null) {
                     user.setLocale(securityContext.getLocale().toLanguageTag());
                 }
                 storage.createUser(user);

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/service/UserService.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/service/UserService.java
@@ -54,6 +54,9 @@ public class UserService implements DataAccessUtilMixin {
         if (user.getFullName() != null) {
             updatedUser.setFullName(user.getFullName());
         }
+        if (user.getLocale() != null) {
+            updatedUser.setLocale(user.getLocale());
+        }
         tryAction(() -> storage.updateUser(updatedUser));
     }
 

--- a/manager/api/security/src/main/java/io/apiman/manager/api/security/ISecurityContext.java
+++ b/manager/api/security/src/main/java/io/apiman/manager/api/security/ISecurityContext.java
@@ -16,10 +16,11 @@
 package io.apiman.manager.api.security;
 
 import io.apiman.manager.api.beans.idm.PermissionType;
-import io.apiman.manager.api.rest.exceptions.NotAuthorizedException;
 import io.apiman.manager.api.beans.idm.UserDto;
+import io.apiman.manager.api.rest.exceptions.NotAuthorizedException;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -127,4 +128,9 @@ public interface ISecurityContext {
      * Find all users in an org who have a specific permission
      */
     List<UserDto> getUsersWithPermission(PermissionType permission, String orgName);
+
+    /**
+     * Get Locale from security context (e.g. token, browser headers).
+     */
+    Locale getLocale();
 }

--- a/manager/api/security/src/main/java/io/apiman/manager/api/security/impl/AbstractSecurityContext.java
+++ b/manager/api/security/src/main/java/io/apiman/manager/api/security/impl/AbstractSecurityContext.java
@@ -31,6 +31,7 @@ import io.apiman.manager.api.security.i18n.Messages;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -220,6 +221,8 @@ public abstract class AbstractSecurityContext implements ISecurityContext {
             throw new RuntimeException(e);
         }
     }
+
+    public abstract Locale getLocale();
 
     /**
      * {@inheritDoc}

--- a/manager/api/security/src/main/java/io/apiman/manager/api/security/impl/DefaultSecurityContext.java
+++ b/manager/api/security/src/main/java/io/apiman/manager/api/security/impl/DefaultSecurityContext.java
@@ -20,6 +20,7 @@ import io.apiman.manager.api.beans.idm.UserDto;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
@@ -61,6 +62,11 @@ public class DefaultSecurityContext extends AbstractSecurityContext {
      */
     protected static void clearPermissions() {
         AbstractSecurityContext.clearPermissions();
+    }
+
+    @Override
+    public Locale getLocale() {
+        return servletRequest.get().getLocale();
     }
 
     /**

--- a/manager/api/security/src/main/java/io/apiman/manager/api/security/impl/KeycloakSecurityContext.java
+++ b/manager/api/security/src/main/java/io/apiman/manager/api/security/impl/KeycloakSecurityContext.java
@@ -20,12 +20,15 @@ import io.apiman.common.logging.IApimanLogger;
 import io.apiman.manager.api.beans.idm.UserDto;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Alternative;
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.lang3.LocaleUtils;
 import org.keycloak.adapters.RefreshableKeycloakSecurityContext;
 
 /**
@@ -65,7 +68,6 @@ public class KeycloakSecurityContext extends AbstractSecurityContext {
             return null;
         }
     }
-
     /**
      * {@inheritDoc}
      */
@@ -75,6 +77,18 @@ public class KeycloakSecurityContext extends AbstractSecurityContext {
         org.keycloak.KeycloakSecurityContext session = (org.keycloak.KeycloakSecurityContext) request.getAttribute(org.keycloak.KeycloakSecurityContext.class.getName());
         if (session != null) {
             return session.getToken().getEmail();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public Locale getLocale() {
+        HttpServletRequest request = servletRequest.get();
+        org.keycloak.KeycloakSecurityContext session = (org.keycloak.KeycloakSecurityContext) request.getAttribute(org.keycloak.KeycloakSecurityContext.class.getName());
+        if (session != null) {
+            return Optional.ofNullable(LocaleUtils.toLocale(session.getToken().getLocale()))
+                    .orElse(request.getLocale());
         } else {
             return null;
         }

--- a/manager/test/api/src/test/java/io/apiman/manager/api/notifications/email/SimpleMailNotificationServiceTest.java
+++ b/manager/test/api/src/test/java/io/apiman/manager/api/notifications/email/SimpleMailNotificationServiceTest.java
@@ -8,7 +8,9 @@ import io.apiman.manager.api.war.WarApiManagerConfig;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -82,6 +84,7 @@ public class SimpleMailNotificationServiceTest {
              .builder()
              .setToEmail("marc@blackparrotlabs.io")
              .setToName("Marc")
+             .setLocale(Locale.ENGLISH)
              .setTemplate(template)
              .setTemplateVariables(templateVars)
              .setHeaders(Map.of("X-Super-Secret", "BPL"))
@@ -148,6 +151,8 @@ public class SimpleMailNotificationServiceTest {
              .builder()
              .setToEmail("marc@blackparrotlabs.io")
              .setToName("Marc")
+             .setLocale(Locale.ENGLISH)
+             .setTemplate(template)
              .setTemplate(template)
              .setTemplateVariables(templateVars)
              .setHeaders(Map.of("X-Super-Secret", "BPL"))
@@ -170,7 +175,7 @@ public class SimpleMailNotificationServiceTest {
     @Test
     public void Read_the_email_notification_templates_from_file() {
         SimpleMailNotificationService service = new SimpleMailNotificationService(config, new QteTemplateEngine());
-        Optional<EmailNotificationTemplate> tplOpt = service.findTemplateFor("test.notification.reason");
+        Optional<EmailNotificationTemplate> tplOpt = service.findTemplateFor("test.notification.reason", Locale.ENGLISH);
 
         assertThat(tplOpt).isPresent();
     }
@@ -178,7 +183,7 @@ public class SimpleMailNotificationServiceTest {
     @Test
     public void Template_is_looked_up_by_longest_reason_prefix() {
         SimpleMailNotificationService service = new SimpleMailNotificationService(config, new QteTemplateEngine());
-        EmailNotificationTemplate tpl = service.findTemplateFor("test.notification.reason.blah").orElseThrow();
+        EmailNotificationTemplate tpl = service.findTemplateFor("test.notification.reason.blah", Locale.ENGLISH).orElseThrow();
 
         assertThat(tpl.getNotificationReason())
              .isEqualTo("test.notification.reason");
@@ -190,7 +195,7 @@ public class SimpleMailNotificationServiceTest {
     @Test
     public void Template_is_looked_up_by_exact_reason() {
         SimpleMailNotificationService service = new SimpleMailNotificationService(config, new QteTemplateEngine());
-        EmailNotificationTemplate tpl = service.findTemplateFor("test.notification.reason").orElseThrow();
+        EmailNotificationTemplate tpl = service.findTemplateFor("test.notification.reason", Locale.ENGLISH).orElseThrow();
 
         assertThat(tpl.getNotificationReason())
              .isEqualTo("test.notification.reason");
@@ -202,7 +207,9 @@ public class SimpleMailNotificationServiceTest {
     @Test
     public void All_templates_matching_reason_prefix_are_returned_in_order() {
         SimpleMailNotificationService service = new SimpleMailNotificationService(config, new QteTemplateEngine());
-        List<EmailNotificationTemplate> allTemplates = service.findAllTemplatesFor("test.notification.reason");
+        List<Map<Locale, EmailNotificationTemplate>> allTemplatesAndLocales = service.findAllTemplatesFor("test.notification.reason");
+
+        Collection<EmailNotificationTemplate> allTemplates = allTemplatesAndLocales.get(0).values();
 
         assertThat(allTemplates)
              //.containsOnlyKeys("test.notification", "test.notification.reason")

--- a/manager/test/api/src/test/java/io/apiman/manager/api/notifications/email/SimpleMailNotificationServiceTest.java
+++ b/manager/test/api/src/test/java/io/apiman/manager/api/notifications/email/SimpleMailNotificationServiceTest.java
@@ -207,9 +207,9 @@ public class SimpleMailNotificationServiceTest {
     @Test
     public void All_templates_matching_reason_prefix_are_returned_in_order() {
         SimpleMailNotificationService service = new SimpleMailNotificationService(config, new QteTemplateEngine());
-        List<Map<Locale, EmailNotificationTemplate>> allTemplatesAndLocales = service.findAllTemplatesFor("test.notification.reason");
+        Map<Locale, List<EmailNotificationTemplate>> allTemplatesAndLocales = service.findAllTemplatesFor("test.notification.reason");
 
-        Collection<EmailNotificationTemplate> allTemplates = allTemplatesAndLocales.get(0).values();
+        Collection<EmailNotificationTemplate> allTemplates = allTemplatesAndLocales.get(Locale.ENGLISH);
 
         assertThat(allTemplates)
              //.containsOnlyKeys("test.notification", "test.notification.reason")

--- a/manager/test/api/src/test/resources/apiman/config/email-notification-templates.json
+++ b/manager/test/api/src/test/resources/apiman/config/email-notification-templates.json
@@ -1,58 +1,54 @@
-[
-  {
-    "notificationReason": "apiman.account.signup.approval.request",
-    "subject": "Action required: New account signup {event.userId} needs activation",
-    "htmlBody": "Hi {notification.recipient.fullName}",
-    "plainBody": "Hi {notification.recipient.fullName}",
-    "category": "USER_ADMINISTRATION"
-  },
-  {
-    "notificationReason": "apiman.account.signup.notification",
-    "subject": "Info: A new account '{event.userId}' signed up to the developer portal",
-    "htmlBody": "Hi {notification.recipient.fullName}",
-    "plainBody": "Hi {notification.recipient.fullName}",
-    "category": "USER_ADMINISTRATION"
-  },
-  {
-    "notificationReason": "apiman.api.signup.approval.request",
-    "subject": "Action required: A user requires approval to sign up to API {event.apiName} v{event.apiVersion}",
-    "htmlBody": "Hi {notification.recipient.fullName}",
-    "plainBody": "Hi {notification.recipient.fullName}",
-    "category": "API_ADMINISTRATION"
-  },
-  {
-    "notificationReason": "apiman.api.signup.notification",
-    "subject": "Info: User {event.userId} signed up to {event.apiName} v{event.apiVersion}",
-    "htmlBody": "Hi {notification.recipient.fullName}",
-    "plainBody": "Hi {notification.recipient.fullName}",
-    "category": "API_ADMINISTRATION"
-  },
-  {
-    "notificationReason": "test.notification.reasob", // Should not match
-    "subject": "Pay attention!",
-    "htmlBody": "Salut {name}",
-    "plainBody": "¡Hola, {name}!",
-    "category": "OTHER"
-  },
-  {
-    "notificationReason": "test.notification.reasonn", // Should not match
-    "subject": "Pay attention!",
-    "htmlBody": "Salut {name}",
-    "plainBody": "¡Hola, {name}!",
-    "category": "OTHER"
-  },
-  {
-    "notificationReason": "test.notification.reason",
-    "subject": "Pay attention!",
-    "htmlBody": "Salut {name}",
-    "plainBody": "¡Hola, {name}!",
-    "category": "OTHER"
-  },
-  {
-    "notificationReason": "test.notification",
-    "subject": "Victoria, Mahe",
-    "htmlBody": "Hi html {name}",
-    "plainBody": "Hi plain {name}",
-    "category": "OTHER"
+{
+  "en": {
+    "apiman.account.signup.approval.request": {
+      "subject": "Action required: New account signup {event.userId} needs activation",
+      "htmlBody": "Hi {notification.recipient.fullName}",
+      "plainBody": "Hi {notification.recipient.fullName}",
+      "category": "USER_ADMINISTRATION"
+    },
+    "apiman.account.signup.notification": {
+      "subject": "Info: A new account '{event.userId}' signed up to the developer portal",
+      "htmlBody": "Hi {notification.recipient.fullName}",
+      "plainBody": "Hi {notification.recipient.fullName}",
+      "category": "USER_ADMINISTRATION"
+    },
+    "apiman.api.signup.approval.request": {
+      "subject": "Action required: A user requires approval to sign up to API {event.apiName} v{event.apiVersion}",
+      "htmlBody": "Hi {notification.recipient.fullName}",
+      "plainBody": "Hi {notification.recipient.fullName}",
+      "category": "API_ADMINISTRATION"
+    },
+    "apiman.api.signup.notification": {
+      "subject": "Info: User {event.userId} signed up to {event.apiName} v{event.apiVersion}",
+      "htmlBody": "Hi {notification.recipient.fullName}",
+      "plainBody": "Hi {notification.recipient.fullName}",
+      "category": "API_ADMINISTRATION"
+    },
+    "test.notification.reasob": {
+      // Should not match
+      "subject": "Pay attention!",
+      "htmlBody": "Salut {name}",
+      "plainBody": "¡Hola, {name}!",
+      "category": "OTHER"
+    },
+    "test.notification.reasonn": {
+      // Should not match
+      "subject": "Pay attention!",
+      "htmlBody": "Salut {name}",
+      "plainBody": "¡Hola, {name}!",
+      "category": "OTHER"
+    },
+    "test.notification.reason": {
+      "subject": "Pay attention!",
+      "htmlBody": "Salut {name}",
+      "plainBody": "¡Hola, {name}!",
+      "category": "OTHER"
+    },
+    "test.notification": {
+      "subject": "Victoria, Mahe",
+      "htmlBody": "Hi html {name}",
+      "plainBody": "Hi plain {name}",
+      "category": "OTHER"
+    }
   }
-]
+}


### PR DESCRIPTION
feat(manager-api): add locale to user profile

To better support localised notifications (e.g. via email), we need to store the locale of the 
user we're sending the notification to. Previously we relied on the headers sent in the request from 
the browser to determine preferred language, which only works if there is a request/response 
interaction (i.e. this was not persisted).

Now, on first interaction with the system we take the preferred locale from one of 
(in preferred order):
- Auth token locale (e.g. keycloak)
- Browser language preference
- Default locale

The user's stored locale is preferred over inferred.

The user's locale can be updated through the existing update user REST endpoint.

UI elements will be a separate commit.

Closes #1624