### PR TITLE
refactor(distro-ddl): put Postgres bool functions into Liquibase definition

### DIFF
--- a/distro/ddl/src/main/liquibase/current/201-postgres-add-bool-function.xml
+++ b/distro/ddl/src/main/liquibase/current/201-postgres-add-bool-function.xml
@@ -1,0 +1,45 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+  <changeSet author="msavy marc@blackparrotlabs.io" id="postgresql-boolean-function" dbms="postgresql">
+    <comment>Add boolean parsing function for Postgres (needed for older versions of Postgres to facilitate Hibernate integration)</comment>
+    <sql stripComments="true" ><![CDATA[
+      CREATE OR REPLACE FUNCTION inttobool(num int, val bool) RETURNS bool AS '
+      BEGIN
+          IF num=0 AND NOT val THEN
+              RETURN true;
+          ELSIF num<>0 AND val THEN
+              RETURN true;
+      ELSE
+              RETURN false;
+      END IF;
+      END;
+      ' LANGUAGE 'plpgsql';
+
+      CREATE OR REPLACE FUNCTION inttobool(val bool, num int) RETURNS bool AS '
+          BEGIN
+          RETURN inttobool(num,val);
+          END;
+      ' LANGUAGE 'plpgsql';
+
+      DROP OPERATOR IF EXISTS = (integer, boolean);
+      CREATE OPERATOR = (
+           leftarg = integer,
+           rightarg = boolean,
+           procedure = inttobool,
+           commutator = =,
+           negator = !=
+      );
+      DROP OPERATOR IF EXISTS = (boolean, integer);
+      CREATE OPERATOR = (
+           leftarg = boolean,
+           rightarg = integer,
+           procedure = inttobool,
+           commutator = =,
+           negator = !=
+      );
+    ]]>
+    </sql>
+  </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Previously we were manually inserting the intotobool functions into our DDL, which made it easy to
accidentally overwrite when we updated our data model.

This is now done automatically, so should reduce mistakes in this area.

Closes #1845