### PR TITLE
refactor(manager-api-rest): use DTO for old devportal #getAllApiVersions

### DIFF
--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/developers/DeveloperApiVersionBeanDto.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/developers/DeveloperApiVersionBeanDto.java
@@ -1,0 +1,6 @@
+package io.apiman.manager.api.beans.developers;/**
+ * 
+ *
+ * @author Marc Savy {@literal <marc@blackparrotlabs.io>}
+ */public class DeveloperApiVersionBeanDto {
+}

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/developers/DeveloperApiVersionBeanDto.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/developers/DeveloperApiVersionBeanDto.java
@@ -1,6 +1,281 @@
-package io.apiman.manager.api.beans.developers;/**
- * 
+package io.apiman.manager.api.beans.developers;
+
+import io.apiman.manager.api.beans.apis.ApiBean;
+import io.apiman.manager.api.beans.apis.ApiDefinitionType;
+import io.apiman.manager.api.beans.apis.ApiGatewayBean;
+import io.apiman.manager.api.beans.apis.ApiPlanBean;
+import io.apiman.manager.api.beans.apis.ApiStatus;
+import io.apiman.manager.api.beans.apis.EndpointContentType;
+import io.apiman.manager.api.beans.apis.EndpointType;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.StringJoiner;
+
+/**
+ * Temporary DTO to make old developer endpoint work properly until we delete it.
  *
  * @author Marc Savy {@literal <marc@blackparrotlabs.io>}
- */public class DeveloperApiVersionBeanDto {
+ */
+@Deprecated
+public class DeveloperApiVersionBeanDto {
+        private Long id;
+        private ApiBean api;
+        private ApiStatus status;
+        private String endpoint;
+        private EndpointType endpointType;
+        private EndpointContentType endpointContentType;
+        private Map<String, String> endpointProperties = new HashMap<>();
+        private Set<ApiGatewayBean> gateways;
+        private boolean publicAPI;
+        private Set<ApiPlanBean> plans;
+        private String version;
+        private String createdBy;
+        private Date createdOn;
+        private String modifiedBy;
+        private Date modifiedOn;
+        private Date publishedOn;
+        private Date retiredOn;
+        private ApiDefinitionType definitionType;
+        private boolean parsePayload;
+        private boolean disableKeysStrip;
+        private String definitionUrl;
+        private boolean exposeInPortal = false;
+        private String extendedDescription;
+
+    public DeveloperApiVersionBeanDto() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public ApiBean getApi() {
+        return api;
+    }
+
+    public void setApi(ApiBean api) {
+        this.api = api;
+    }
+
+    public ApiStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ApiStatus status) {
+        this.status = status;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public EndpointType getEndpointType() {
+        return endpointType;
+    }
+
+    public void setEndpointType(EndpointType endpointType) {
+        this.endpointType = endpointType;
+    }
+
+    public EndpointContentType getEndpointContentType() {
+        return endpointContentType;
+    }
+
+    public void setEndpointContentType(EndpointContentType endpointContentType) {
+        this.endpointContentType = endpointContentType;
+    }
+
+    public Map<String, String> getEndpointProperties() {
+        return endpointProperties;
+    }
+
+    public void setEndpointProperties(Map<String, String> endpointProperties) {
+        this.endpointProperties = endpointProperties;
+    }
+
+    public Set<ApiGatewayBean> getGateways() {
+        return gateways;
+    }
+
+    public void setGateways(Set<ApiGatewayBean> gateways) {
+        this.gateways = gateways;
+    }
+
+    public boolean isPublicAPI() {
+        return publicAPI;
+    }
+
+    public void setPublicAPI(boolean publicAPI) {
+        this.publicAPI = publicAPI;
+    }
+
+    public Set<ApiPlanBean> getPlans() {
+        return plans;
+    }
+
+    public void setPlans(Set<ApiPlanBean> plans) {
+        this.plans = plans;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public Date getCreatedOn() {
+        return createdOn;
+    }
+
+    public void setCreatedOn(Date createdOn) {
+        this.createdOn = createdOn;
+    }
+
+    public String getModifiedBy() {
+        return modifiedBy;
+    }
+
+    public void setModifiedBy(String modifiedBy) {
+        this.modifiedBy = modifiedBy;
+    }
+
+    public Date getModifiedOn() {
+        return modifiedOn;
+    }
+
+    public void setModifiedOn(Date modifiedOn) {
+        this.modifiedOn = modifiedOn;
+    }
+
+    public Date getPublishedOn() {
+        return publishedOn;
+    }
+
+    public void setPublishedOn(Date publishedOn) {
+        this.publishedOn = publishedOn;
+    }
+
+    public Date getRetiredOn() {
+        return retiredOn;
+    }
+
+    public void setRetiredOn(Date retiredOn) {
+        this.retiredOn = retiredOn;
+    }
+
+    public ApiDefinitionType getDefinitionType() {
+        return definitionType;
+    }
+
+    public void setDefinitionType(ApiDefinitionType definitionType) {
+        this.definitionType = definitionType;
+    }
+
+    public boolean isParsePayload() {
+        return parsePayload;
+    }
+
+    public void setParsePayload(boolean parsePayload) {
+        this.parsePayload = parsePayload;
+    }
+
+    public boolean isDisableKeysStrip() {
+        return disableKeysStrip;
+    }
+
+    public void setDisableKeysStrip(boolean disableKeysStrip) {
+        this.disableKeysStrip = disableKeysStrip;
+    }
+
+    public String getDefinitionUrl() {
+        return definitionUrl;
+    }
+
+    public void setDefinitionUrl(String definitionUrl) {
+        this.definitionUrl = definitionUrl;
+    }
+
+    public boolean isExposeInPortal() {
+        return exposeInPortal;
+    }
+
+    public void setExposeInPortal(boolean exposeInPortal) {
+        this.exposeInPortal = exposeInPortal;
+    }
+
+    public String getExtendedDescription() {
+        return extendedDescription;
+    }
+
+    public void setExtendedDescription(String extendedDescription) {
+        this.extendedDescription = extendedDescription;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DeveloperApiVersionBeanDto that = (DeveloperApiVersionBeanDto) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", DeveloperApiVersionBeanDto.class.getSimpleName() + "[", "]")
+                .add("id=" + id)
+                .add("api=" + api)
+                .add("status=" + status)
+                .add("endpoint='" + endpoint + "'")
+                .add("endpointType=" + endpointType)
+                .add("endpointContentType=" + endpointContentType)
+                .add("endpointProperties=" + endpointProperties)
+                .add("gateways=" + gateways)
+                .add("publicAPI=" + publicAPI)
+                .add("plans=" + plans)
+                .add("version='" + version + "'")
+                .add("createdBy='" + createdBy + "'")
+                .add("createdOn=" + createdOn)
+                .add("modifiedBy='" + modifiedBy + "'")
+                .add("modifiedOn=" + modifiedOn)
+                .add("publishedOn=" + publishedOn)
+                .add("retiredOn=" + retiredOn)
+                .add("definitionType=" + definitionType)
+                .add("parsePayload=" + parsePayload)
+                .add("disableKeysStrip=" + disableKeysStrip)
+                .add("definitionUrl='" + definitionUrl + "'")
+                .add("exposeInPortal=" + exposeInPortal)
+                .add("extendedDescription='" + extendedDescription + "'")
+                .toString();
+    }
 }

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/developers/DeveloperBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/developers/DeveloperBean.java
@@ -40,6 +40,7 @@ import org.hibernate.annotations.Parameter;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Table(name = "developers")
 @Entity
+@Deprecated
 public class DeveloperBean implements Serializable {
 
     private static final long serialVersionUID = 7127400624541487145L;

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/developers/DeveloperMapper.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/developers/DeveloperMapper.java
@@ -1,0 +1,6 @@
+package io.apiman.manager.api.beans.developers;/**
+ * 
+ *
+ * @author Marc Savy {@literal <marc@blackparrotlabs.io>}
+ */public interface DeveloperMapper {
+}

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/developers/DeveloperMapper.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/developers/DeveloperMapper.java
@@ -1,6 +1,19 @@
-package io.apiman.manager.api.beans.developers;/**
- * 
+package io.apiman.manager.api.beans.developers;
+
+import io.apiman.manager.api.beans.apis.ApiVersionBean;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
  *
  * @author Marc Savy {@literal <marc@blackparrotlabs.io>}
- */public interface DeveloperMapper {
+ */
+@Mapper
+public interface DeveloperMapper {
+
+    DeveloperMapper INSTANCE = Mappers.getMapper(DeveloperMapper.class);
+
+    DeveloperApiVersionBeanDto toDto(ApiVersionBean apiVersion);
 }

--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/DeveloperResourceImpl.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/rest/impl/DeveloperResourceImpl.java
@@ -19,7 +19,9 @@ package io.apiman.manager.api.rest.impl;
 import io.apiman.common.logging.ApimanLoggerFactory;
 import io.apiman.common.logging.IApimanLogger;
 import io.apiman.manager.api.beans.apis.ApiVersionBean;
+import io.apiman.manager.api.beans.developers.DeveloperApiVersionBeanDto;
 import io.apiman.manager.api.beans.developers.DeveloperBean;
+import io.apiman.manager.api.beans.developers.DeveloperMapper;
 import io.apiman.manager.api.beans.developers.DeveloperMappingBean;
 import io.apiman.manager.api.beans.developers.UpdateDeveloperBean;
 import io.apiman.manager.api.beans.summary.ClientVersionSummaryBean;
@@ -37,13 +39,12 @@ import io.apiman.manager.api.rest.impl.util.RestHelper;
 import io.apiman.manager.api.security.ISecurityContext;
 import io.apiman.manager.api.service.ApiService;
 import io.apiman.manager.api.service.ApiService.ApiDefinitionStream;
-import io.apiman.manager.api.service.ClientAppService;
-import io.apiman.manager.api.service.ContractService;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.transaction.Transactional;
@@ -170,7 +171,7 @@ public class DeveloperResourceImpl implements IDeveloperResource, DataAccessUtil
     }
 
     @Override
-    public List<ApiVersionBean> getAllApiVersions(String id) throws DeveloperNotFoundException, NotAuthorizedException {
+    public List<DeveloperApiVersionBeanDto> getAllApiVersions(String id) throws DeveloperNotFoundException, NotAuthorizedException {
         securityContext.checkIfUserIsCurrentUser(id);
 
         List<ApiVersionBean> apiVersionBeans = new ArrayList<>();
@@ -183,7 +184,9 @@ public class DeveloperResourceImpl implements IDeveloperResource, DataAccessUtil
                 apiVersionBeans.add(RestHelper.hideSensitiveDataFromApiVersionBean(apiVersion));
             }
         }
-        return apiVersionBeans;
+        return apiVersionBeans.stream()
+                .map(DeveloperMapper.INSTANCE::toDto)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/manager/api/rest/src/main/java/io/apiman/manager/api/rest/IDeveloperResource.java
+++ b/manager/api/rest/src/main/java/io/apiman/manager/api/rest/IDeveloperResource.java
@@ -18,6 +18,7 @@ package io.apiman.manager.api.rest;
 
 import io.apiman.common.util.MediaType;
 import io.apiman.manager.api.beans.apis.ApiVersionBean;
+import io.apiman.manager.api.beans.developers.DeveloperApiVersionBeanDto;
 import io.apiman.manager.api.beans.developers.DeveloperBean;
 import io.apiman.manager.api.beans.developers.UpdateDeveloperBean;
 import io.apiman.manager.api.beans.summary.ClientVersionSummaryBean;
@@ -182,7 +183,7 @@ public interface IDeveloperResource {
     @GET
     @Path("{developerId}/apis")
     @Produces(MediaType.APPLICATION_JSON)
-    List<ApiVersionBean> getAllApiVersions(@PathParam("developerId") String id) throws DeveloperNotFoundException, NotAuthorizedException;
+    List<DeveloperApiVersionBeanDto> getAllApiVersions(@PathParam("developerId") String id) throws DeveloperNotFoundException, NotAuthorizedException;
 
     /**
      * Use this endpoint to retrieve the API Definition if the user has a contract to


### PR DESCRIPTION
To avoid Jackson IdentityInfo references leaking to presentation layer we add a simple DTO.