### PR TITLE
refactor(distro-wildfly): align Apiman to Keycloak 15.1.1, which required upgrading to WildFly 23.0.2

### DIFF
--- a/distro/wildfly/pom.xml
+++ b/distro/wildfly/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <docker.wildfly.version>wildfly</docker.wildfly.version>
-    <docker.base-image>jboss/wildfly:20.0.1.Final</docker.base-image>
+    <docker.base-image>quay.io/wildfly/wildfly</docker.base-image>
     <docker.target-image-name>apiman/on-wildfly:latest</docker.target-image-name>
     <docker.target-image-name.alias>wildfly-master</docker.target-image-name.alias>
   </properties>

--- a/distro/wildfly/pom.xml
+++ b/distro/wildfly/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <docker.wildfly.version>wildfly</docker.wildfly.version>
-    <docker.base-image>quay.io/wildfly/wildfly</docker.base-image>
+    <docker.base-image>quay.io/wildfly/wildfly:23.0.2.Final</docker.base-image>
     <docker.target-image-name>apiman/on-wildfly:latest</docker.target-image-name>
     <docker.target-image-name.alias>wildfly-master</docker.target-image-name.alias>
   </properties>

--- a/distro/wildfly/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
+++ b/distro/wildfly/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
@@ -48,14 +48,6 @@
     </system-properties>
     <management>
         <security-realms>
-            <security-realm name="UndertowRealm">
-                <server-identities>
-                    <ssl>
-                        <keystore path="apiman.jks" relative-to="jboss.server.config.dir" keystore-password="secret"
-                          alias="apimancert" key-password="secret" />
-                    </ssl>
-                </server-identities>
-            </security-realm>
             <security-realm name="ManagementRealm">
                 <authentication>
                     <local default-user="$local" skip-group-loading="true"/>
@@ -68,7 +60,11 @@
             <security-realm name="ApplicationRealm">
                 <server-identities>
                     <ssl>
-                        <keystore path="application.keystore" relative-to="jboss.server.config.dir" keystore-password="password" alias="server" key-password="password" generate-self-signed-certificate-host="localhost"/>
+                        <keystore path="apiman.jks"
+                          relative-to="jboss.server.config.dir"
+                          keystore-password="secret"
+                          alias="apimancert"
+                          key-password="secret"/>
                     </ssl>
                 </server-identities>
                 <authentication>
@@ -363,15 +359,15 @@
             </sasl>
             <tls>
                 <key-stores>
-                    <key-store name="applicationKS">
-                        <credential-reference clear-text="password"/>
+                    <key-store name="httpsKS">
+                        <credential-reference clear-text="secret" />
                         <implementation type="JKS"/>
-                        <file path="application.keystore" relative-to="jboss.server.config.dir"/>
+                        <file path="apiman.jks" relative-to="jboss.server.config.dir" />
                     </key-store>
                 </key-stores>
                 <key-managers>
-                    <key-manager name="applicationKM" key-store="applicationKS" generate-self-signed-certificate-host="localhost">
-                        <credential-reference clear-text="password"/>
+                    <key-manager name="applicationKM" key-store="httpsKS">
+                        <credential-reference clear-text="secret" />
                     </key-manager>
                 </key-managers>
                 <server-ssl-contexts>

--- a/distro/wildfly/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
+++ b/distro/wildfly/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
@@ -22,7 +22,6 @@
         <extension module="org.jboss.as.transactions"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
-        <extension module="org.wildfly.extension.batch.jberet"/>
         <extension module="org.wildfly.extension.bean-validation"/>
         <extension module="org.wildfly.extension.clustering.web"/>
         <extension module="org.wildfly.extension.core-management"/>
@@ -30,11 +29,6 @@
         <extension module="org.wildfly.extension.ee-security"/>
         <extension module="org.wildfly.extension.elytron"/>
         <extension module="org.wildfly.extension.io"/>
-        <extension module="org.wildfly.extension.microprofile.config-smallrye"/>
-        <extension module="org.wildfly.extension.microprofile.health-smallrye"/>
-        <extension module="org.wildfly.extension.microprofile.jwt-smallrye"/>
-        <extension module="org.wildfly.extension.microprofile.metrics-smallrye"/>
-        <extension module="org.wildfly.extension.microprofile.opentracing-smallrye"/>
         <extension module="org.wildfly.extension.request-controller"/>
         <extension module="org.wildfly.extension.security.manager"/>
         <extension module="org.wildfly.extension.undertow"/>
@@ -55,12 +49,12 @@
     <management>
         <security-realms>
             <security-realm name="UndertowRealm">
-              <server-identities>
-                <ssl>
-                  <keystore path="apiman.jks" relative-to="jboss.server.config.dir" keystore-password="secret"
-                    alias="apimancert" key-password="secret" />
-                </ssl>
-              </server-identities>
+                <server-identities>
+                    <ssl>
+                        <keystore path="apiman.jks" relative-to="jboss.server.config.dir" keystore-password="secret"
+                          alias="apimancert" key-password="secret" />
+                    </ssl>
+                </server-identities>
             </security-realm>
             <security-realm name="ManagementRealm">
                 <authentication>
@@ -121,14 +115,14 @@
                 <level name="INFO"/>
                 <formatter>
                     <!-- Uncomment to log as JSON. See formatter section below. -->
-<!--                    <named-formatter name="JSON"/> -->
+                    <!--                    <named-formatter name="JSON"/> -->
                     <named-formatter name="COLOR-PATTERN"/>
                 </formatter>
             </console-handler>
             <periodic-rotating-file-handler name="FILE" autoflush="true">
                 <formatter>
-                <!-- Uncomment to log as JSON. See formatter section below. -->
-<!--                    <named-formatter name="JSON"/> -->
+                    <!-- Uncomment to log as JSON. See formatter section below. -->
+                    <!--                    <named-formatter name="JSON"/> -->
                     <named-formatter name="PATTERN"/>
                 </formatter>
                 <file relative-to="jboss.server.log.dir" path="server.log"/>
@@ -163,21 +157,10 @@
             <formatter name="COLOR-PATTERN">
                 <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
             </formatter>
-<!--            Default JSON format. More advanced customisations available. Refer to WildFly/EAP docs. -->
-<!--            <formatter name="JSON">-->
-<!--                <json-formatter/>-->
-<!--            </formatter>-->
-        </subsystem>
-        <subsystem xmlns="urn:jboss:domain:batch-jberet:2.0">
-            <default-job-repository name="in-memory"/>
-            <default-thread-pool name="batch"/>
-            <job-repository name="in-memory">
-                <in-memory/>
-            </job-repository>
-            <thread-pool name="batch">
-                <max-threads count="10"/>
-                <keepalive-time time="30" unit="seconds"/>
-            </thread-pool>
+            <!--            Default JSON format. More advanced customisations available. Refer to WildFly/EAP docs. -->
+            <!--            <formatter name="JSON">-->
+            <!--                <json-formatter/>-->
+            <!--            </formatter>-->
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
         <subsystem xmlns="urn:jboss:domain:core-management:1.0"/>
@@ -279,7 +262,7 @@
             <statistics enabled="${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}"/>
             <log-system-exceptions value="true"/>
         </subsystem>
-        <subsystem xmlns="urn:wildfly:elytron:10.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
+        <subsystem xmlns="urn:wildfly:elytron:13.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
             <providers>
                 <aggregate-providers name="combined-providers">
                     <providers name="elytron"/>
@@ -378,40 +361,38 @@
                 </mechanism-provider-filtering-sasl-server-factory>
                 <provider-sasl-server-factory name="global"/>
             </sasl>
+            <tls>
+                <key-stores>
+                    <key-store name="applicationKS">
+                        <credential-reference clear-text="password"/>
+                        <implementation type="JKS"/>
+                        <file path="application.keystore" relative-to="jboss.server.config.dir"/>
+                    </key-store>
+                </key-stores>
+                <key-managers>
+                    <key-manager name="applicationKM" key-store="applicationKS" generate-self-signed-certificate-host="localhost">
+                        <credential-reference clear-text="password"/>
+                    </key-manager>
+                </key-managers>
+                <server-ssl-contexts>
+                    <server-ssl-context name="applicationSSC" key-manager="applicationKM"/>
+                </server-ssl-contexts>
+            </tls>
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:infinispan:10.0">
-            <cache-container name="web" default-cache="passivation" module="org.wildfly.clustering.web.infinispan">
+        <subsystem xmlns="urn:jboss:domain:infinispan:12.0">
+            <cache-container name="ejb" default-cache="passivation" aliases="sfsb" modules="org.wildfly.clustering.ejb.infinispan">
                 <local-cache name="passivation">
-                    <file-store passivation="true" purge="false"/>
-                </local-cache>
-                <local-cache name="sso"/>
-                <local-cache name="routing"/>
-            </cache-container>
-            <cache-container name="server" default-cache="default" module="org.wildfly.clustering.server">
-                <local-cache name="default"/>
-            </cache-container>
-            <cache-container name="ejb" aliases="sfsb" default-cache="passivation" module="org.wildfly.clustering.ejb.infinispan">
-                <local-cache name="passivation">
+                    <locking isolation="REPEATABLE_READ"/>
+                    <transaction mode="BATCH"/>
                     <file-store passivation="true" purge="false"/>
                 </local-cache>
             </cache-container>
-            <cache-container name="hibernate" module="org.infinispan.hibernate-cache">
-                <local-cache name="entity">
-                    <object-memory size="10000"/>
-                    <expiration max-idle="100000"/>
-                </local-cache>
-                <local-cache name="local-query">
-                    <object-memory size="10000"/>
-                    <expiration max-idle="100000"/>
-                </local-cache>
-                <local-cache name="timestamps"/>
-            </cache-container>
-            <cache-container name="keycloak">
+            <cache-container name="keycloak" modules="org.keycloak.keycloak-model-infinispan">
                 <local-cache name="realms">
-                    <object-memory size="10000"/>
+                    <heap-memory size="10000"/>
                 </local-cache>
                 <local-cache name="users">
-                    <object-memory size="10000"/>
+                    <heap-memory size="10000"/>
                 </local-cache>
                 <local-cache name="sessions"/>
                 <local-cache name="authenticationSessions"/>
@@ -421,16 +402,44 @@
                 <local-cache name="loginFailures"/>
                 <local-cache name="work"/>
                 <local-cache name="authorization">
-                    <object-memory size="10000"/>
+                    <heap-memory size="10000"/>
                 </local-cache>
                 <local-cache name="keys">
-                    <object-memory size="1000"/>
+                    <heap-memory size="1000"/>
                     <expiration max-idle="3600000"/>
                 </local-cache>
                 <local-cache name="actionTokens">
-                    <object-memory size="-1"/>
+                    <heap-memory size="-1"/>
                     <expiration interval="300000" max-idle="-1"/>
                 </local-cache>
+            </cache-container>
+            <cache-container name="server" default-cache="default" modules="org.wildfly.clustering.server">
+                <local-cache name="default">
+                    <transaction mode="BATCH"/>
+                </local-cache>
+            </cache-container>
+            <cache-container name="web" default-cache="passivation" modules="org.wildfly.clustering.web.infinispan">
+                <local-cache name="passivation">
+                    <locking isolation="REPEATABLE_READ"/>
+                    <transaction mode="BATCH"/>
+                    <file-store passivation="true" purge="false"/>
+                </local-cache>
+                <local-cache name="sso">
+                    <locking isolation="REPEATABLE_READ"/>
+                    <transaction mode="BATCH"/>
+                </local-cache>
+                <local-cache name="routing"/>
+            </cache-container>
+            <cache-container name="hibernate" modules="org.infinispan.hibernate-cache">
+                <local-cache name="entity">
+                    <heap-memory size="10000"/>
+                    <expiration max-idle="100000"/>
+                </local-cache>
+                <local-cache name="local-query">
+                    <heap-memory size="10000"/>
+                    <expiration max-idle="100000"/>
+                </local-cache>
+                <local-cache name="timestamps"/>
             </cache-container>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:io:3.0">
@@ -466,9 +475,13 @@
         <subsystem xmlns="urn:jboss:domain:jpa:1.1">
             <jpa default-datasource="" default-extended-persistence-inheritance="DEEP"/>
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:jsf:1.1"/>
         <subsystem xmlns="urn:jboss:domain:keycloak-server:1.1">
             <web-context>auth</web-context>
+            <providers>
+                <provider>
+                    classpath:${jboss.home.dir}/providers/*
+                </provider>
+            </providers>
             <master-realm-name>master</master-realm-name>
             <scheduled-task-interval>900</scheduled-task-interval>
             <theme>
@@ -477,15 +490,6 @@
                 <cacheTemplates>true</cacheTemplates>
                 <dir>${jboss.home.dir}/themes</dir>
             </theme>
-            <spi name="hostname">
-                <default-provider>default</default-provider>
-                <provider name="default" enabled="true">
-                    <properties>
-                        <property name="frontendUrl" value="${keycloak.frontendUrl:}"/>
-                        <property name="forceBackendUrlToFrontendUrl" value="false"/>
-                    </properties>
-                </provider>
-            </spi>
             <spi name="eventsStore">
                 <provider name="jpa" enabled="true">
                     <properties>
@@ -537,20 +541,24 @@
                     </properties>
                 </provider>
             </spi>
+            <spi name="x509cert-lookup">
+                <default-provider>${keycloak.x509cert.lookup.provider:default}</default-provider>
+                <provider name="default" enabled="true"/>
+            </spi>
+            <spi name="hostname">
+                <default-provider>default</default-provider>
+                <provider name="default" enabled="true">
+                    <properties>
+                        <property name="frontendUrl" value="${keycloak.frontendUrl:}"/>
+                        <property name="forceBackendUrlToFrontendUrl" value="false"/>
+                    </properties>
+                </provider>
+            </spi>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:mail:4.0">
             <mail-session name="default" jndi-name="java:jboss/mail/Default">
                 <smtp-server outbound-socket-binding-ref="mail-smtp"/>
             </mail-session>
-        </subsystem>
-        <subsystem xmlns="urn:wildfly:microprofile-config-smallrye:1.0"/>
-        <subsystem xmlns="urn:wildfly:microprofile-health-smallrye:2.0" security-enabled="false" empty-liveness-checks-status="${env.MP_HEALTH_EMPTY_LIVENESS_CHECKS_STATUS:UP}" empty-readiness-checks-status="${env.MP_HEALTH_EMPTY_READINESS_CHECKS_STATUS:UP}"/>
-        <subsystem xmlns="urn:wildfly:microprofile-jwt-smallrye:1.0"/>
-        <subsystem xmlns="urn:wildfly:microprofile-metrics-smallrye:2.0" security-enabled="false" exposed-subsystems="*" prefix="${wildfly.metrics.prefix:wildfly}"/>
-        <subsystem xmlns="urn:wildfly:microprofile-opentracing-smallrye:2.0" default-tracer="jaeger">
-            <jaeger-tracer name="jaeger">
-                <sampler-configuration sampler-type="const" sampler-param="1.0"/>
-            </jaeger-tracer>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:naming:2.0">
             <remote-naming/>
@@ -652,34 +660,34 @@
         <subsystem xmlns="urn:jboss:domain:weld:4.0"/>
         <!-- Apiman's Keycloak client adapter configuration. -->
         <subsystem xmlns="urn:jboss:domain:keycloak:1.1">
-          <secure-deployment name="apiman.war">
-            <realm>${env.APIMAN_AUTH_REALM:apiman}</realm>
-            <auth-server-url>${env.APIMAN_AUTH_URL:/auth}</auth-server-url>
-            <resource>apiman</resource>
-            <credential name="secret">password</credential>
-            <disable-trust-manager>true</disable-trust-manager>
-            <bearer-only>true</bearer-only>
-            <enable-basic-auth>true</enable-basic-auth>
-            <principal-attribute>preferred_username</principal-attribute>
-          </secure-deployment>
-          <secure-deployment name="apimanui.war">
-            <realm>${env.APIMAN_AUTH_REALM:apiman}</realm>
-            <auth-server-url>${env.APIMAN_AUTH_URL:/auth}</auth-server-url>
-            <resource>apimanui</resource>
-            <credential name="secret">password</credential>
-            <disable-trust-manager>true</disable-trust-manager>
-            <principal-attribute>preferred_username</principal-attribute>
-          </secure-deployment>
-          <secure-deployment name="apiman-gateway-api.war">
-            <realm>${env.APIMAN_AUTH_REALM:apiman}</realm>
-            <auth-server-url>${env.APIMAN_AUTH_URL:/auth}</auth-server-url>
-            <resource>apiman-gateway-api</resource>
-            <credential name="secret">password</credential>
-            <disable-trust-manager>true</disable-trust-manager>
-            <bearer-only>true</bearer-only>
-            <enable-basic-auth>true</enable-basic-auth>
-            <principal-attribute>preferred_username</principal-attribute>
-          </secure-deployment>
+            <secure-deployment name="apiman.war">
+                <realm>${env.APIMAN_AUTH_REALM:apiman}</realm>
+                <auth-server-url>${env.APIMAN_AUTH_URL:/auth}</auth-server-url>
+                <resource>apiman</resource>
+                <credential name="secret">password</credential>
+                <disable-trust-manager>true</disable-trust-manager>
+                <bearer-only>true</bearer-only>
+                <enable-basic-auth>true</enable-basic-auth>
+                <principal-attribute>preferred_username</principal-attribute>
+            </secure-deployment>
+            <secure-deployment name="apimanui.war">
+                <realm>${env.APIMAN_AUTH_REALM:apiman}</realm>
+                <auth-server-url>${env.APIMAN_AUTH_URL:/auth}</auth-server-url>
+                <resource>apimanui</resource>
+                <credential name="secret">password</credential>
+                <disable-trust-manager>true</disable-trust-manager>
+                <principal-attribute>preferred_username</principal-attribute>
+            </secure-deployment>
+            <secure-deployment name="apiman-gateway-api.war">
+                <realm>${env.APIMAN_AUTH_REALM:apiman}</realm>
+                <auth-server-url>${env.APIMAN_AUTH_URL:/auth}</auth-server-url>
+                <resource>apiman-gateway-api</resource>
+                <credential name="secret">password</credential>
+                <disable-trust-manager>true</disable-trust-manager>
+                <bearer-only>true</bearer-only>
+                <enable-basic-auth>true</enable-basic-auth>
+                <principal-attribute>preferred_username</principal-attribute>
+            </secure-deployment>
         </subsystem>
     </profile>
     <interfaces>

--- a/gateway/platforms/war/wildfly8/api/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/gateway/platforms/war/wildfly8/api/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,5 +1,9 @@
 <jboss-deployment-structure>
   <deployment>
+    <exclusions>
+      <module name="org.apache.log4j" />
+      <module name="org.apache.logging.log4j.api" />
+    </exclusions>
     <dependencies>
       <module name="com.fasterxml.jackson.core.jackson-core" />
       <module name="com.fasterxml.jackson.core.jackson-annotations" />
@@ -7,8 +11,6 @@
       <module name="com.fasterxml.jackson.datatype.jackson-datatype-jdk8" />
       <module name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" />
       <module name="org.infinispan" />
-<!--      <module name="org.apache.log4j" />-->
-      <module name="org.slf4j" />
       <module name="org.picketbox" />
     </dependencies>
     <exclude-subsystems>

--- a/gateway/platforms/war/wildfly8/api/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/gateway/platforms/war/wildfly8/api/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,10 +1,13 @@
 <jboss-deployment-structure>
   <deployment>
     <dependencies>
-      <module name="org.codehaus.jackson.jackson-core-asl" />
-      <module name="org.codehaus.jackson.jackson-mapper-asl" />
+      <module name="com.fasterxml.jackson.core.jackson-core" />
+      <module name="com.fasterxml.jackson.core.jackson-annotations" />
+      <module name="com.fasterxml.jackson.core.jackson-databind" />
+      <module name="com.fasterxml.jackson.datatype.jackson-datatype-jdk8" />
+      <module name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" />
       <module name="org.infinispan" />
-      <module name="org.apache.log4j" />
+<!--      <module name="org.apache.log4j" />-->
       <module name="org.slf4j" />
       <module name="org.picketbox" />
     </dependencies>

--- a/gateway/platforms/war/wildfly8/gateway/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/gateway/platforms/war/wildfly8/gateway/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,8 +1,11 @@
 <jboss-deployment-structure>
   <deployment>
     <dependencies>
-      <module name="org.codehaus.jackson.jackson-core-asl" />
-      <module name="org.codehaus.jackson.jackson-mapper-asl" />
+      <module name="com.fasterxml.jackson.core.jackson-core" />
+      <module name="com.fasterxml.jackson.core.jackson-annotations" />
+      <module name="com.fasterxml.jackson.core.jackson-databind" />
+      <module name="com.fasterxml.jackson.datatype.jackson-datatype-jdk8" />
+      <module name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" />
       <module name="org.infinispan" />
       <module name="org.apache.log4j" />
       <module name="org.slf4j" />

--- a/gateway/platforms/war/wildfly8/gateway/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/gateway/platforms/war/wildfly8/gateway/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,5 +1,9 @@
 <jboss-deployment-structure>
   <deployment>
+    <exclusions>
+      <module name="org.apache.log4j" />
+      <module name="org.apache.logging.log4j.api" />
+    </exclusions>
     <dependencies>
       <module name="com.fasterxml.jackson.core.jackson-core" />
       <module name="com.fasterxml.jackson.core.jackson-annotations" />
@@ -7,8 +11,6 @@
       <module name="com.fasterxml.jackson.datatype.jackson-datatype-jdk8" />
       <module name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" />
       <module name="org.infinispan" />
-      <module name="org.apache.log4j" />
-      <module name="org.slf4j" />
       <module name="org.picketbox" />
     </dependencies>
     <exclude-subsystems>

--- a/manager/api/war/wildfly8/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/manager/api/war/wildfly8/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,10 +1,12 @@
 <jboss-deployment-structure>
   <deployment>
+    <exclusions>
+      <module name="org.apache.log4j" />
+      <module name="org.apache.logging.log4j.api" />
+    </exclusions>
     <dependencies>
       <module name="org.infinispan" />
       <module name="org.hibernate" />
-      <module name="org.apache.log4j" />
-      <module name="org.slf4j" />
       <module name="org.picketbox" />
     </dependencies>
     <exclude-subsystems>

--- a/manager/ui/war/wildfly8/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/manager/ui/war/wildfly8/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,5 +1,9 @@
 <jboss-deployment-structure>
   <deployment>
+    <exclusions>
+      <module name="org.apache.log4j" />
+      <module name="org.apache.logging.log4j.api" />
+    </exclusions>
     <exclude-subsystems>
       <subsystem name="webservices" />
     </exclude-subsystems>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -122,7 +122,7 @@
     <version.org.elasticsearch>7.13.4</version.org.elasticsearch>
     <version.org.hamcrest>1.3</version.org.hamcrest>
     <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.2</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
-    <version.org.hibernate>5.3.17.Final</version.org.hibernate> <!-- Pin to Wildfly version -->
+    <version.org.hibernate>5.3.20.Final</version.org.hibernate> <!-- Pin to WildFly version -->
     <version.org.infinispan>8.2.12.Final</version.org.infinispan>
     <version.org.jboss.jandex>2.4.0.Final</version.org.jboss.jandex>
     <version.org.jboss.logging.jboss-logging>3.4.2.Final</version.org.jboss.logging.jboss-logging>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -130,7 +130,7 @@
     <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.1.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
     <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>2.0.2.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>
     <version.org.jboss.weld.weld>3.1.8.Final</version.org.jboss.weld.weld>
-    <version.org.keycloak>12.0.4</version.org.keycloak>
+    <version.org.keycloak>15.1.1</version.org.keycloak>
     <version.org.mockito>3.12.1</version.org.mockito>
     <version.org.mvel>2.4.12.Final</version.org.mvel>
     <version.org.picketbox>5.1.0.Final</version.org.picketbox>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.apiman</groupId>
     <artifactId>apiman-parent</artifactId>
-    <version>2.1.5.Final</version>
+    <version>2.1.6-SNAPSHOT</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 

--- a/tools/server-all/pom.xml
+++ b/tools/server-all/pom.xml
@@ -79,7 +79,7 @@
                     <antversion property="antversion" />
                     <echo>Ant Version: ${antversion}</echo>
 
-                    <property name="wildfly.version" value="20.0.1.Final"/>
+                    <property name="wildfly.version" value="23.0.2.Final"/>
 
                     <property name="appserver.id" value="wildfly" />
                     <property name="apiman.wildfly.download.url" value="https://download.jboss.org/wildfly/${wildfly.version}/wildfly-${wildfly.version}.zip" />


### PR DESCRIPTION
refactor: Align Apiman with  Keycloak 15.1.1, which required upgrading to WildFly 23.0.2

This mostly included reworking the WildFly quickstart distro's `standalone-apiman.xml` config (again).

Now using a self-signed cert instead of default certificate. Could there be unintended consequences to this? For example, it is not explicitly linked to the apiman keystore, so could that mess with existing configs.