### PR TITLE
fix(manager-api): fix image upload

### DIFF
--- a/manager/api/war/tomcat8/src/main/webapp/WEB-INF/web.xml
+++ b/manager/api/war/tomcat8/src/main/webapp/WEB-INF/web.xml
@@ -135,6 +135,12 @@
       <http-method-omission>OPTIONS</http-method-omission>
     </web-resource-collection>
     <web-resource-collection>
+      <web-resource-name>Blobs</web-resource-name>
+      <url-pattern>/blobs</url-pattern>
+      <http-method-omission>OPTIONS</http-method-omission>
+      <http-method-omission>GET</http-method-omission>
+    </web-resource-collection>
+    <web-resource-collection>
       <web-resource-name>Developers (deprecated)</web-resource-name>
       <url-pattern>/developers/*</url-pattern>
       <http-method-omission>OPTIONS</http-method-omission>

--- a/manager/api/war/wildfly8/src/main/webapp/WEB-INF/web.xml
+++ b/manager/api/war/wildfly8/src/main/webapp/WEB-INF/web.xml
@@ -117,6 +117,12 @@
       <http-method-omission>OPTIONS</http-method-omission>
     </web-resource-collection>
     <web-resource-collection>
+      <web-resource-name>Blobs</web-resource-name>
+      <url-pattern>/blobs</url-pattern>
+      <http-method-omission>OPTIONS</http-method-omission>
+      <http-method-omission>GET</http-method-omission>
+    </web-resource-collection>
+    <web-resource-collection>
       <web-resource-name>Developers (deprecated)</web-resource-name>
       <url-pattern>/developers/*</url-pattern>
       <http-method-omission>OPTIONS</http-method-omission>


### PR DESCRIPTION
Because of a missing entry in the web.xml (wildfly and tomcat) the loggedIn-check for uploading images didnt work properly.
We added the entry for the /blobs endpoint back in, to fix the loggedIn-check.

Closes: #2049