### PR TITLE
fix(ui): restore "requires approval" functionality on devportal tab

### DIFF
--- a/manager/ui/war/plugins/api-manager/html/api/api-devportal.html
+++ b/manager/ui/war/plugins/api-manager/html/api/api-devportal.html
@@ -59,14 +59,14 @@
 
           <div class="container-fluid container-cards-pf">
             <div class="row row-cards-pf"  style="display: flex;">
-              <div class="col-xs-6 col-sm-5 col-md-5 container-border" style="display: inline-flex; width: 27em;" ng-repeat="plan in data.planSummaries">
+              <div class="col-xs-6 col-sm-5 col-md-5 container-border" style="display: inline-flex; width: 27em;" ng-repeat="plan in data.apiVersion.plans">
                 <div class="card-pf card-pf-accented card-pf-aggregate-status">
                   <h2 class="card-pf-title">
-                    {{ plan.planName  }}
+                    {{ getApiPlanSummaryBean(plan).planName }}
                   </h2>
                   <h6 class="card-subtitle mb-2 text-muted">Version {{ plan.version }}</h6>
                   <div class="card-pf-body text-left">
-                    <p class="card-text">{{ plan.planDescription }}</p>
+                    <p class="card-text">{{ getApiPlanSummaryBean(plan).planDescription }}</p>
                     <div>
                       <ul class="list-group list-group-flush">
                         <li style="max-width: max-content !important;" class="list-group-item">&#9702;  Plan <strong>is available</strong> to: {{ getDiscoverabilityDescription(plan.discoverability) }}</li>

--- a/manager/ui/war/plugins/api-manager/ts/api/api-devportal.ts
+++ b/manager/ui/war/plugins/api-manager/ts/api/api-devportal.ts
@@ -176,6 +176,7 @@ function devPortalBusinessLogic(
   $scope.deleteImage = deleteApiImage;
   $scope.onDiscoverabilityChange = onDiscoverabilityChange;
   $scope.getDiscoverabilityDescription = getDiscoverabilityDescription;
+  $scope.getApiPlanSummaryBean = getApiPlanSummaryBean;
 
   // TUI Markdown editor. Will initialise
   let markdownEditor: Editor = initEditor();
@@ -381,10 +382,13 @@ function devPortalBusinessLogic(
   }
 
   function onDiscoverabilityChange(change): void {
-    const changedPlanSummary: ApiPlanSummaryBean = change.plan;
-    // change the real plan bean and not the summary (used for save)
-    let planToChange: ApiPlanBean = $scope.data.apiVersion.plans.find((plan: ApiPlanBean) => { return plan.planId === changedPlanSummary.planId})
-    planToChange.discoverability = change.level;
+    change.plan.discoverability = change.level;
+  }
+
+  function getApiPlanSummaryBean(plan: ApiPlanBean): ApiPlanSummaryBean {
+    return $scope.data.planSummaries.find((planSummary: ApiPlanSummaryBean) => {
+      return planSummary.planId === plan.planId;
+    })
   }
 
   function getDiscoverabilityDescription(discoverability: Discoverability): string {


### PR DESCRIPTION
Partially reverted changes that got introduced with "fix(ui): show correct discoverability on the plans" (a9552462f86fa2a5d753ffb670d4f8f2c54afb6f).

Changes of the `requiresApproval` were lost because the wrong entity was modified (ApiPlanSummaryBeans instead of ApiPlanBeans).

The summary beans are now only used to display a `planDescription` and the `planName` as these fields are not available in the ApiPlanBean.

Closes: #2071