### PR TITLE
fix(manager-api): grant membership as non-admin user

### DIFF
--- a/manager/api/rest-impl/src/main/java/io/apiman/manager/api/service/OrganizationService.java
+++ b/manager/api/rest-impl/src/main/java/io/apiman/manager/api/service/OrganizationService.java
@@ -80,7 +80,7 @@ public class OrganizationService implements DataAccessUtilMixin {
     private ApiManagerConfig config;
     private IStorage storage;
     private IStorageQuery query;
-    private IUserResource users;
+    private UserService userService;
     private IRoleResource roles;
     private ISecurityContext securityContext;
     private IGatewayLinkFactory gatewayLinkFactory;
@@ -94,7 +94,7 @@ public class OrganizationService implements DataAccessUtilMixin {
          ApiManagerConfig config,
          IStorage storage,
          IStorageQuery query,
-         IUserResource users,
+         UserService userService,
          IRoleResource roles,
          ISecurityContext securityContext,
          IGatewayLinkFactory gatewayLinkFactory,
@@ -103,7 +103,7 @@ public class OrganizationService implements DataAccessUtilMixin {
         this.config = config;
         this.storage = storage;
         this.query = query;
-        this.users = users;
+        this.userService = userService;
         this.roles = roles;
         this.securityContext = securityContext;
         this.gatewayLinkFactory = gatewayLinkFactory;
@@ -204,7 +204,7 @@ public class OrganizationService implements DataAccessUtilMixin {
             LOGGER.debug("Deleted Organization: " + organizationBean.getName()); //$NON-NLS-1$
         });
     }
-    
+
     public OrganizationBean getOrg(String organizationId) throws OrganizationNotFoundException {
         // No permission check is needed, because this would break All Organizations UI
         OrganizationBean organizationBean = tryAction(() -> getOrganizationFromStorage(organizationId));
@@ -229,7 +229,7 @@ public class OrganizationService implements DataAccessUtilMixin {
 
         LOGGER.debug(String.format("Updated organization %s: %s", orgForUpdate.getName(), orgForUpdate)); //$NON-NLS-1$
     }
-    
+
     public SearchResultsBean<AuditEntryBean> activity(String organizationId, int page, int pageSize)
         throws OrganizationNotFoundException, NotAuthorizedException {
         PagingBean paging = PagingBean.create(page, pageSize);
@@ -286,7 +286,7 @@ public class OrganizationService implements DataAccessUtilMixin {
 
         // Verify that the references are valid.
         getOrg(organizationId);
-        users.get(bean.getUserId());
+        userService.getUserById(bean.getUserId());
         for (String roleId : bean.getRoleIds()) {
             roles.get(roleId);
         }
@@ -313,7 +313,7 @@ public class OrganizationService implements DataAccessUtilMixin {
         NotAuthorizedException {
 
         getOrg(organizationId);
-        users.get(userId);
+        userService.getUserById(userId);
         roles.get(roleId);
 
         MembershipData auditData = new MembershipData();
@@ -331,7 +331,7 @@ public class OrganizationService implements DataAccessUtilMixin {
         RoleNotFoundException, UserNotFoundException, NotAuthorizedException {
 
         getOrg(organizationId);
-        users.get(userId);
+        userService.getUserById(userId);
 
         MembershipData auditData = new MembershipData();
         auditData.setUserId(userId);

--- a/manager/test/api/src/test/resources/test-plan-data/members/auditing/001_activity.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/members/auditing/001_activity.resttest
@@ -17,7 +17,7 @@ Content-Type: application/json
         "entityVersion" : null,
         "organizationId" : "Organization1",
         "what" : "Revoke",
-        "who" : "admin"
+        "who" : "user1"
       },
       { "data" : "{\"userId\":\"user2\",\"roles\":[\"APIDeveloper\"]}",
         "entityId" : null,
@@ -25,9 +25,9 @@ Content-Type: application/json
         "entityVersion" : null,
         "organizationId" : "Organization1",
         "what" : "Grant",
-        "who" : "admin"
+        "who" : "user1"
       },
-      { "data" : "{\"userId\":\"user1\",\"roles\":[\"APIDeveloper\"]}",
+      { "data" : "{\"userId\":\"user1\",\"roles\":[\"OrganizationOwner\",\"APIDeveloper\"]}",
         "entityId" : null,
         "entityType" : "Organization",
         "entityVersion" : null,

--- a/manager/test/api/src/test/resources/test-plan-data/members/manage/004_grant-user1-api.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/members/manage/004_grant-user1-api.resttest
@@ -3,7 +3,7 @@ Content-Type: application/json
 
 {
   "userId" : "user1",
-  "roleIds" : [ "APIDeveloper" ]
+  "roleIds" : [ "APIDeveloper", "OrganizationOwner" ]
 }
 ----
 204

--- a/manager/test/api/src/test/resources/test-plan-data/members/manage/005_grant-user2-api.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/members/manage/005_grant-user2-api.resttest
@@ -1,4 +1,4 @@
-POST /organizations/Organization1/roles admin/admin
+POST /organizations/Organization1/roles user1/user1
 Content-Type: application/json
 
 {

--- a/manager/test/api/src/test/resources/test-plan-data/members/manage/006_get-members.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/members/manage/006_get-members.resttest
@@ -15,7 +15,12 @@ Content-Type: application/json
   {
     "userId" : "user1",
     "userName" : "User 1",
-    "email" : "user1@example.org"
+    "email" : "user1@example.org",
+    "roles": [
+        {"roleId": "ClientDeveloper", "roleName": "Client Developer"},
+        {"roleId": "OrganizationOwner", "roleName": "Organization Owner"},
+        {"roleId": "APIDeveloper", "roleName": "API Developer"}
+    ]
   },
   {
     "userId" : "user2",

--- a/manager/test/api/src/test/resources/test-plan-data/members/manage/007_revoke-user2.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/members/manage/007_revoke-user2.resttest
@@ -1,3 +1,3 @@
-DELETE /organizations/Organization1/roles/APIDeveloper/user2 admin/admin
+DELETE /organizations/Organization1/roles/APIDeveloper/user2 user1/user1
 ----
 204

--- a/manager/test/api/src/test/resources/test-plan-data/members/manage/008_get-members.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/members/manage/008_get-members.resttest
@@ -15,6 +15,11 @@ Content-Type: application/json
   {
     "userId" : "user1",
     "userName" : "User 1",
-    "email" : "user1@example.org"
+    "email" : "user1@example.org",
+    "roles": [
+        {"roleId": "ClientDeveloper", "roleName": "Client Developer"},
+        {"roleId": "OrganizationOwner", "roleName": "Organization Owner"},
+        {"roleId": "APIDeveloper", "roleName": "API Developer"}
+    ]
   }
 ]


### PR DESCRIPTION
By changing from `IUserResource` to the `UserService` directly we avoid the `checkIfUserIsCurrentUser` in the security context.
This check was a problem during granting memberships as non-admin user because it was not allowed to get the user object as non-admin / as non-being the user itself.

Closes: #2069