### PR TITLE
fix(common-plugin): remove in plugin loader code due to unpredictable behaviour

### DIFF
--- a/common/plugin/src/main/java/io/apiman/common/plugin/Plugin.java
+++ b/common/plugin/src/main/java/io/apiman/common/plugin/Plugin.java
@@ -15,6 +15,8 @@
  */
 package io.apiman.common.plugin;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 
@@ -33,7 +35,7 @@ import java.util.List;
  *
  * @author eric.wittmann@redhat.com
  */
-public class Plugin {
+public class Plugin implements Closeable, AutoCloseable {
     
     private PluginSpec spec;
     private PluginCoordinates coordinates;
@@ -114,4 +116,8 @@ public class Plugin {
         return this.loader.getPolicyDefinitionResources();
     }
 
+    @Override
+    public void close() throws IOException {
+        loader.close();
+    }
 }

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/logging/VertxLoggerDelegate.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/logging/VertxLoggerDelegate.java
@@ -18,9 +18,12 @@ package io.apiman.gateway.platforms.vertx3.logging;
 
 import io.apiman.common.logging.IApimanLogger;
 import io.apiman.common.logging.IDelegateFactory;
+import io.apiman.common.logging.annotations.ApimanLoggerFactory;
+
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
+@ApimanLoggerFactory("vertx")
 public class VertxLoggerDelegate implements IDelegateFactory {
 
     // For the Apiman logger system.

--- a/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apis/ApiVersionBean.java
+++ b/manager/api/beans/src/main/java/io/apiman/manager/api/beans/apis/ApiVersionBean.java
@@ -44,6 +44,7 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
@@ -111,6 +112,7 @@ public class ApiVersionBean implements Serializable, Cloneable {
     private DiscoverabilityLevel discoverability = DiscoverabilityLevel.ORG_MEMBERS;
 
     @OneToOne(mappedBy = "apiVersion", orphanRemoval = true, cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JsonIgnore
     ApiDefinitionBean apiDefinition; // Deliberately no explicit getter/setter for this
 
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "apiVersion", cascade = CascadeType.ALL, orphanRemoval = true)


### PR DESCRIPTION
… behaviour

Finalize is deprecated, in part because it causes surprising behaviour whereby
objects can be GCed far earlier than the programmer might expect.

This causes many subtle bugs.

This patch removes finalize by using `Closeable` and `AutoCloseable`, although
there may be some edge cases we haven't picked up that require explicit close
now and could cause memory leaks in certain circumstances.