### PR TITLE
replace "Opendistro for Elasticsearch" with "Opensearch"

### DIFF
--- a/common/es/src/main/resources-filtered/io/apiman/common/es/util/apiman-es.properties
+++ b/common/es/src/main/resources-filtered/io/apiman/common/es/util/apiman-es.properties
@@ -1,2 +1,2 @@
 apiman.elasticsearch-version=${version.org.elasticsearch}
-apiman.opendistro-version=${version.com.amazon.opendistroforelasticsearch}
+apiman.opensearch-version=${version.org.opensearch.opensearch}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -102,7 +102,7 @@
     <version.commons-io>2.11.0</version.commons-io>
     <version.commons-logging>1.2</version.commons-logging>
     <version.commons-pool>1.6</version.commons-pool>
-    <version.com.amazon.opendistroforelasticsearch>1.13.1</version.com.amazon.opendistroforelasticsearch>
+    <version.org.opensearch.opensearch>1.2.4</version.org.opensearch.opensearch>
     <version.com.zaxxer>2.7.9</version.com.zaxxer>
     <version.com.google.guava>30.1.1-jre</version.com.google.guava>
     <version.io.prometheus>0.0.13</version.io.prometheus>

--- a/test/common/src/main/java/io/apiman/test/common/es/EsTestUtil.java
+++ b/test/common/src/main/java/io/apiman/test/common/es/EsTestUtil.java
@@ -29,8 +29,8 @@ public final class EsTestUtil {
     private EsTestUtil() {}
 
     /**
-     * Provide a testcontainer for elasticsearch based on a system property or environment variable.
-     * Use apiman.es.provider=opendistro or APIMAN_ES_PROVIDER=opendistro
+     * Provide a test container for elasticsearch based on a system property or environment variable.
+     * Use apiman.es.provider=opensearch or APIMAN_ES_PROVIDER=opensearch
      *
      * @return a testcontainer for elasticsearch tests
      */
@@ -39,11 +39,13 @@ public final class EsTestUtil {
         String esProvider = Optional.ofNullable(System.getenv("APIMAN_ES_PROVIDER"))
             .orElseGet(() -> System.getProperty("apiman.es.provider"));
 
-        if ("opendistro".equalsIgnoreCase(esProvider)) {
-            return new ElasticsearchContainer(DockerImageName.parse("amazon/opendistro-for-elasticsearch")
-                .withTag(EsConstants.getEsVersion().getProperty("apiman.opendistro-version"))
+        if ("opensearch".equalsIgnoreCase(esProvider)) {
+            return new ElasticsearchContainer(DockerImageName.parse("opensearchproject/opensearch")
+                .withTag(EsConstants.getEsVersion().getProperty("apiman.opensearch-version"))
                 .asCompatibleSubstituteFor(esImageType))
-                .withEnv("opendistro_security.disabled", "true");
+                .withEnv("discovery.type", "single-node")
+                .withEnv("DISABLE_INSTALL_DEMO_CONFIG", "true")
+                .withEnv("DISABLE_SECURITY_PLUGIN", "true");
         }
         return new ElasticsearchContainer(DockerImageName.parse(esImageType)
             .withTag(EsConstants.getEsVersion().getProperty("apiman.elasticsearch-version")))


### PR DESCRIPTION
Changed the ability to run opensearch instead of opendistro if you run apiman test suites

Closes #1825