### PR TITLE
feat(gateway-engine-core): thread-safe batched non-blocking metrics consumer

### DIFF
--- a/gateway/engine/core/pom.xml
+++ b/gateway/engine/core/pom.xml
@@ -53,6 +53,10 @@
       <groupId>com.unboundid</groupId>
       <artifactId>unboundid-ldapsdk</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+    </dependency>
 
     <!-- Test Only Dependencies -->
     <dependency>

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/metrics/BatchedMetricsConsumer.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/metrics/BatchedMetricsConsumer.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022. Black Parrot Labs Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.gateway.engine.metrics;
+
+import io.apiman.common.logging.ApimanLoggerFactory;
+import io.apiman.common.logging.IApimanLogger;
+import io.apiman.gateway.engine.async.IAsyncHandler;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
+
+/**
+ * Batched metrics consumer. Uses a single spin-wait daemon thread to poll a {@link ManyToOneConcurrentArrayQueue}. Calls to {@link #offer(Object)} are thread safe.
+ * <p>
+ * This implementation will flush to the batchHandler as fast as it can, with a maximum batch size specified.
+ * <p>
+ * It is generally acceptable for implementors to use the metric processing thread to perform whatever actions are required to dispatch their metrics; new metrics will
+ * be queued up until the thread becomes available again, as long as this is not an excessively long period of time (i.e. allowing the buffer to overflow).
+ * <p>
+ * Important: The List<M> provided to batchHandler is cleared after the callback returns, so don't hold onto it.
+ *
+ * @author Marc Savy {@literal <marc@blackparrotlabs.io>}
+ */
+public class BatchedMetricsConsumer<M> implements Closeable {
+    private final IApimanLogger LOGGER = ApimanLoggerFactory.getLogger(BatchedMetricsConsumer.class);
+    private final String metricConsumerName;
+    private final ManyToOneConcurrentArrayQueue<M> metricQueue;
+    private final int maxBatchSize;
+    private final ArrayList<M> batchBuffer;
+    private final IAsyncHandler<List<M>> batchHandler;
+    private boolean running = false;
+
+    public BatchedMetricsConsumer(String metricConsumerName,
+                                  int queueCapacity,
+                                  int maxBatchSize,
+                                  IAsyncHandler<List<M>> batchHandler) {
+        Objects.requireNonNull(metricConsumerName, "Must provide metric consumer name");
+        Objects.requireNonNull(batchHandler, "Must provide handler to drain metrics to");
+        this.metricConsumerName = metricConsumerName;
+        this.metricQueue = new ManyToOneConcurrentArrayQueue<>(queueCapacity);
+        this.maxBatchSize = maxBatchSize;
+        this.batchBuffer = new ArrayList<>(maxBatchSize);
+        this.batchHandler = batchHandler;
+    }
+
+    public void start() {
+        this.running = true;
+        var metricsConsumerThread = new Thread(() -> {
+            LOGGER.info("Starting metrics consumer: {0}...", metricConsumerName);
+            while (running) {
+                while (metricQueue.isEmpty()) {
+                    Thread.onSpinWait();
+                }
+                try {
+                    consumeBatch();
+                } catch (RuntimeException rte) {
+                    LOGGER.error("An error occurred when consuming a batch of metrics; this will be ignored so that the metrics subsystem can continue functioning. "
+                                         + "Implementors should handle any errors in their code to prevent entire batches being dropped.", rte);
+                    LOGGER.warn("Dropping {0} metrics", batchBuffer.size());
+                }
+                // Must always clear batch buffer, even if exception occurs.
+                batchBuffer.clear();
+            }
+        }, metricConsumerName);
+        metricsConsumerThread.setDaemon(true);
+        metricsConsumerThread.start();
+    }
+
+    public boolean offer(M requestMetric) {
+        return metricQueue.offer(requestMetric);
+    }
+
+    private void consumeBatch() {
+        int elemsDrained = metricQueue.drainTo(batchBuffer, maxBatchSize);
+        if (elemsDrained > 0) {
+            LOGGER.debug("Draining {0} metrics to handler", elemsDrained);
+            batchHandler.handle(batchBuffer);
+        }
+    }
+
+    @Override
+    public void close() {
+        LOGGER.info("Stopping metrics consumer: {0}...", metricConsumerName);
+        this.running = false;
+        metricQueue.clear();
+    }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -121,6 +121,7 @@
     <version.org.apache.httpcomponents.httpcore>4.4.14</version.org.apache.httpcomponents.httpcore>
     <version.org.apache.httpcomponents.httpasyncclient>4.1.4</version.org.apache.httpcomponents.httpasyncclient>
     <version.org.apache.logging.log4j>2.17.2</version.org.apache.logging.log4j>
+    <version.org.agrona>1.15.2</version.org.agrona>
     <version.org.eclipse.jetty>9.4.41.v20210516</version.org.eclipse.jetty>
     <version.org.glassfish.javax.el>3.0.0</version.org.glassfish.javax.el>
     <version.org.elasticsearch>7.13.4</version.org.elasticsearch>
@@ -681,6 +682,11 @@
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpasyncclient</artifactId>
         <version>${version.org.apache.httpcomponents.httpasyncclient}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.agrona</groupId>
+        <artifactId>agrona</artifactId>
+        <version>${version.org.agrona}</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.okhttp</groupId>


### PR DESCRIPTION
A generic batched metrics consumer that should allow batched, thread-safe non-blocking metrics
ingestion by many different metrics implementations, rather than reinventing this pattern many
times.

This implementation runs as fast as it can, using a spin-wait worker thread that polls a
non-blocking queue. It passes these metrics to a call-handler which may then go and perform
actions such as serializing and transmitting those metrics.

This implementation does not have a minimum batch size nor minimum polling interval.