### PR TITLE
build(deps): bump Vert.x from 3.9.8 to 3.9.10

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -137,10 +137,10 @@
     <version.org.reflections>0.9.11</version.org.reflections>
     <version.org.slf4j>1.7.32</version.org.slf4j>
     <version.org.testcontainers>1.16.0</version.org.testcontainers>
-    <version.io.netty>4.1.67.Final</version.io.netty>
+    <version.io.netty>4.1.69.Final</version.io.netty>
     <version.io.swagger>1.6.2</version.io.swagger>
     <version.xmlunit>1.6</version.xmlunit>
-    <version.io.vertx>3.9.8</version.io.vertx>
+    <version.io.vertx>3.9.10</version.io.vertx>
     <version.net.openhft>0.15</version.net.openhft>
     <version.com.ibm.icu4j>69.1</version.com.ibm.icu4j>
     <version.com.hazelcast>4.2.2</version.com.hazelcast>


### PR DESCRIPTION
Also match Netty version, bump 4.1.67 to 4.1.69