### PR TITLE
fix(ui): show correct discoverability on the plans

### DIFF
--- a/manager/ui/war/plugins/api-manager/html/api/api-devportal.html
+++ b/manager/ui/war/plugins/api-manager/html/api/api-devportal.html
@@ -59,14 +59,14 @@
 
           <div class="container-fluid container-cards-pf">
             <div class="row row-cards-pf"  style="display: flex;">
-              <div class="col-xs-6 col-sm-5 col-md-5 container-border" style="display: inline-flex; width: 27em;" ng-repeat="plan in data.apiVersion.plans">
+              <div class="col-xs-6 col-sm-5 col-md-5 container-border" style="display: inline-flex; width: 27em;" ng-repeat="plan in data.planSummaries">
                 <div class="card-pf card-pf-accented card-pf-aggregate-status">
                   <h2 class="card-pf-title">
-                    {{  data.planSummaries[$index].planName }}
+                    {{ plan.planName  }}
                   </h2>
                   <h6 class="card-subtitle mb-2 text-muted">Version {{ plan.version }}</h6>
                   <div class="card-pf-body text-left">
-                    <p class="card-text">{{ data.planSummaries[$index].planDescription }}</p>
+                    <p class="card-text">{{ plan.planDescription }}</p>
                     <div>
                       <ul class="list-group list-group-flush">
                         <li style="max-width: max-content !important;" class="list-group-item">&#9702;  Plan <strong>is available</strong> to: {{ getDiscoverabilityDescription(plan.discoverability) }}</li>
@@ -76,8 +76,8 @@
                       </ul>
                       <!-- Checkbox -- requires approval -->
                       <div class="form-check px-4 pl-2">
-                        <input class="form-check-input" type="checkbox" ng-model="plan.requiresApproval" value="{{ plan.requiresApproval }}" id="requiresApproval-{{$index}}">
-                        <label class="form-check-label" for="requiresApproval-{{$index}}">
+                        <input class="form-check-input" type="checkbox" ng-model="plan.requiresApproval" value="{{ plan.requiresApproval }}" id="requiresApproval-{{plan.planId}}">
+                        <label class="form-check-label" for="requiresApproval-{{plan.planId}}">
                           Requires approval
                         </label>
                       </div>

--- a/manager/ui/war/plugins/api-manager/ts/api/api-devportal.ts
+++ b/manager/ui/war/plugins/api-manager/ts/api/api-devportal.ts
@@ -1,5 +1,14 @@
 import {_module} from "../apimanPlugin";
-import {ApiBean, ApiPlanSummaryBean, ApiVersionBean, Discoverability, KeyValueTagDto, UpdateApiBean, UpdateApiVersionBean,} from "../model/api.model";
+import {
+  ApiBean,
+  ApiPlanBean,
+  ApiPlanSummaryBean,
+  ApiVersionBean,
+  Discoverability,
+  KeyValueTagDto,
+  UpdateApiBean,
+  UpdateApiVersionBean,
+} from "../model/api.model";
 
 // CSS
 import 'prismjs/themes/prism.css'
@@ -371,7 +380,10 @@ function devPortalBusinessLogic(
   }
 
   function onDiscoverabilityChange(change): void {
-    change.plan.discoverability = change.level;
+    const changedPlanSummary: ApiPlanSummaryBean = change.plan;
+    // change the real plan bean and not the summary (used for save)
+    let planToChange: ApiPlanBean = $scope.data.apiVersion.plans.find((plan: ApiPlanBean) => { return plan.planId === changedPlanSummary.planId})
+    planToChange.discoverability = change.level;
   }
 
   function getDiscoverabilityDescription(discoverability: Discoverability): string {


### PR DESCRIPTION
Switched to the PlanSummary beans in the ui to display the correct name and discoverability level.
Changed the onChange method to get the "real" plan bean updated from the summary bean before the update request is sent

Closes: #2002