### PR TITLE
fix(manager-api-jpa): ensure policies are not left dangling after deletion

### DIFF
--- a/manager/test/api/src/test/java/io/apiman/manager/test/DeleteTest.java
+++ b/manager/test/api/src/test/java/io/apiman/manager/test/DeleteTest.java
@@ -1,0 +1,16 @@
+package io.apiman.manager.test;
+
+import io.apiman.manager.test.junit.ManagerRestTestPlan;
+import io.apiman.manager.test.junit.ManagerRestTester;
+
+import org.junit.runner.RunWith;
+
+/**
+ * Runs the "delete" test plan.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+@RunWith(ManagerRestTester.class)
+@ManagerRestTestPlan("test-plans/delete-testPlan.xml")
+public class DeleteTest {
+}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/api/001_delete-api.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/api/001_delete-api.resttest
@@ -1,0 +1,3 @@
+DELETE /organizations/Organization1/apis/Test admin/admin
+----
+204

--- a/manager/test/api/src/test/resources/test-plan-data/delete/api/002_recreate-api.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/api/002_recreate-api.resttest
@@ -1,0 +1,20 @@
+POST /organizations/Organization1/apis admin/admin
+Content-Type: application/json
+
+{
+  "name" : "Test",
+  "description" : "This is the description of Test."
+}
+----
+200
+Content-Type: application/json
+
+{
+  "organization" : {
+    "id" : "Organization1"
+  },
+  "id" : "Test",
+  "name" : "Test",
+  "description" : "This is the description of Test.",
+  "createdBy" : "admin"
+}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/api/003_activity.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/api/003_activity.resttest
@@ -1,0 +1,19 @@
+GET /organizations/Organization1/apis/Test/activity admin/admin
+----
+200
+Content-Type: application/json
+
+{
+  "beans" : [
+    {
+      "who":"admin",
+      "organizationId":"Organization1",
+      "entityType":"Api",
+      "entityId":"Test",
+      "entityVersion":null,
+      "what":"Create",
+      "data":null
+    }
+  ],
+  "totalSize":1
+}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/api/004_get-missing-version.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/api/004_get-missing-version.resttest
@@ -1,0 +1,6 @@
+GET /organizations/Organization1/apis/Test/versions/1.0 admin/admin
+----
+404
+Content-Type: application/json
+
+{"type":"ApiVersionNotFoundException","errorCode":5003,"message":"API Version does not exist: Test/1.0","moreInfoUrl":null}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/api/005_create-version-1.0.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/api/005_create-version-1.0.resttest
@@ -1,0 +1,24 @@
+POST /organizations/Organization1/apis/Test/versions admin/admin
+Content-Type: application/json
+
+{
+  "version" : "1.0"
+}
+----
+200
+Content-Type: application/json
+
+{
+  "api" : {
+    "organization" : {
+      "id" : "Organization1"
+    },
+    "id" : "Test",
+    "name" : "Test",
+    "description" : "This is the description of Test.",
+    "createdBy":"admin"
+  },
+  "status" : "Created",
+  "version" : "1.0",
+  "createdBy" : "admin"
+}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/api/006_version-activity.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/api/006_version-activity.resttest
@@ -1,0 +1,19 @@
+GET /organizations/Organization1/apis/Test/versions/1.0/activity admin/admin
+----
+200
+Content-Type: application/json
+
+{
+  "beans" : [
+    {
+      "who":"admin",
+      "organizationId":"Organization1",
+      "entityType":"Api",
+      "entityId":"Test",
+      "entityVersion":"1.0",
+      "what":"Create",
+      "data":null
+    }
+  ],
+  "totalSize":1
+}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/api/007_list-api-policies.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/api/007_list-api-policies.resttest
@@ -1,0 +1,6 @@
+GET /organizations/Organization1/apis/Test/versions/1.0/policies admin/admin
+----
+200
+Content-Type: application/json
+
+[]

--- a/manager/test/api/src/test/resources/test-plan-data/delete/api/008_list-client-policies.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/api/008_list-client-policies.resttest
@@ -3,4 +3,4 @@ GET /organizations/Organization1/clients/Test/versions/1.0/policies admin/admin
 200
 Content-Type: application/json
 
-[{"policyDefinitionId":"RateLimitingPolicy","id":8,"name":"Rate Limiting Policy","description":"Consumers are limited to  requests per  per .","icon":"sliders","createdBy":"admin","createdOn":"2022-03-25T10:43:33.000+00:00"}]
+[{"policyDefinitionId":"RateLimitingPolicy","id":8,"name":"Rate Limiting Policy","description":"Consumers are limited to  requests per  per .","icon":"sliders","createdBy":"admin"}]

--- a/manager/test/api/src/test/resources/test-plan-data/delete/api/008_list-client-policies.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/api/008_list-client-policies.resttest
@@ -1,0 +1,6 @@
+GET /organizations/Organization1/clients/Test/versions/1.0/policies admin/admin
+----
+200
+Content-Type: application/json
+
+[{"policyDefinitionId":"RateLimitingPolicy","id":8,"name":"Rate Limiting Policy","description":"Consumers are limited to  requests per  per .","icon":"sliders","createdBy":"admin","createdOn":"2022-03-25T10:43:33.000+00:00"}]

--- a/manager/test/api/src/test/resources/test-plan-data/delete/api/009_list-plan-policies.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/api/009_list-plan-policies.resttest
@@ -3,4 +3,4 @@ GET /organizations/Organization1/plans/Test/versions/1.0/policies admin/admin
 200
 Content-Type: application/json
 
-[{"policyDefinitionId":"RateLimitingPolicy","id":4,"name":"Rate Limiting Policy","description":"Consumers are limited to  requests per  per .","icon":"sliders","createdBy":"admin","createdOn":"2022-03-25T10:43:08.000+00:00"}]
+[{"policyDefinitionId":"RateLimitingPolicy","id":4,"name":"Rate Limiting Policy","description":"Consumers are limited to  requests per  per .","icon":"sliders","createdBy":"admin"}]

--- a/manager/test/api/src/test/resources/test-plan-data/delete/api/009_list-plan-policies.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/api/009_list-plan-policies.resttest
@@ -1,0 +1,6 @@
+GET /organizations/Organization1/plans/Test/versions/1.0/policies admin/admin
+----
+200
+Content-Type: application/json
+
+[{"policyDefinitionId":"RateLimitingPolicy","id":4,"name":"Rate Limiting Policy","description":"Consumers are limited to  requests per  per .","icon":"sliders","createdBy":"admin","createdOn":"2022-03-25T10:43:08.000+00:00"}]

--- a/manager/test/api/src/test/resources/test-plan-data/delete/client/001_delete-client.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/client/001_delete-client.resttest
@@ -1,0 +1,3 @@
+DELETE /organizations/Organization1/clients/Test admin/admin
+----
+204

--- a/manager/test/api/src/test/resources/test-plan-data/delete/client/002_recreate-client.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/client/002_recreate-client.resttest
@@ -1,0 +1,20 @@
+POST /organizations/Organization1/clients admin/admin
+Content-Type: application/json
+
+{
+  "name" : "Test",
+  "description" : "This is the description of Test."
+}
+----
+200
+Content-Type: application/json
+
+{
+  "organization" : {
+    "id" : "Organization1"
+  },
+  "id" : "Test",
+  "name" : "Test",
+  "description" : "This is the description of Test.",
+  "createdBy" : "admin"
+}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/client/003_activity.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/client/003_activity.resttest
@@ -1,0 +1,19 @@
+GET /organizations/Organization1/clients/Test/activity admin/admin
+----
+200
+Content-Type: application/json
+
+{
+  "beans" : [
+    {
+      "who":"admin",
+      "organizationId":"Organization1",
+      "entityType":"Client",
+      "entityId":"Test",
+      "entityVersion":null,
+      "what":"Create",
+      "data":null
+    }
+  ],
+  "totalSize":1
+}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/client/004_get-missing-version.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/client/004_get-missing-version.resttest
@@ -1,0 +1,6 @@
+GET /organizations/Organization1/clients/Test/versions/1.0 admin/admin
+----
+404
+Content-Type: application/json
+
+{"type":"ClientVersionNotFoundException","errorCode":4003,"message":"Client Version does not exist: Test/1.0","moreInfoUrl":null}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/client/005_create-version-1.0.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/client/005_create-version-1.0.resttest
@@ -1,0 +1,24 @@
+POST /organizations/Organization1/clients/Test/versions admin/admin
+Content-Type: application/json
+
+{
+  "version" : "1.0"
+}
+----
+200
+Content-Type: application/json
+
+{
+  "client" : {
+    "organization" : {
+      "id" : "Organization1"
+    },
+    "id" : "Test",
+    "name" : "Test",
+    "description" : "This is the description of Test.",
+    "createdBy":"admin"
+  },
+  "status" : "Created",
+  "version" : "1.0",
+  "createdBy" : "admin"
+}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/client/006_version-activity.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/client/006_version-activity.resttest
@@ -1,0 +1,19 @@
+GET /organizations/Organization1/clients/Test/versions/1.0/activity admin/admin
+----
+200
+Content-Type: application/json
+
+{
+  "beans" : [
+    {
+      "who":"admin",
+      "organizationId":"Organization1",
+      "entityType":"Client",
+      "entityId":"Test",
+      "entityVersion":"1.0",
+      "what":"Create",
+      "data":null
+    }
+  ],
+  "totalSize":1
+}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/client/007_list-client-policies.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/client/007_list-client-policies.resttest
@@ -1,0 +1,6 @@
+GET /organizations/Organization1/clients/Test/versions/1.0/policies admin/admin
+----
+200
+Content-Type: application/json
+
+[]

--- a/manager/test/api/src/test/resources/test-plan-data/delete/client/008_list-plan-policies.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/client/008_list-plan-policies.resttest
@@ -3,4 +3,4 @@ GET /organizations/Organization1/plans/Test/versions/1.0/policies admin/admin
 200
 Content-Type: application/json
 
-[{"policyDefinitionId":"RateLimitingPolicy","id":4,"name":"Rate Limiting Policy","description":"Consumers are limited to  requests per  per .","icon":"sliders","createdBy":"admin","createdOn":"2022-03-25T10:43:08.000+00:00"}]
+[{"policyDefinitionId":"RateLimitingPolicy","id":4,"name":"Rate Limiting Policy","description":"Consumers are limited to  requests per  per .","icon":"sliders","createdBy":"admin"}]

--- a/manager/test/api/src/test/resources/test-plan-data/delete/client/008_list-plan-policies.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/client/008_list-plan-policies.resttest
@@ -1,0 +1,6 @@
+GET /organizations/Organization1/plans/Test/versions/1.0/policies admin/admin
+----
+200
+Content-Type: application/json
+
+[{"policyDefinitionId":"RateLimitingPolicy","id":4,"name":"Rate Limiting Policy","description":"Consumers are limited to  requests per  per .","icon":"sliders","createdBy":"admin","createdOn":"2022-03-25T10:43:08.000+00:00"}]

--- a/manager/test/api/src/test/resources/test-plan-data/delete/import/000_import-data.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/import/000_import-data.resttest
@@ -1,0 +1,486 @@
+POST /system/import admin/admin
+Content-Type: application/json
+
+{
+  "Metadata" : {
+    "id" : 1648206297334,
+    "exportedOn" : "2022-03-25T11:04:57Z",
+    "apimanVersion" : "3.0.0-SNAPSHOT"
+  },
+  "Users" : [ {
+    "username" : "admin",
+    "fullName" : "apiman admin",
+    "email" : "admin@example.org",
+    "joinedOn" : "2022-03-25T10:40:36Z",
+    "locale" : "en",
+    "notificationPreferences" : [ ],
+    "admin" : false
+  }, {
+    "username" : "user",
+    "fullName" : "apiman user",
+    "email" : "user@example.com",
+    "joinedOn" : "2022-03-25T11:04:30Z",
+    "locale" : "en",
+    "notificationPreferences" : [ ],
+    "admin" : false
+  } ],
+  "Gateways" : [ {
+    "id" : "TheGateway",
+    "name" : "The Gateway",
+    "description" : "This is the default gateway.",
+    "createdBy" : "admin",
+    "createdOn" : "2018-05-09T12:00:00Z",
+    "modifiedBy" : "admin",
+    "modifiedOn" : "2018-05-09T12:00:00Z",
+    "type" : "REST",
+    "configuration" : "{\"endpoint\":\"${apiman.gateway-endpoint:https://localhost:8443/apiman-gateway-api}\",\"username\":\"${apiman.gateway-endpoint.username:apimanager}\",\"password\":\"${apiman.gateway-endpoint.password:apiman123!}\"}"
+  } ],
+  "Plugins" : [ ],
+  "Roles" : [ {
+    "id" : "APIDeveloper",
+    "name" : "API Developer",
+    "description" : "Users responsible for creating and managing APIs should be granted this role within an Organization.",
+    "createdBy" : "admin",
+    "createdOn" : "2016-05-16T12:34:14Z",
+    "autoGrant" : false,
+    "permissions" : [ "apiEdit", "orgView", "apiView", "planAdmin", "planEdit", "planView", "apiAdmin" ]
+  }, {
+    "id" : "ClientAppDeveloper",
+    "name" : "Client App Developer",
+    "description" : "Users responsible for creating and managing client apps should be granted this role within an Organization.",
+    "createdBy" : "admin",
+    "createdOn" : "2016-05-16T12:34:14Z",
+    "autoGrant" : false,
+    "permissions" : [ "orgView", "clientView", "clientAdmin", "clientEdit" ]
+  }, {
+    "id" : "OrganizationOwner",
+    "name" : "Organization Owner",
+    "description" : "Automatically granted to the user who creates an Organization.  Grants all privileges.",
+    "createdBy" : "admin",
+    "createdOn" : "2016-05-16T12:34:14Z",
+    "autoGrant" : true,
+    "permissions" : [ "apiEdit", "orgView", "apiView", "orgAdmin", "orgEdit", "planAdmin", "planEdit", "clientView", "planView", "clientAdmin", "clientEdit", "apiAdmin" ]
+  } ],
+  "PolicyDefinitions" : [ {
+    "id" : "AuthorizationPolicy",
+    "policyImpl" : "class:io.apiman.gateway.engine.policies.AuthorizationPolicy",
+    "name" : "Authorization Policy",
+    "description" : "Enables fine grained authorization to API resources based on authenticated user roles.",
+    "icon" : "users",
+    "templates" : [ {
+      "template" : "Appropriate authorization roles are required.  There are ${rules.size()} authorization rules defined."
+    } ],
+    "formType" : "Default",
+    "deleted" : false
+  }, {
+    "id" : "BASICAuthenticationPolicy",
+    "policyImpl" : "class:io.apiman.gateway.engine.policies.BasicAuthenticationPolicy",
+    "name" : "BASIC Authentication Policy",
+    "description" : "Enables HTTP BASIC Authentication on an API.  Some configuration required.",
+    "icon" : "lock",
+    "templates" : [ {
+      "template" : "Access to the API is protected by BASIC Authentication through the '${realm}' authentication realm.  @if{forwardIdentityHttpHeader != null}Successfully authenticated requests will forward the authenticated identity to the back end API via the '${forwardIdentityHttpHeader}' custom HTTP header.@end{}"
+    } ],
+    "formType" : "Default",
+    "deleted" : false
+  }, {
+    "id" : "CachingResourcesPolicy",
+    "policyImpl" : "class:io.apiman.gateway.engine.policies.CachingResourcesPolicy",
+    "name" : "Caching Resources Policy",
+    "description" : "Allows caching of API responses in the Gateway to reduce overall traffic to the back-end API.",
+    "icon" : "hdd-o",
+    "templates" : [ {
+      "template" : "API responses will be cached for @{ttl} seconds."
+    } ],
+    "deleted" : false
+  }, {
+    "id" : "IPBlacklistPolicy",
+    "policyImpl" : "class:io.apiman.gateway.engine.policies.IPBlacklistPolicy",
+    "name" : "IP Blacklist Policy",
+    "description" : "Requests that originate from a specified set of valid IP addresses will be denied access.",
+    "icon" : "thumbs-down",
+    "templates" : [ {
+      "template" : "Requests that originate from the set of ${ipList.size()} configured IP address(es) will be denied access to the managed API."
+    } ],
+    "formType" : "Default",
+    "deleted" : false
+  }, {
+    "id" : "IPWhitelistPolicy",
+    "policyImpl" : "class:io.apiman.gateway.engine.policies.IPWhitelistPolicy",
+    "name" : "IP Whitelist Policy",
+    "description" : "Only requests that originate from a specified set of valid IP addresses will be allowed through.",
+    "icon" : "filter",
+    "templates" : [ {
+      "template" : "Only requests that originate from the set of ${ipList.size()} configured IP address(es) will be allowed to invoke the managed API."
+    } ],
+    "formType" : "Default",
+    "deleted" : false
+  }, {
+    "id" : "IgnoredResourcesPolicy",
+    "policyImpl" : "class:io.apiman.gateway.engine.policies.IgnoredResourcesPolicy",
+    "name" : "Ignored Resources Policy",
+    "description" : "Requests satisfying the provided regular expression will be ignored.",
+    "icon" : "eye-slash",
+    "templates" : [ {
+      "template" : "Requests matching any of the ${rules.size()} regular expressions provided will receive a 404 error code."
+    } ],
+    "formType" : "Default",
+    "deleted" : false
+  }, {
+    "id" : "QuotaPolicy",
+    "policyImpl" : "class:io.apiman.gateway.engine.policies.QuotaPolicy",
+    "name" : "Quota Policy",
+    "description" : "Provides a way to limit the total number of requests that can be sent to an API.",
+    "icon" : "exchange",
+    "templates" : [ {
+      "template" : "Consumers cannot exceed their quota of ${limit} requests per ${granularity} per ${period}."
+    } ],
+    "formType" : "Default",
+    "deleted" : false
+  }, {
+    "id" : "RateLimitingPolicy",
+    "policyImpl" : "class:io.apiman.gateway.engine.policies.RateLimitingPolicy",
+    "name" : "Rate Limiting Policy",
+    "description" : "Enforces rate configurable request rate limits on an API.  This ensures that consumers can't overload an API with too many requests.",
+    "icon" : "sliders",
+    "templates" : [ {
+      "template" : "Consumers are limited to ${limit} requests per ${granularity} per ${period}."
+    } ],
+    "formType" : "Default",
+    "deleted" : false
+  }, {
+    "id" : "TimeRestrictedAccessPolicy",
+    "policyImpl" : "class:io.apiman.gateway.engine.policies.TimeRestrictedAccessPolicy",
+    "name" : "Time Restricted Access Policy",
+    "description" : "Requests matching the specified regular expression and made within the specified time period will be ignored.",
+    "icon" : "clock-o",
+    "templates" : [ {
+      "template" : "Requests matching the regular expression and made outside the specified time period will receive a 423 error code."
+    } ],
+    "formType" : "Default",
+    "deleted" : false
+  }, {
+    "id" : "TransferQuotaPolicy",
+    "policyImpl" : "class:io.apiman.gateway.engine.policies.TransferQuotaPolicy",
+    "name" : "Transfer Quota Policy",
+    "description" : "Provides a way to limit the total number of bytes that can be transferred from (or to) an API.",
+    "icon" : "download",
+    "templates" : [ {
+      "template" : "Consumers are limited to transferring ${limit} bytes per ${granularity} per ${period}."
+    } ],
+    "formType" : "Default",
+    "deleted" : false
+  }, {
+    "id" : "URLRewritingPolicy",
+    "policyImpl" : "class:io.apiman.gateway.engine.policies.URLRewritingPolicy",
+    "name" : "URL Rewriting Policy",
+    "description" : "Responses from the back-end API will be modified by fixing up any incorrect URLs found with modified ones.  This is useful because apiman works through an API Gateway.",
+    "icon" : "pencil-square",
+    "templates" : [ {
+      "template" : "Requests and/or responses will be modified by finding all text matching regular expression '${fromRegex}' with '${toReplacement}'."
+    } ],
+    "formType" : "Default",
+    "deleted" : false
+  } ],
+  "Developers" : [ ],
+  "Blobs" : [ ],
+  "Orgs" : [ {
+    "OrganizationBean" : {
+      "id" : "Organization1",
+      "name" : "Organization1",
+      "createdBy" : "admin",
+      "createdOn" : "2022-03-25T10:41:52Z",
+      "modifiedBy" : "admin",
+      "modifiedOn" : "2022-03-25T10:41:52Z"
+    },
+    "Memberships" : [ {
+      "id" : 1000,
+      "userId" : "admin",
+      "roleId" : "OrganizationOwner",
+      "organizationId" : "Organization1",
+      "createdOn" : "2022-03-25T10:41:52Z"
+    }, {
+      "id" : 1033,
+      "userId" : "user",
+      "roleId" : "APIDeveloper",
+      "organizationId" : "Organization1",
+      "createdOn" : "2022-03-25T11:04:51Z"
+    } ],
+    "Plans" : [ {
+      "PlanBean" : {
+        "id" : "Test",
+        "name" : "Test",
+        "createdBy" : "admin",
+        "createdOn" : "2022-03-25T10:42:50Z"
+      },
+      "Versions" : [ {
+        "PlanVersionBean" : {
+          "id" : 1002,
+          "status" : "Created",
+          "version" : "1.0",
+          "createdBy" : "admin",
+          "createdOn" : "2022-03-25T10:42:50Z",
+          "modifiedBy" : "admin",
+          "modifiedOn" : "2022-03-25T10:43:08Z"
+        },
+        "Policies" : [ {
+          "id" : 1004,
+          "type" : "Plan",
+          "organizationId" : "Organization1",
+          "entityId" : "Test",
+          "entityVersion" : "1.0",
+          "name" : "Rate Limiting Policy",
+          "configuration" : "{\"limit\":1,\"granularity\":\"Client\",\"period\":\"Second\"}",
+          "createdBy" : "admin",
+          "createdOn" : "2022-03-25T10:43:08Z",
+          "modifiedBy" : "admin",
+          "modifiedOn" : "2022-03-25T10:43:08Z",
+          "definition" : {
+            "id" : "RateLimitingPolicy",
+            "templates" : [ ],
+            "deleted" : false
+          },
+          "orderIndex" : 1
+        } ]
+      } ]
+    } ],
+    "Apis" : [ {
+      "ApiBean" : {
+        "id" : "Test",
+        "name" : "Test",
+        "tags" : [ ],
+        "createdBy" : "admin",
+        "createdOn" : "2022-03-25T10:43:44Z"
+      },
+      "Versions" : [ {
+        "ApiVersionBean" : {
+          "id" : 1012,
+          "status" : "Created",
+          "endpointProperties" : { },
+          "gateways" : [ {
+            "gatewayId" : "TheGateway"
+          } ],
+          "publicAPI" : false,
+          "plans" : [ ],
+          "version" : "1.0",
+          "createdBy" : "admin",
+          "createdOn" : "2022-03-25T10:43:44Z",
+          "modifiedBy" : "admin",
+          "modifiedOn" : "2022-03-25T10:43:58Z",
+          "definitionType" : "None",
+          "parsePayload" : false,
+          "disableKeysStrip" : false,
+          "exposeInPortal" : false
+        },
+        "Policies" : [ {
+          "id" : 1014,
+          "type" : "Api",
+          "organizationId" : "Organization1",
+          "entityId" : "Test",
+          "entityVersion" : "1.0",
+          "name" : "Rate Limiting Policy",
+          "configuration" : "{\"limit\":1,\"granularity\":\"Client\",\"period\":\"Second\"}",
+          "createdBy" : "admin",
+          "createdOn" : "2022-03-25T10:43:58Z",
+          "modifiedBy" : "admin",
+          "modifiedOn" : "2022-03-25T10:43:58Z",
+          "definition" : {
+            "id" : "RateLimitingPolicy",
+            "templates" : [ ],
+            "deleted" : false
+          },
+          "orderIndex" : 1
+        } ]
+      } ]
+    } ],
+    "Clients" : [ {
+      "ClientBean" : {
+        "id" : "Test",
+        "name" : "Test",
+        "createdBy" : "admin",
+        "createdOn" : "2022-03-25T10:43:21Z"
+      },
+      "Versions" : [ {
+        "ClientVersionBean" : {
+          "id" : 1007,
+          "status" : "Created",
+          "version" : "1.0",
+          "createdBy" : "admin",
+          "createdOn" : "2022-03-25T10:43:21Z",
+          "modifiedBy" : "admin",
+          "modifiedOn" : "2022-03-25T10:43:33Z",
+          "apikey" : "3a2636bc-2d9b-483f-8bb9-fcca183f0923"
+        },
+        "Policies" : [ {
+          "id" : 1009,
+          "type" : "Client",
+          "organizationId" : "Organization1",
+          "entityId" : "Test",
+          "entityVersion" : "1.0",
+          "name" : "Rate Limiting Policy",
+          "configuration" : "{\"limit\":1,\"granularity\":\"Client\",\"period\":\"Second\"}",
+          "createdBy" : "admin",
+          "createdOn" : "2022-03-25T10:43:33Z",
+          "modifiedBy" : "admin",
+          "modifiedOn" : "2022-03-25T10:43:33Z",
+          "definition" : {
+            "id" : "RateLimitingPolicy",
+            "templates" : [ ],
+            "deleted" : false
+          },
+          "orderIndex" : 1
+        } ],
+        "Contracts" : [ ]
+      } ]
+    } ],
+    "Audits" : [ {
+      "id" : 999,
+      "who" : "admin",
+      "organizationId" : "Organization1",
+      "entityType" : "Organization",
+      "createdOn" : "2022-03-25T10:41:52Z",
+      "what" : "Create"
+    }, {
+      "id" : 1001,
+      "who" : "admin",
+      "organizationId" : "Organization1",
+      "entityType" : "Plan",
+      "entityId" : "Test",
+      "createdOn" : "2022-03-25T10:42:50Z",
+      "what" : "Create"
+    }, {
+      "id" : 1003,
+      "who" : "admin",
+      "organizationId" : "Organization1",
+      "entityType" : "Plan",
+      "entityId" : "Test",
+      "entityVersion" : "1.0",
+      "createdOn" : "2022-03-25T10:42:50Z",
+      "what" : "Create"
+    }, {
+      "id" : 1005,
+      "who" : "admin",
+      "organizationId" : "Organization1",
+      "entityType" : "Plan",
+      "entityId" : "Test",
+      "entityVersion" : "1.0",
+      "createdOn" : "2022-03-25T10:43:08Z",
+      "what" : "AddPolicy",
+      "data" : "{\"policyDefId\":\"RateLimitingPolicy\"}"
+    }, {
+      "id" : 1006,
+      "who" : "admin",
+      "organizationId" : "Organization1",
+      "entityType" : "Client",
+      "entityId" : "Test",
+      "createdOn" : "2022-03-25T10:43:21Z",
+      "what" : "Create"
+    }, {
+      "id" : 1008,
+      "who" : "admin",
+      "organizationId" : "Organization1",
+      "entityType" : "Client",
+      "entityId" : "Test",
+      "entityVersion" : "1.0",
+      "createdOn" : "2022-03-25T10:43:21Z",
+      "what" : "Create"
+    }, {
+      "id" : 1010,
+      "who" : "admin",
+      "organizationId" : "Organization1",
+      "entityType" : "Client",
+      "entityId" : "Test",
+      "entityVersion" : "1.0",
+      "createdOn" : "2022-03-25T10:43:33Z",
+      "what" : "AddPolicy",
+      "data" : "{\"policyDefId\":\"RateLimitingPolicy\"}"
+    }, {
+      "id" : 1011,
+      "who" : "admin",
+      "organizationId" : "Organization1",
+      "entityType" : "Api",
+      "entityId" : "Test",
+      "createdOn" : "2022-03-25T10:43:44Z",
+      "what" : "Create"
+    }, {
+      "id" : 1013,
+      "who" : "admin",
+      "organizationId" : "Organization1",
+      "entityType" : "Api",
+      "entityId" : "Test",
+      "entityVersion" : "1.0",
+      "createdOn" : "2022-03-25T10:43:44Z",
+      "what" : "Create"
+    }, {
+      "id" : 1015,
+      "who" : "admin",
+      "organizationId" : "Organization1",
+      "entityType" : "Api",
+      "entityId" : "Test",
+      "entityVersion" : "1.0",
+      "createdOn" : "2022-03-25T10:43:58Z",
+      "what" : "AddPolicy",
+      "data" : "{\"policyDefId\":\"RateLimitingPolicy\"}"
+    }, {
+      "id" : 1034,
+      "who" : "admin",
+      "organizationId" : "Organization1",
+      "entityType" : "Organization",
+      "createdOn" : "2022-03-25T11:04:51Z",
+      "what" : "Grant",
+      "data" : "{\"userId\":\"user\",\"roles\":[\"APIDeveloper\"]}"
+    } ]
+  } ]
+}
+----
+200
+Content-Type: text/plain;charset=utf-8
+X-RestTest-RegexMatching: true
+
+INFO: ----------------------------
+INFO: Starting apiman data import: .*apiman_import_migrated.*json
+INFO: Importing a user: admin
+INFO: Importing a user: user
+INFO: Importing a gateway: The Gateway
+INFO: Importing a role: API Developer
+INFO: Importing a role: Client App Developer
+INFO: Importing a role: Organization Owner
+INFO: Importing a policy definition: Authorization Policy
+INFO: Importing a policy definition: BASIC Authentication Policy
+INFO: Importing a policy definition: Caching Resources Policy
+INFO: Importing a policy definition: IP Blacklist Policy
+INFO: Importing a policy definition: IP Whitelist Policy
+INFO: Importing a policy definition: Ignored Resources Policy
+INFO: Importing a policy definition: Quota Policy
+INFO: Importing a policy definition: Rate Limiting Policy
+INFO: Importing a policy definition: Time Restricted Access Policy
+INFO: Importing a policy definition: Transfer Quota Policy
+INFO: Importing a policy definition: URL Rewriting Policy
+INFO: Importing an organization: Organization1
+INFO:   Importing a role membership: admin\+OrganizationOwner=>Organization1
+INFO:   Importing a role membership: user\+APIDeveloper=>Organization1
+INFO:   Importing a plan: Test
+INFO:     Importing a plan version: 1.0
+INFO:       Importing a plan policy: Rate Limiting Policy
+INFO:     Importing an API: Test
+INFO:     Importing an API version: 1.0
+INFO:       Importing an API policy: Rate Limiting Policy
+INFO:   Importing a client: Test
+INFO:     Importing a client version: 1.0
+INFO:       Importing a client policy: Rate Limiting Policy
+INFO:   Importing an audit entry: 999
+INFO:   Importing an audit entry: 1001
+INFO:   Importing an audit entry: 1003
+INFO:   Importing an audit entry: 1005
+INFO:   Importing an audit entry: 1006
+INFO:   Importing an audit entry: 1008
+INFO:   Importing an audit entry: 1010
+INFO:   Importing an audit entry: 1011
+INFO:   Importing an audit entry: 1013
+INFO:   Importing an audit entry: 1015
+INFO:   Importing an audit entry: 1034
+INFO: Publishing APIs to the gateway.
+INFO: Registering clients in the gateway.
+INFO: -----------------------------------
+INFO: Data import completed successfully!
+INFO: -----------------------------------

--- a/manager/test/api/src/test/resources/test-plan-data/delete/import/000_import-data.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/import/000_import-data.resttest
@@ -12,16 +12,12 @@ Content-Type: application/json
     "fullName" : "apiman admin",
     "email" : "admin@example.org",
     "joinedOn" : "2022-03-25T10:40:36Z",
-    "locale" : "en",
-    "notificationPreferences" : [ ],
     "admin" : false
   }, {
     "username" : "user",
     "fullName" : "apiman user",
     "email" : "user@example.com",
     "joinedOn" : "2022-03-25T11:04:30Z",
-    "locale" : "en",
-    "notificationPreferences" : [ ],
     "admin" : false
   } ],
   "Gateways" : [ {
@@ -183,7 +179,6 @@ Content-Type: application/json
     "deleted" : false
   } ],
   "Developers" : [ ],
-  "Blobs" : [ ],
   "Orgs" : [ {
     "OrganizationBean" : {
       "id" : "Organization1",
@@ -248,7 +243,6 @@ Content-Type: application/json
       "ApiBean" : {
         "id" : "Test",
         "name" : "Test",
-        "tags" : [ ],
         "createdBy" : "admin",
         "createdOn" : "2022-03-25T10:43:44Z"
       },
@@ -269,8 +263,7 @@ Content-Type: application/json
           "modifiedOn" : "2022-03-25T10:43:58Z",
           "definitionType" : "None",
           "parsePayload" : false,
-          "disableKeysStrip" : false,
-          "exposeInPortal" : false
+          "disableKeysStrip" : false
         },
         "Policies" : [ {
           "id" : 1014,

--- a/manager/test/api/src/test/resources/test-plan-data/delete/org/001_delete-org.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/org/001_delete-org.resttest
@@ -1,0 +1,3 @@
+DELETE /organizations/Organization1 admin/admin
+----
+204

--- a/manager/test/api/src/test/resources/test-plan-data/delete/org/002_recreate-org.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/org/002_recreate-org.resttest
@@ -1,0 +1,12 @@
+POST /organizations admin/admin
+Content-Type: application/json
+
+{"name":"Organization 1"}
+----
+200
+Content-Type: application/json
+
+{
+  "name" : "Organization 1",
+  "id" : "Organization1"
+}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/org/003_activity.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/org/003_activity.resttest
@@ -1,0 +1,19 @@
+GET /organizations/Organization1/activity admin/admin
+----
+200
+Content-Type: application/json
+
+{
+  "beans" : [
+    {
+      "who" : "admin",
+      "organizationId" : "Organization1",
+      "entityType" : "Organization",
+      "entityId" : null,
+      "entityVersion" : null,
+      "what" : "Create",
+      "data" : null
+    }
+  ],
+  "totalSize" : 1
+}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/org/004_get-members.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/org/004_get-members.resttest
@@ -1,0 +1,15 @@
+GET /organizations/Organization1/members admin/admin
+----
+200
+Content-Type: application/json
+
+[
+  {
+    "userId" : "admin",
+    "userName" : "apiman admin",
+    "email" : "admin@example.org",
+    "roles" : [
+      {"roleId":"OrganizationOwner", "roleName":"Organization Owner"}
+    ]
+  }
+]

--- a/manager/test/api/src/test/resources/test-plan-data/delete/org/005_get-missing-api.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/org/005_get-missing-api.resttest
@@ -1,0 +1,7 @@
+GET /organizations/Organization1/apis/Test admin/admin
+----
+404
+Content-Type: application/json
+X-Apiman-Error: true
+
+{"type":"ApiNotFoundException","errorCode":5002,"message":"API does not exist: Test","moreInfoUrl":null}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/org/006_get-missing-client.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/org/006_get-missing-client.resttest
@@ -1,0 +1,7 @@
+GET /organizations/Organization1/clients/Test admin/admin
+----
+404
+Content-Type: application/json
+X-Apiman-Error: true
+
+{"type":"ClientNotFoundException","errorCode":4002,"message":"Client does not exist: Test","moreInfoUrl":null}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/org/007_get-missing-plan.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/org/007_get-missing-plan.resttest
@@ -1,0 +1,7 @@
+GET /organizations/Organization1/plans/Test admin/admin
+----
+404
+Content-Type: application/json
+X-Apiman-Error: true
+
+{"type":"PlanNotFoundException","errorCode":6002,"message":"Plan does not exist: Test","moreInfoUrl":null}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/plan/001_delete-plan.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/plan/001_delete-plan.resttest
@@ -1,0 +1,3 @@
+DELETE /organizations/Organization1/plans/Test admin/admin
+----
+204

--- a/manager/test/api/src/test/resources/test-plan-data/delete/plan/002_recreate-plan.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/plan/002_recreate-plan.resttest
@@ -1,0 +1,20 @@
+POST /organizations/Organization1/plans admin/admin
+Content-Type: application/json
+
+{
+  "name" : "Test",
+  "description" : "This is the description of Test."
+}
+----
+200
+Content-Type: application/json
+
+{
+  "organization" : {
+    "id" : "Organization1"
+  },
+  "id" : "Test",
+  "name" : "Test",
+  "description" : "This is the description of Test.",
+  "createdBy" : "admin"
+}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/plan/003_activity.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/plan/003_activity.resttest
@@ -1,0 +1,19 @@
+GET /organizations/Organization1/plans/Test/activity admin/admin
+----
+200
+Content-Type: application/json
+
+{
+  "beans" : [
+    {
+      "who":"admin",
+      "organizationId":"Organization1",
+      "entityType":"Plan",
+      "entityId":"Test",
+      "entityVersion":null,
+      "what":"Create",
+      "data":null
+    }
+  ],
+  "totalSize":1
+}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/plan/004_get-missing-version.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/plan/004_get-missing-version.resttest
@@ -1,0 +1,6 @@
+GET /organizations/Organization1/plans/Test/versions/1.0 admin/admin
+----
+404
+Content-Type: application/json
+
+{"type":"PlanVersionNotFoundException","errorCode":6003,"message":"Plan Version does not exist: Test:1.0","moreInfoUrl":null}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/plan/005_create-version-1.0.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/plan/005_create-version-1.0.resttest
@@ -1,0 +1,24 @@
+POST /organizations/Organization1/plans/Test/versions admin/admin
+Content-Type: application/json
+
+{
+  "version" : "1.0"
+}
+----
+200
+Content-Type: application/json
+
+{
+  "plan" : {
+    "organization" : {
+      "id" : "Organization1"
+    },
+    "id" : "Test",
+    "name" : "Test",
+    "description" : "This is the description of Test.",
+    "createdBy":"admin"
+  },
+  "status" : "Created",
+  "version" : "1.0",
+  "createdBy" : "admin"
+}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/plan/006_version-activity.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/plan/006_version-activity.resttest
@@ -1,0 +1,19 @@
+GET /organizations/Organization1/plans/Test/versions/1.0/activity admin/admin
+----
+200
+Content-Type: application/json
+
+{
+  "beans" : [
+    {
+      "who":"admin",
+      "organizationId":"Organization1",
+      "entityType":"Plan",
+      "entityId":"Test",
+      "entityVersion":"1.0",
+      "what":"Create",
+      "data":null
+    }
+  ],
+  "totalSize":1
+}

--- a/manager/test/api/src/test/resources/test-plan-data/delete/plan/007_list-plan-policies.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/delete/plan/007_list-plan-policies.resttest
@@ -1,0 +1,6 @@
+GET /organizations/Organization1/plans/Test/versions/1.0/policies admin/admin
+----
+200
+Content-Type: application/json
+
+[]

--- a/manager/test/api/src/test/resources/test-plans/delete-testPlan.xml
+++ b/manager/test/api/src/test/resources/test-plans/delete-testPlan.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testPlan name="delete and recreate" xmlns="urn:io.apiman.test:2014:02:testPlan">
+
+  <!-- Create Organizations -->
+  <testGroup name="Import Apiman Data">
+    <test name="Import Apiman Data">test-plan-data/delete/import/000_import-data.resttest</test>
+  </testGroup>
+
+  <testGroup name="Test API Deletion">
+    <test name="Delete API">test-plan-data/delete/api/001_delete-api.resttest</test>
+    <test name="Recreate API">test-plan-data/delete/api/002_recreate-api.resttest</test>
+    <test name="Check API activity">test-plan-data/delete/api/003_activity.resttest</test>
+    <test name="Get missing API version">test-plan-data/delete/api/004_get-missing-version.resttest</test>
+    <test name="Create API version 1.0">test-plan-data/delete/api/005_create-version-1.0.resttest</test>
+    <test name="Check API version activity">test-plan-data/delete/api/006_version-activity.resttest</test>
+    <test name="List API policies">test-plan-data/delete/api/007_list-api-policies.resttest</test>
+    <test name="Check delete do not affect client policies">test-plan-data/delete/api/008_list-client-policies.resttest</test>
+    <test name="Check delete do not affect plan policies">test-plan-data/delete/api/009_list-plan-policies.resttest</test>
+  </testGroup>
+
+  <testGroup name="Test Client Deletion">
+    <test name="Delete client">test-plan-data/delete/client/001_delete-client.resttest</test>
+    <test name="Recreate client">test-plan-data/delete/client/002_recreate-client.resttest</test>
+    <test name="Check client activity">test-plan-data/delete/client/003_activity.resttest</test>
+    <test name="Get missing client version">test-plan-data/delete/client/004_get-missing-version.resttest</test>
+    <test name="Create client version 1.0">test-plan-data/delete/client/005_create-version-1.0.resttest</test>
+    <test name="Check client version activity">test-plan-data/delete/client/006_version-activity.resttest</test>
+    <test name="List client policies">test-plan-data/delete/client/007_list-client-policies.resttest</test>
+    <test name="Check delete do not affect plan policies">test-plan-data/delete/client/008_list-plan-policies.resttest</test>
+  </testGroup>
+
+  <testGroup name="Test Plan Deletion">
+    <test name="Delete plan">test-plan-data/delete/plan/001_delete-plan.resttest</test>
+    <test name="Recreate plan">test-plan-data/delete/plan/002_recreate-plan.resttest</test>
+    <test name="Check plan activity">test-plan-data/delete/plan/003_activity.resttest</test>
+    <test name="Get missing plan version">test-plan-data/delete/plan/004_get-missing-version.resttest</test>
+    <test name="Create plan version 1.0">test-plan-data/delete/plan/005_create-version-1.0.resttest</test>
+    <test name="Check plan version activity">test-plan-data/delete/plan/006_version-activity.resttest</test>
+    <test name="List plan policies">test-plan-data/delete/plan/007_list-plan-policies.resttest</test>
+  </testGroup>
+
+  <testGroup name="Test Organization Deletion">
+    <test name="Delete org">test-plan-data/delete/org/001_delete-org.resttest</test>
+    <test name="Recreate org">test-plan-data/delete/org/002_recreate-org.resttest</test>
+    <test name="Check org activity">test-plan-data/delete/org/003_activity.resttest</test>
+    <test name="Get org members">test-plan-data/delete/org/004_get-members.resttest</test>
+    <test name="Get missing API">test-plan-data/delete/org/005_get-missing-api.resttest</test>
+    <test name="Get missing client">test-plan-data/delete/org/006_get-missing-client.resttest</test>
+    <test name="Get missing plan">test-plan-data/delete/org/007_get-missing-plan.resttest</test>
+  </testGroup>
+</testPlan>


### PR DESCRIPTION
If a client / plan / API gets deleted, all attached policies should be deleted as well.

To fix the current behaviour,  where the policies remain in the database after the deletion
of a plan / API / client, a missing `executeUpdate` is added to the deleteAllPolicies function.

To ensure future changes won't break this logic a new delete test is added, as well.

Closes: #1887