### PR TITLE
build(gateway-platforms-vertx3): ensure Vert.x gateway can use JDBC registry

### DIFF
--- a/gateway/platforms/vertx3/vertx3/pom.xml
+++ b/gateway/platforms/vertx3/vertx3/pom.xml
@@ -120,6 +120,10 @@
     </dependency>
     <dependency>
       <groupId>io.apiman</groupId>
+      <artifactId>apiman-gateway-engine-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.apiman</groupId>
       <artifactId>apiman-gateway-engine-es</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
We should make a more optimal one using the Vert.x-specific async JDBC libraries soon

In general, only the polling JDBC library should be used to avoid blocking issues. Even then, it's probably not perfect.

I'll make a version with the Vert.x JDBC non-blocking library, if possible.