### PR TITLE
fix(ui): fix permission check of contract approve button

### DIFF
--- a/manager/ui/war/plugins/api-manager/html/api/api-contracts.html
+++ b/manager/ui/war/plugins/api-manager/html/api/api-contracts.html
@@ -65,7 +65,7 @@
                         <!-- Approval button -->
                         <button type="button"
                                 ng-show="contract.status === 'AwaitingApproval'"
-                                apiman-permission="planAdmin,admin"
+                                apiman-permission="planAdmin"
                                 ng-click="approveContract(contract)"
                                 class="btn-sm btn-success"
                                 style="float: right">Approve</button>


### PR DESCRIPTION
Due to a wrong permission check on the approve contract button only user with the IDM role 'apiadmin' were able to approve contracts.

We fixed this permission check, that it only checks the apiman permission 'planAdmin' now. User with the IDM role 'apiadmin' will still bypass this permission check.

Closes: #2046