### PR TITLE
fix(gateway-engine-policies): check for null request path in URLRewritingPolicy

### DIFF
--- a/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/ApiRequest.java
+++ b/gateway/engine/beans/src/main/java/io/apiman/gateway/engine/beans/ApiRequest.java
@@ -20,6 +20,8 @@ import io.apiman.gateway.engine.beans.util.QueryMap;
 
 import java.io.Serializable;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * An inbound request for a managed API.
  *
@@ -116,6 +118,7 @@ public class ApiRequest implements IApiObject, Serializable {
     /**
      * @return the destination
      */
+    @Nullable
     public String getDestination() {
         return destination;
     }

--- a/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/URLRewritingPolicy.java
+++ b/gateway/engine/policies/src/main/java/io/apiman/gateway/engine/policies/URLRewritingPolicy.java
@@ -52,7 +52,9 @@ public class URLRewritingPolicy extends AbstractMappedDataPolicy<URLRewritingCon
     protected void doApply(ApiRequest request, IPolicyContext context, URLRewritingConfig config,
             IPolicyChain<ApiRequest> chain) {
         if (config.isProcessRequestUrl()) {
-            request.setDestination(request.getDestination().replaceAll(config.getFromRegex(), config.getToReplacement()));
+            if (request.getDestination() != null) {
+                request.setDestination(request.getDestination().replaceAll(config.getFromRegex(), config.getToReplacement()));
+            }
         }
         if (config.isProcessRequestHeaders()) {
             replaceHeaders(config, request.getHeaders());

--- a/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/URLRewritingPolicyTest.java
+++ b/gateway/engine/policies/src/test/java/io/apiman/gateway/engine/policies/URLRewritingPolicyTest.java
@@ -139,7 +139,7 @@ public class URLRewritingPolicyTest extends ApimanPolicyTest {
         final String responseBody = response.body();
         Assert.assertNotNull(responseBody);
         final HashMap responseMap = new ObjectMapper().readValue(responseBody, HashMap.class);
-        Assertions.assertThat(responseMap.get("resource")).isNull();
+        Assertions.assertThat(responseMap.get("resource")).isEqualTo("/?foo=bar");
     }
 
     public static final class URLRewritingTestBackend implements IPolicyTestBackEndApi {


### PR DESCRIPTION
- fix(gateway-engine-policies): check for null request path in URLRewritingPolicy
- test(gateway-engine-policies): add test for empty resource on URLRewritingPolicy

Fixes #1828