### PR TITLE
fix(ui): browser back button on "all"-pages

### DIFF
--- a/manager/ui/war/plugins/api-manager/html/headers/community.include
+++ b/manager/ui/war/plugins/api-manager/html/headers/community.include
@@ -71,7 +71,7 @@
                             </a>
                         </li>
                         <li class="list-group-item" id="apiman-sidebar-apis-consume" data-target="#apis-all_apis-tertiary">
-                            <a href="{{ pluginName }}/browse/apis">
+                            <a href="{{ pluginName }}/browse/apis?q=*&cp=1&ps=12">
                                 <span class="list-group-item-value" apiman-i18n-key="actions.find-api">All APIs</span>
                             </a>
                         </li>
@@ -138,7 +138,7 @@
                             </a>
                         </li>
                         <li class="list-group-item" id="apiman-sidebar-orgs-browse" data-target="#apis-new_contract-tertiary">
-                            <a href="{{ pluginName }}/browse/orgs">
+                            <a href="{{ pluginName }}/browse/orgs?q=*&cp=1&ps=12">
                                 <span class="list-group-item-value" apiman-i18n-key="actions.browse-orgs">All Organizations</span>
                             </a>
                         </li>


### PR DESCRIPTION
By directly linking to the URL with query parameters we automatically load the first page. This avoids reloading the first page via `loadFirstPage()` in `consumer-orgs/apis.ts` which would create two browser history entries.
Keeping `loadFirstPage()` is still useful to display the first results after reloading the page or after resetting the search.

Closes: #1181