### PR TITLE
feat(metrics-es): allow logging metrics to JSON file with `write-to` option

### DIFF
--- a/common/util/src/main/java/io/apiman/common/util/JsonUtil.java
+++ b/common/util/src/main/java/io/apiman/common/util/JsonUtil.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
-import org.checkerframework.checker.units.qual.K;
 
 import static com.fasterxml.jackson.core.json.JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER;
 import static com.fasterxml.jackson.core.json.JsonReadFeature.ALLOW_JAVA_COMMENTS;

--- a/distro/tomcat/src/main/resources/overlay/log4j2/conf/log4j2-tomcat.xml
+++ b/distro/tomcat/src/main/resources/overlay/log4j2/conf/log4j2-tomcat.xml
@@ -31,6 +31,29 @@ See more detail at: https://logging.apache.org/log4j/2.x/manual/async.html
       </DefaultRolloverStrategy>
     </RollingRandomAccessFile>
 
+    <!-- Metrics logger -->
+    <RollingRandomAccessFile
+      name="RollingMetricsRandomAccessFile"
+      fileName="${env:CATALINA_HOME}/logs/apiman/metrics.log"
+      filePattern="${env:CATALINA_HOME}/logs/apiman/metrics-%d{dd-MM-yyyy}-%i.log.zip"
+      immediateFlush="false">
+      <PatternLayout>
+        <Pattern>%m%n</Pattern>
+      </PatternLayout>
+      <!-- JSON logging can be enabled by changing to JSONLayout. See https://logging.apache.org/log4j/log4j-2.2/manual/layouts.html#JSONLayout -->
+      <!-- <JSONLayout /> -->
+      <Policies>
+        <TimeBasedTriggeringPolicy modulate="true"/>
+        <SizeBasedTriggeringPolicy size="2 GB"/>
+      </Policies>
+      <DefaultRolloverStrategy max="10">
+        <Delete basePath="${env:CATALINA_HOME}/logs/apiman" maxDepth="1">
+          <IfFileName glob="metrics*.log" />
+          <IfLastModified age="7d" />
+        </Delete>
+      </DefaultRolloverStrategy>
+    </RollingRandomAccessFile>
+
     <Console name="Console-Appender" target="SYSTEM_OUT" immediateFlush="false">
       <PatternLayout>
         <pattern>
@@ -46,6 +69,10 @@ See more detail at: https://logging.apache.org/log4j/2.x/manual/async.html
     <AsyncLogger level="${sys:apiman-logLevel:-info}" name="io.apiman" additivity="false">
       <AppenderRef ref="RollingRandomAccessFile"/>
       <AppenderRef ref="Console-Appender"/>
+    </AsyncLogger>
+    <!-- Apiman metrics disk-based logging (if you use it) -->
+    <AsyncLogger level="info" name="MetricsLogger" additivity="false">
+      <AppenderRef ref="RollingMetricsRandomAccessFile"/>
     </AsyncLogger>
     <!-- You can add your own loggers with separate levels, etc. -->
     <!-- <AsyncLogger level="info" name="com.example.yourpackage" additivity="false">

--- a/distro/wildfly/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
+++ b/distro/wildfly/src/main/resources/overlay/standalone/configuration/standalone-apiman.xml
@@ -119,7 +119,15 @@
                     <named-formatter name="PATTERN"/>
                 </formatter>
                 <file relative-to="jboss.server.log.dir" path="server.log"/>
-                <suffix value=".yyyy-MM-dd"/>
+                <suffix value=".yyyy-MM-dd.zip"/>
+                <append value="true"/>
+            </periodic-rotating-file-handler>
+            <periodic-rotating-file-handler name="APIMAN-METRICS-LOGS-ROTATING-HANDLER" autoflush="false">
+                <formatter>
+                    <named-formatter name="PLAIN"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="metrics.log"/>
+                <suffix value=".yyyy-MM-dd.zip"/>
                 <append value="true"/>
             </periodic-rotating-file-handler>
             <logger category="com.arjuna">
@@ -136,6 +144,12 @@
             </logger>
             <logger category="io.apiman">
                 <level name="INFO"/>
+            </logger>
+            <logger category="MetricsLogger" use-parent-handlers="false">
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="APIMAN-METRICS-LOGS-ASYNC-HANDLER"/>
+                </handlers>
             </logger>
             <root-logger>
                 <level name="INFO"/>
@@ -154,6 +168,17 @@
             <!--            <formatter name="JSON">-->
             <!--                <json-formatter/>-->
             <!--            </formatter>-->
+            <formatter name="PLAIN">
+                <pattern-formatter pattern="%s%e%n"/>
+            </formatter>
+            <async-handler name="APIMAN-METRICS-LOGS-ASYNC-HANDLER">
+                <level name="INFO"/>
+                <queue-length value="2048"/>
+                <overflow-action value="discard"/>
+                <subhandlers>
+                    <handler name="APIMAN-METRICS-LOGS-ROTATING-HANDLER"/>
+                </subhandlers>
+            </async-handler>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
         <subsystem xmlns="urn:jboss:domain:core-management:1.0"/>

--- a/gateway/engine/core/src/main/java/io/apiman/gateway/engine/IMetrics.java
+++ b/gateway/engine/core/src/main/java/io/apiman/gateway/engine/IMetrics.java
@@ -15,6 +15,8 @@
  */
 package io.apiman.gateway.engine;
 
+import io.apiman.common.logging.ApimanLoggerFactory;
+import io.apiman.common.logging.IApimanLogger;
 import io.apiman.gateway.engine.beans.ApiRequest;
 import io.apiman.gateway.engine.beans.ApiResponse;
 import io.apiman.gateway.engine.metrics.RequestMetric;
@@ -28,6 +30,7 @@ import io.apiman.gateway.engine.metrics.RequestMetric;
  * @author marc@blackparrotlabs.io
  */
 public interface IMetrics {
+    IApimanLogger METRICS_LOGGER = ApimanLoggerFactory.getLogger("MetricsLogger");
 
     /**
      * Records the metrics for a single request.  Most implementations will likely

--- a/manager/test/api/src/test/java/io/apiman/manager/test/es/EsMetricsAccessorTest.java
+++ b/manager/test/api/src/test/java/io/apiman/manager/test/es/EsMetricsAccessorTest.java
@@ -76,7 +76,7 @@ public class EsMetricsAccessorTest {
 
     public static final String APIMAN_METRICS_INDEX_NAME = "apiman_metrics";
     @Container
-    private static ElasticsearchContainer node = EsTestUtil.provideElasticsearchContainer();
+    private final static ElasticsearchContainer NODE = EsTestUtil.provideElasticsearchContainer();
 
     private static RestHighLevelClient client;
     private static Locale locale;
@@ -86,7 +86,7 @@ public class EsMetricsAccessorTest {
         locale = Locale.getDefault();
         Locale.setDefault(Locale.US);
 
-        node.start();
+        NODE.start();
 
         // Delete, refresh and create new client
         client = createEsClient();
@@ -111,15 +111,15 @@ public class EsMetricsAccessorTest {
     private static RestHighLevelClient createEsClient() {
         Map<String, String> config = new HashMap<>();
         config.put("client.protocol", "http");
-        config.put("client.host", node.getHost());
-        config.put("client.port", node.getFirstMappedPort().toString());
+        config.put("client.host", NODE.getHost());
+        config.put("client.port", NODE.getFirstMappedPort().toString());
         config.put("client.initialize", "true");
         config.put("client.type", "es");
 
         // We want the metrics client to initialise its indexes and this is an easy way of doing that.
         // Normally it would be triggered at startup of the component, but we bypass it in these tests.
         EsMetrics metrics = new EsMetrics(config);
-        System.out.println(metrics.getEsIndices());
+        System.out.println(metrics.getClient());
 
         return new DefaultEsClientFactory()
             .createClient(config,
@@ -142,7 +142,7 @@ public class EsMetricsAccessorTest {
     public static void teardown() throws Exception {
         System.out.println("----------- All done.");
         Locale.setDefault(locale);
-        node.stop();
+        NODE.stop();
     }
 
     @Before


### PR DESCRIPTION
To facilitate scrape-based metrics, this commit allows Apiman's ES metrics (as JSON) to be written
to a log file. The specific behaviour is controlled via whatever logging framework is used.

It is possible to write to any of: `remote` (ES server), `log`

The configuration provided in this commit calls the output `metrics.log`, but we the user can change
this, as per their preferences. Async logging is used, where possible, to mitigate the impact on
performance, as this is likely to generate a considerable number of log writes.

Thanks again to Terry, Russel, Joe, Colin, LN, Shivraj, and the rest of the team.

Fixes: #2100