### PR TITLE
fix(ui): only show remove button if removal is possible

### DIFF
--- a/manager/ui/war/plugins/api-manager/html/directives/policyList.html
+++ b/manager/ui/war/plugins/api-manager/html/directives/policyList.html
@@ -1,7 +1,8 @@
+<!--corresponding directive: apimanPolicyList from directives.ts-->
 <div class="apiman-policies" id='draggable-ctr' as-sortable="policyListOptions" ng-model="ctrl.policies">
     <div class="container-fluid apiman-summaryrow" ng-repeat="policy in ctrl.policies" as-sortable-item>
         <div class="row" >
-            <div as-sortable-item-handle apiman-permission="apiEdit" ng-show="!isEntityDisabled()" class="policy-grabber" style="height: 48px"></div>
+            <div as-sortable-item-handle apiman-permission="apiEdit" ng-show="!isButtonDisabled()" class="policy-grabber" style="height: 48px"></div>
             <div class="col-md-1 col-no-padding">
                 <i class="apiman-policy-icon fa fa-{{ policy.icon }} fa-fw"></i>
             </div>
@@ -21,7 +22,7 @@
                 </div>
             </div>
             <div class="col pull-right">
-                <button apiman-i18n-key="remove" class="btn btn-default" ng-show="!isEntityDisabled()" ng-click="ctrl.remove( policy )">Remove</button>
+                <button apiman-i18n-key="remove" class="btn btn-default" ng-show="!isButtonDisabled()" ng-click="ctrl.remove( policy )">Remove</button>
             </div>
         </div>
         <hr />

--- a/manager/ui/war/plugins/api-manager/ts/directives.ts
+++ b/manager/ui/war/plugins/api-manager/ts/directives.ts
@@ -433,8 +433,10 @@ _module.directive('apimanPolicyList',
                         $scope.ctrl.reorder($scope.ctrl.policies);
                     }
                 };
-
+                // access values from parent component
                 $scope.pluginName = $scope.$parent.pluginName;
+                // change name from parent to avoid confusing name clashes through the project (directives)
+                $scope.isButtonDisabled = $scope.$parent.isEntityDisabled;
             }],
             controllerAs: 'ctrl',
             bindToController: true,

--- a/manager/ui/war/plugins/api-manager/ts/plan/plan-policies.ts
+++ b/manager/ui/war/plugins/api-manager/ts/plan/plan-policies.ts
@@ -2,8 +2,8 @@ import {_module} from "../apimanPlugin";
 import angular = require("angular");
 
 _module.controller("Apiman.PlanPoliciesController",
-    ['$q', '$scope', '$location', '$uibModal', 'OrgSvcs', 'ApimanSvcs', 'Logger', 'PageLifecycle', 'PlanEntityLoader', '$routeParams',
-    function ($q, $scope, $location, $uibModal, OrgSvcs, ApimanSvcs, Logger, PageLifecycle, PlanEntityLoader, $routeParams) {
+    ['$q', '$scope', '$location', '$uibModal', 'OrgSvcs', 'ApimanSvcs', 'EntityStatusSvc', 'Logger', 'PageLifecycle', 'PlanEntityLoader', '$routeParams',
+    function ($q, $scope, $location, $uibModal, OrgSvcs, ApimanSvcs, EntityStatusSvc, Logger, PageLifecycle, PlanEntityLoader, $routeParams) {
         var params = $routeParams;
         $scope.organizationId = params.org;
         $scope.tab = 'policies';
@@ -16,6 +16,8 @@ _module.controller("Apiman.PlanPoliciesController",
                 }
             });
         };
+
+        $scope.isEntityDisabled = EntityStatusSvc.isEntityDisabled;
 
         $scope.removePolicy = function(policy, size) {
             Logger.info('Removing policy: {0}', policy);


### PR DESCRIPTION
A locked plan cannot be altered, therefore the delete button for a policy should also not be visible. This also applies for retired APIs.
Fixing the problem by passing the entity check from parent to child component.

Closes: #2030