### PR TITLE
feat(ui): hide notifications icon if notifications subsystem disabled

### DIFF
--- a/manager/ui/war/plugins/api-manager/html/headers/community.include
+++ b/manager/ui/war/plugins/api-manager/html/headers/community.include
@@ -13,17 +13,15 @@
         </div>
         <nav class="collapse navbar-collapse">
             <ul class="nav navbar-nav navbar-right navbar-iconic navbar-utility">
-                <li class="drawer-pf-trigger dropdown">
+                <li class="drawer-pf-trigger dropdown" ng-show="notificationsEnabled">
                     <!-- Consider adding dropdown drawer -->
-<!--                    <a  href="{{ pluginName }}/notifications">-->
-                        <a class="btn btn-link nav-item-iconic drawer-pf-trigger-icon" href="{{ pluginName }}/notifications">
-                            <span class="fa fa-bell dropdown-title" title="Notifications"></span>
-                                <span class="badge badge-pf-bordered"
-                                      ng-show="userNotificationCount > 0">
-                                    {{ userNotificationCount }}
-                                </span>
-                        </a>
-<!--                    </a>-->
+                    <a class="btn btn-link nav-item-iconic drawer-pf-trigger-icon" href="{{ pluginName }}/notifications">
+                        <span class="fa fa-bell dropdown-title" title="Notifications"></span>
+                            <span class="badge badge-pf-bordered"
+                                  ng-show="userNotificationCount > 0">
+                                {{ userNotificationCount }}
+                            </span>
+                    </a>
                 </li>
                 <li class="dropdown">
                     <a href="#0" class="dropdown-toggle nav-item-iconic" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">

--- a/manager/ui/war/plugins/api-manager/ts/configuration.ts
+++ b/manager/ui/war/plugins/api-manager/ts/configuration.ts
@@ -46,14 +46,17 @@ angular.module('ApimanConfiguration', [])
             };
         }
 
-        if (cdata.ui.metrics == undefined || cdata.ui.metrics == null) {
+        if (cdata.ui.metrics == undefined) {
             cdata.ui.metrics = true;
         }
-        if (cdata.ui.platform == undefined || cdata.ui.platform == null) {
+        if (cdata.ui.platform == undefined) {
             cdata.ui.platform = "community";
         }
-        if (cdata.ui.adminOnlyOrgCreation == undefined || cdata.ui.adminOnlyOrgCreation == null) {
+        if (cdata.ui.adminOnlyOrgCreation == undefined) {
             cdata.ui.adminOnlyOrgCreation = false;
+        }
+        if (cdata.ui.notifications == undefined) {
+            cdata.ui.notifications = false;
         }
 
         return cdata;

--- a/manager/ui/war/plugins/api-manager/ts/navbar.ts
+++ b/manager/ui/war/plugins/api-manager/ts/navbar.ts
@@ -13,6 +13,7 @@ _module.controller("Apiman.NavbarController",
         window.location.href = Configuration.ui.backToConsole;
       };
       $scope.userNotificationCount = null;
+      $scope.notificationsEnabled = Configuration.ui.notifications;
 
       NotificationService.getNotificationCount(Configuration.user.username).then(
           (count) => {


### PR DESCRIPTION
Backend provides config that lets us know whether the notifications subsystem is enabled
or not.

```
var APIMAN_CONFIG_DATA = {
  <snip>
  "ui" : {
    "header" : "apiman",
    "metrics" : true,
    "notifications": true <-- backend indicating notification subsystem is active 
  }
  <snip>
};
```

Closes: #1671