### PR TITLE
fix(manager-api-beans): UpdateApiVersionBean should use Boolean wrapper to allow null (indicates no update)

### DIFF
--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apis/ApiVersionBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apis/ApiVersionBean.java
@@ -20,7 +20,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.StringJoiner;
 import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -120,7 +119,7 @@ public class ApiVersionBean implements Serializable, Cloneable {
     @Column(name = "definition_url", updatable = true, nullable = true)
     private String definitionUrl;
     @Column(name = "expose_in_portal", updatable = true, nullable = false)
-    private boolean exposeInPortal = false;
+    private Boolean exposeInPortal = false;
     @Column(name = "extended_description", updatable = true, nullable = true)
     @Nationalized
     @Lob // <-- may not be necessary? // varchar -> nvarchar
@@ -430,11 +429,11 @@ public class ApiVersionBean implements Serializable, Cloneable {
         this.definitionUrl = definitionUrl;
     }
 
-    public boolean isExposeInPortal() {
+    public Boolean isExposeInPortal() {
         return exposeInPortal;
     }
 
-    public ApiVersionBean setExposeInPortal(boolean exposeInPortal) {
+    public ApiVersionBean setExposeInPortal(Boolean exposeInPortal) {
         this.exposeInPortal = exposeInPortal;
         return this;
     }

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apis/UpdateApiVersionBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apis/UpdateApiVersionBean.java
@@ -44,7 +44,7 @@ public class UpdateApiVersionBean implements Serializable {
     private Boolean disableKeysStrip;
     private Set<ApiPlanBean> plans;
     private String extendedDescription;
-    private boolean exposeInPortal = false;
+    private Boolean exposeInPortal;
 
     /**
      * Constructor.
@@ -183,11 +183,11 @@ public class UpdateApiVersionBean implements Serializable {
         return this;
     }
 
-    public boolean isExposeInPortal() {
+    public Boolean isExposeInPortal() {
         return exposeInPortal;
     }
 
-    public UpdateApiVersionBean setExposeInPortal(boolean exposeInPortal) {
+    public UpdateApiVersionBean setExposeInPortal(Boolean exposeInPortal) {
         this.exposeInPortal = exposeInPortal;
         return this;
     }


### PR DESCRIPTION
With previous code `exposeInPortal` would default to false, and hence if the UI tried to submit a
patch update it could accidentally be set to `false` automatically.

Fixes #1861