### PR TITLE
build(deps): bump resteasy, mvel2, testcontainers, and ldapsdk

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -91,7 +91,7 @@
     <version.com.github.seancfoley.ipaddress>5.3.3</version.com.github.seancfoley.ipaddress>
     <version.com.squareup.okhttp>2.7.5</version.com.squareup.okhttp>
     <version.com.squareup.okio>2.10.0</version.com.squareup.okio>
-    <version.com.unboundid.unboundid-ldapsdk>6.0.0</version.com.unboundid.unboundid-ldapsdk>
+    <version.com.unboundid.unboundid-ldapsdk>6.0.2</version.com.unboundid.unboundid-ldapsdk>
     <version.commons-beanutils>1.9.4</version.commons-beanutils>
     <version.commons-codec>1.15</version.commons-codec>
     <version.commons-collections>3.2.2</version.commons-collections>
@@ -126,17 +126,17 @@
     <version.org.infinispan>8.2.12.Final</version.org.infinispan>
     <version.org.jboss.jandex>2.4.0.Final</version.org.jboss.jandex>
     <version.org.jboss.logging.jboss-logging>3.4.2.Final</version.org.jboss.logging.jboss-logging>
-    <version.org.jboss.resteasy>3.15.1.Final</version.org.jboss.resteasy>
+    <version.org.jboss.resteasy>3.15.3.Final</version.org.jboss.resteasy>
     <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.1.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
     <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>2.0.2.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>
     <version.org.jboss.weld.weld>3.1.8.Final</version.org.jboss.weld.weld>
     <version.org.keycloak>12.0.4</version.org.keycloak>
     <version.org.mockito>3.12.1</version.org.mockito>
-    <version.org.mvel>2.4.12.Final</version.org.mvel>
+    <version.org.mvel>2.4.14.Final</version.org.mvel>
     <version.org.picketbox>5.1.0.Final</version.org.picketbox>
     <version.org.reflections>0.9.11</version.org.reflections>
     <version.org.slf4j>1.7.32</version.org.slf4j>
-    <version.org.testcontainers>1.16.0</version.org.testcontainers>
+    <version.org.testcontainers>1.16.2</version.org.testcontainers>
     <version.io.netty>4.1.72.Final</version.io.netty>
     <version.io.swagger>1.6.2</version.io.swagger>
     <version.xmlunit>1.6</version.xmlunit>
@@ -155,7 +155,7 @@
     <version.javax.xml.bind>2.3.3</version.javax.xml.bind>
     <version.jakarta.servlet>4.0.4</version.jakarta.servlet>
     <version.info.picocli>4.6.1</version.info.picocli>
-    <version.apache.maven.maven-artifact>3.8.2</version.apache.maven.maven-artifact>
+    <version.apache.maven.maven-artifact>3.8.4</version.apache.maven.maven-artifact>
   </properties>
 
   <reporting>


### PR DESCRIPTION
---
build(deps): bump version.org.jboss.resteasy in /parent

Bumps `version.org.jboss.resteasy` from 3.15.1.Final to 3.15.3.Final.

Updates `resteasy-jaxrs` from 3.15.1.Final to 3.15.3.Final

Updates `resteasy-vertx` from 3.15.1.Final to 3.15.3.Final

Updates `resteasy-jackson2-provider` from 3.15.1.Final to 3.15.3.Final

Updates `resteasy-jaxb-provider` from 3.15.1.Final to 3.15.3.Final

Updates `resteasy-cdi` from 3.15.1.Final to 3.15.3.Final
- [Release notes](https://github.com/resteasy/Resteasy/releases)
- [Commits](https://github.com/resteasy/Resteasy/compare/3.15.1.Final...3.15.3.Final)

---
updated-dependencies:
- dependency-name: org.jboss.resteasy:resteasy-jaxrs
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.jboss.resteasy:resteasy-vertx
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.jboss.resteasy:resteasy-jackson2-provider
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.jboss.resteasy:resteasy-jaxb-provider
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.jboss.resteasy:resteasy-cdi
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump mvel2 from 2.4.12.Final to 2.4.14.Final in /parent

Bumps [mvel2](https://github.com/mvel/mvel) from 2.4.12.Final to 2.4.14.Final.
- [Release notes](https://github.com/mvel/mvel/releases)
- [Commits](https://github.com/mvel/mvel/compare/mvel2-2.4.12.Final...mvel2-2.4.14.Final)

---
updated-dependencies:
- dependency-name: org.mvel:mvel2
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump version.org.testcontainers in /parent

Bumps `version.org.testcontainers` from 1.16.0 to 1.16.2.

Updates `testcontainers` from 1.16.0 to 1.16.2
- [Release notes](https://github.com/testcontainers/testcontainers-java/releases)
- [Changelog](https://github.com/testcontainers/testcontainers-java/blob/master/CHANGELOG.md)
- [Commits](https://github.com/testcontainers/testcontainers-java/compare/1.16.0...1.16.2)

Updates `elasticsearch` from 1.16.0 to 1.16.2
- [Release notes](https://github.com/testcontainers/testcontainers-java/releases)
- [Changelog](https://github.com/testcontainers/testcontainers-java/blob/master/CHANGELOG.md)
- [Commits](https://github.com/testcontainers/testcontainers-java/compare/1.16.0...1.16.2)

Updates `junit-jupiter` from 1.16.0 to 1.16.2
- [Release notes](https://github.com/testcontainers/testcontainers-java/releases)
- [Changelog](https://github.com/testcontainers/testcontainers-java/blob/master/CHANGELOG.md)
- [Commits](https://github.com/testcontainers/testcontainers-java/compare/1.16.0...1.16.2)

---
updated-dependencies:
- dependency-name: org.testcontainers:testcontainers
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.testcontainers:elasticsearch
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.testcontainers:junit-jupiter
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump unboundid-ldapsdk from 6.0.0 to 6.0.2 in /parent

Bumps [unboundid-ldapsdk](https://github.com/pingidentity/ldapsdk) from 6.0.0 to 6.0.2.
- [Release notes](https://github.com/pingidentity/ldapsdk/releases)
- [Changelog](https://github.com/pingidentity/ldapsdk/blob/master/docs/release-notes.html)
- [Commits](https://github.com/pingidentity/ldapsdk/compare/6.0.0...6.0.2)

---
updated-dependencies:
- dependency-name: com.unboundid:unboundid-ldapsdk
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>