### PR TITLE
fix(manager-api-jpa): parse filter number into same numeric data type as target field

### DIFF
--- a/manager/test/api/src/test/resources/test-plan-data/searching/queries/apis/013_query-integer-field-issue-2283.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/searching/queries/apis/013_query-integer-field-issue-2283.resttest
@@ -1,0 +1,20 @@
+POST /search/apis admin/admin
+Content-Type: application/json
+
+{
+  "filters": [
+    {
+      "name": "numPublished",
+      "value": "0",
+      "operator": "gt"
+    }
+  ]
+}
+----
+200
+Content-Type: application/json
+
+{
+  "beans":[],
+  "totalSize":0
+}

--- a/manager/test/api/src/test/resources/test-plans/searching-testPlan.xml
+++ b/manager/test/api/src/test/resources/test-plans/searching-testPlan.xml
@@ -50,6 +50,7 @@
     <test name="Query Api By Name Lowercase">test-plan-data/searching/queries/apis/010_query-by-name-lower.resttest</test>
     <test name="Query Api By Name Mixedcase">test-plan-data/searching/queries/apis/011_query-by-name-mixed.resttest</test>
     <test name="Query Api By Name Special">test-plan-data/searching/queries/apis/012_query-by-name-special.resttest</test>
+    <test name="Query integer field with numeric gt comparison (Issue 2283)">test-plan-data/searching/queries/apis/013_query-integer-field-issue-2283.resttest</test>
     <!-- Misc -->
     <test name="Query API Catalogs">test-plan-data/searching/queries/misc/001_query-api-catalog.resttest</test>
     <test name="List API Catalog Namespaces">test-plan-data/searching/queries/misc/002_query-api-namespaces.resttest</test>


### PR DESCRIPTION
Previously, we were assuming all the fields were `Long`. In some cases they are `Integer` and this causes a data type mismatch with certain target fields.

Fixes: #2283