### PR TITLE
fix(gateway): apply java proxy options to vert.x connection

### DIFF
--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/ConnectorFactory.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/ConnectorFactory.java
@@ -25,10 +25,12 @@ import io.apiman.gateway.engine.IConnectorFactory;
 import io.apiman.gateway.engine.auth.RequiredAuthType;
 import io.apiman.gateway.engine.beans.Api;
 import io.apiman.gateway.engine.beans.ApiRequest;
+import io.apiman.gateway.platforms.vertx3.engine.proxy.SysPropsProxySelector;
 import io.apiman.gateway.platforms.vertx3.http.HttpClientOptionsFactory;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.net.ProxyOptions;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -44,6 +46,7 @@ import java.util.concurrent.ExecutionException;
  */
 public class ConnectorFactory implements IConnectorFactory {
 
+    private final SysPropsProxySelector proxySelector = new SysPropsProxySelector();
     private static final Set<String> SUPPRESSED_HEADERS = new HashSet<>();
     static {
         SUPPRESSED_HEADERS.add("Transfer-Encoding"); //$NON-NLS-1$
@@ -68,6 +71,8 @@ public class ConnectorFactory implements IConnectorFactory {
                                 .setIdleTimeout(opts.getIdleTimeout())
                                 .setKeepAlive(opts.isKeepAlive())
                                 .setTryUseCompression(opts.isTryUseCompression());
+
+                        applyProxyOptions(opts, vxClientOptions);
                         return vertx.createHttpClient(vxClientOptions);
                     }
                 });
@@ -142,5 +147,25 @@ public class ConnectorFactory implements IConnectorFactory {
     @Override
     public IConnectorConfig createConnectorConfig(ApiRequest request, Api api) {
         return new VertxConnectorConfig();
+    }
+
+    /*
+     * Set the proxy options in the same way it was originally implemented by msavy
+     * @see io.apiman.gateway.platforms.vertx3.engine.VertxPluginRegistry#createVertxClientOptions(URI, boolean)
+     */
+    private void applyProxyOptions(ApimanHttpConnectorOptions opts, HttpClientOptions vxClientOptions) {
+        proxySelector.resolveProxy(opts.getUri()).ifPresent(proxy -> {
+            ProxyOptions proxyOptions = new ProxyOptions();
+            proxyOptions.setHost(proxy.getHost());
+            proxyOptions.setPort(proxy.getPort());
+            proxyOptions.setType(proxySelector.translateProxyType(proxy));
+
+            proxy.getCredentials().ifPresent((credentials) -> {
+                proxyOptions.setUsername(credentials.getPrinciple());
+                proxyOptions.setPassword(credentials.getPasswordAsString());
+            });
+
+            vxClientOptions.setProxyOptions(proxyOptions);
+        });
     }
 }

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/engine/VertxPluginRegistry.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/engine/VertxPluginRegistry.java
@@ -50,7 +50,17 @@ import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.net.ProxyOptions;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.Base64;
+import java.util.Map;
 
 /**
  * A vertx implementation of the API Gateway's plugin registry. This version simply extends the default
@@ -199,20 +209,7 @@ public class VertxPluginRegistry extends DefaultPluginRegistry {
             httpClientOptions.setSsl(true);
         }
 
-        // If there's a proxy that should be used, it will be resolved and set here.
-        proxySelector.resolveProxy(artifactUrl).ifPresent(proxy -> {
-            ProxyOptions proxyOptions = new ProxyOptions();
-            proxyOptions.setHost(proxy.getHost());
-            proxyOptions.setPort(proxy.getPort());
-            proxyOptions.setType(proxySelector.translateProxyType(proxy));
-
-            proxy.getCredentials().ifPresent((credentials) -> {
-                proxyOptions.setUsername(credentials.getPrinciple());
-                proxyOptions.setPassword(credentials.getPasswordAsString());
-            });
-
-            httpClientOptions.setProxyOptions(proxyOptions);
-        });
+        proxySelector.setProxyOptions(artifactUrl, httpClientOptions);
 
         return httpClientOptions;
     }

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/engine/VertxPluginRegistry.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/engine/VertxPluginRegistry.java
@@ -24,7 +24,6 @@ import io.apiman.gateway.engine.vertx.polling.exceptions.BadResponseCodeError;
 import io.apiman.gateway.platforms.vertx3.common.config.InheritingHttpClientOptions;
 import io.apiman.gateway.platforms.vertx3.common.config.InheritingHttpClientOptionsConverter;
 import io.apiman.gateway.platforms.vertx3.common.config.VertxEngineConfig;
-import io.apiman.gateway.platforms.vertx3.engine.proxy.HttpProxy;
 import io.apiman.gateway.platforms.vertx3.engine.proxy.SysPropsProxySelector;
 import io.apiman.gateway.platforms.vertx3.i18n.Messages;
 
@@ -52,7 +51,6 @@ import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.ProxyOptions;
-import io.vertx.core.net.ProxyType;
 
 /**
  * A vertx implementation of the API Gateway's plugin registry. This version simply extends the default
@@ -144,7 +142,7 @@ public class VertxPluginRegistry extends DefaultPluginRegistry {
             handler.handle(AsyncResultImpl.create(failure));
         });
     }
-    
+
     private void tryDownloadingArtifact(HttpClient client, int port, URL artifactUrl, File pluginFile, Promise<File> promise) {
         final HttpClientRequest request = client.get(port, artifactUrl.getHost(), artifactUrl.getPath(),
             (Handler<HttpClientResponse>) response -> {
@@ -206,27 +204,16 @@ public class VertxPluginRegistry extends DefaultPluginRegistry {
             ProxyOptions proxyOptions = new ProxyOptions();
             proxyOptions.setHost(proxy.getHost());
             proxyOptions.setPort(proxy.getPort());
-            proxyOptions.setType(translateProxyType(proxy));
+            proxyOptions.setType(proxySelector.translateProxyType(proxy));
 
             proxy.getCredentials().ifPresent((credentials) -> {
                 proxyOptions.setUsername(credentials.getPrinciple());
                 proxyOptions.setPassword(credentials.getPasswordAsString());
             });
+
+            httpClientOptions.setProxyOptions(proxyOptions);
         });
 
         return httpClientOptions;
-    }
-
-    private ProxyType translateProxyType(HttpProxy proxy) {
-        switch(proxy.getProxyType()) {
-            case HTTP:
-                return ProxyType.HTTP;
-            case SOCKS4:
-                return ProxyType.SOCKS4;
-            case SOCKS5:
-                return ProxyType.SOCKS5;
-            default:
-                throw new IllegalStateException("Unexpected value: " + proxy.getProxyType());
-        }
     }
 }

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/engine/proxy/SysPropsProxySelector.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/engine/proxy/SysPropsProxySelector.java
@@ -15,6 +15,8 @@
  */
 package io.apiman.gateway.platforms.vertx3.engine.proxy;
 
+import io.vertx.core.net.ProxyType;
+
 import java.net.URI;
 import java.util.Optional;
 import java.util.StringJoiner;
@@ -55,6 +57,19 @@ public class SysPropsProxySelector {
             return socksProxy.getProxy(resourceUri.getHost());
         }
         return Optional.empty();
+    }
+
+    public ProxyType translateProxyType(HttpProxy proxy) {
+        switch(proxy.getProxyType()) {
+            case HTTP:
+                return ProxyType.HTTP;
+            case SOCKS4:
+                return ProxyType.SOCKS4;
+            case SOCKS5:
+                return ProxyType.SOCKS5;
+            default:
+                throw new IllegalStateException("Unexpected value: " + proxy.getProxyType());
+        }
     }
 
     @Override

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/engine/proxy/SysPropsProxySelector.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/engine/proxy/SysPropsProxySelector.java
@@ -15,6 +15,8 @@
  */
 package io.apiman.gateway.platforms.vertx3.engine.proxy;
 
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
 
 import java.net.URI;
@@ -39,10 +41,32 @@ public class SysPropsProxySelector {
     }
 
     /**
+     * Set proxy options on vxClientOptions derived from System properties.
+     *
+     * @param proxyUri proxy URI
+     * @param vxClientOptions Vert.x client options to mutate
+     */
+    public void setProxyOptions(URI proxyUri, HttpClientOptions vxClientOptions) {
+        this.resolveProxy(proxyUri).ifPresent(proxy -> {
+            ProxyOptions proxyOptions = new ProxyOptions();
+            proxyOptions.setHost(proxy.getHost());
+            proxyOptions.setPort(proxy.getPort());
+            proxyOptions.setType(translateProxyType(proxy));
+
+            proxy.getCredentials().ifPresent((credentials) -> {
+                proxyOptions.setUsername(credentials.getPrinciple());
+                proxyOptions.setPassword(credentials.getPasswordAsString());
+            });
+
+            vxClientOptions.setProxyOptions(proxyOptions);
+        });
+    }
+
+    /**
      * Resolve a proxy, if there is one.
      *
      * @param resourceUri the URI that will be assessed against the proxy configuration
-     * @return the proxy, if there is an appropriate one configured and it is not on the non-proxy list.
+     * @return the proxy, if there is an appropriate one configured, and it is not on the non-proxy list.
      */
     public Optional<HttpProxy> resolveProxy(URI resourceUri) {
         String scheme = resourceUri.getScheme();
@@ -59,7 +83,7 @@ public class SysPropsProxySelector {
         return Optional.empty();
     }
 
-    public ProxyType translateProxyType(HttpProxy proxy) {
+    private ProxyType translateProxyType(HttpProxy proxy) {
         switch(proxy.getProxyType()) {
             case HTTP:
                 return ProxyType.HTTP;


### PR DESCRIPTION
Take care of java sys proxy options for connection between the vert.x gateway and the backend service. Additionally, this fixed the plugin download in vert.x if a proxy is used.

Closes: #2250