### PR TITLE
feat(policies): add ip granularity to transfer quota policy

### DIFF
--- a/gateway/test/src/test/java/io/apiman/gateway/test/Policy_TransferQuotaTest.java
+++ b/gateway/test/src/test/java/io/apiman/gateway/test/Policy_TransferQuotaTest.java
@@ -1,0 +1,12 @@
+package io.apiman.gateway.test;
+
+import io.apiman.gateway.test.junit.GatewayRestTestPlan;
+import io.apiman.gateway.test.junit.GatewayRestTester;
+import org.junit.runner.RunWith;
+
+@RunWith(GatewayRestTester.class)
+@GatewayRestTestPlan("test-plans/policies/transfer-quota-testPlan.xml")
+public class Policy_TransferQuotaTest {
+
+
+}

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/001-publish-api.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/001-publish-api.resttest
@@ -1,0 +1,12 @@
+PUT /apis admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "Policy_TransferQuotaTest",
+  "apiId" : "echo",
+  "version" : "1.0.0",
+  "endpointType" : "REST",
+  "endpoint" : "${apiman.test.gateway.endpoints.echo}/"
+}
+----
+204

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/002-register-client.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/002-register-client.resttest
@@ -1,0 +1,24 @@
+PUT /clients admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "Policy_TransferQuotaTest",
+  "clientId" : "test",
+  "version" : "1.0.0",
+  "apiKey" : "12345",
+  "contracts" : [
+    {
+      "apiOrgId" : "Policy_TransferQuotaTest",
+      "apiId" : "echo",
+      "apiVersion" : "1.0.0",
+      "policies" : [
+        {
+          "policyImpl" : "class:io.apiman.gateway.engine.policies.TransferQuotaPolicy",
+          "policyJsonConfig" : "{\"limit\":100,\"direction\":\"both\",\"granularity\":\"Client\",\"period\":\"Hour\"}"
+        }
+      ]
+    }
+  ]
+}
+----
+204

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/003-success.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/003-success.resttest
@@ -1,0 +1,13 @@
+GET /Policy_TransferQuotaTest/echo/1.0.0/path/to/app/resource admin/admin
+X-API-Key: 12345
+
+----
+200
+Content-Type: application/json
+X-TransferQuota-Limit: 100
+
+{
+  "method" : "GET",
+  "resource" : "/path/to/app/resource",
+  "uri" : "/path/to/app/resource"
+}

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/003.5-probe-transfer-quota.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/003.5-probe-transfer-quota.resttest
@@ -1,0 +1,27 @@
+POST /organizations/Policy_TransferQuotaTest/apis/echo/versions/1.0.0/policies/0?apiKey=12345 admin/admin
+Content-Type: application/json
+X-API-Key: 12345
+
+{
+    "user": "bgembalczyk",
+    "apiKey": "12345",
+    "callerIp": "127.0.0.1"
+}
+
+----
+200
+Content-Type: application/json
+
+{
+  "TransferQuotaProbeResponse": {
+    "config": {
+      "limit": 100,
+      "granularity": "Client",
+      "period": "Hour"
+    },
+    "status": {
+      "accepted": false
+    },
+    "probeType": "TransferQuotaProbeResponse"
+  }
+}

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/004-failure.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/004-failure.resttest
@@ -1,0 +1,13 @@
+GET /Policy_TransferQuotaTest/echo/1.0.0/path/to/app/resource admin/admin
+X-API-Key: 12345
+
+----
+429
+Content-Type: application/json
+X-Policy-Failure-Type: Other
+X-Policy-Failure-Code: 10013
+
+{
+    "type" : "Other",
+    "failureCode" : 10013
+}

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/005-register-client-ip-policy.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/005-register-client-ip-policy.resttest
@@ -1,0 +1,24 @@
+PUT /clients admin/admin
+Content-Type: application/json
+
+{
+  "organizationId" : "Policy_TransferQuotaTest",
+  "clientId" : "testIp",
+  "version" : "1.0.0",
+  "apiKey" : "12345-ip",
+  "contracts" : [
+    {
+      "apiOrgId" : "Policy_TransferQuotaTest",
+      "apiId" : "echo",
+      "apiVersion" : "1.0.0",
+      "policies" : [
+        {
+          "policyImpl" : "class:io.apiman.gateway.engine.policies.TransferQuotaPolicy",
+          "policyJsonConfig" : "{\"limit\":100,\"direction\":\"both\",\"granularity\":\"Ip\",\"period\":\"Hour\"}"
+        }
+      ]
+    }
+  ]
+}
+----
+204

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/006-success-ip-address.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/006-success-ip-address.resttest
@@ -1,0 +1,13 @@
+GET /Policy_TransferQuotaTest/echo/1.0.0/path/to/app/resource admin/admin
+X-API-Key: 12345-ip
+
+----
+200
+Content-Type: application/json
+X-TransferQuota-Limit: 100
+
+{
+  "method" : "GET",
+  "resource" : "/path/to/app/resource",
+  "uri" : "/path/to/app/resource"
+}

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/007-failure-ip-address.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/007-failure-ip-address.resttest
@@ -1,0 +1,13 @@
+GET /Policy_TransferQuotaTest/echo/1.0.0/path/to/app/resource admin/admin
+X-API-Key: 12345-ip
+
+----
+429
+Content-Type: application/json
+X-Policy-Failure-Type: Other
+X-Policy-Failure-Code: 10013
+
+{
+    "type" : "Other",
+    "failureCode" : 10013
+}

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/008-probe-ip-transfer-quota.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/008-probe-ip-transfer-quota.resttest
@@ -1,0 +1,27 @@
+POST /organizations/Policy_TransferQuotaTest/apis/echo/versions/1.0.0/policies/0?apiKey=12345-ip admin/admin
+Content-Type: application/json
+X-API-Key: 12345-ip
+
+{
+  "user": "bgembalczyk",
+  "apiKey": "12345-ip",
+  "callerIp": "127.0.0.1"
+}
+
+----
+200
+Content-Type: application/json
+
+{
+  "TransferQuotaProbeResponse": {
+    "config": {
+      "limit": 100,
+      "granularity": "Ip",
+      "period": "Hour"
+    },
+    "status": {
+      "accepted": false
+    },
+    "probeType": "TransferQuotaProbeResponse"
+  }
+}

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/009-probe-ip-transfer-quota.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/009-probe-ip-transfer-quota.resttest
@@ -1,0 +1,28 @@
+POST /organizations/Policy_TransferQuotaTest/apis/echo/versions/1.0.0/policies/0?apiKey=12345-ip admin/admin
+Content-Type: application/json
+X-API-Key: 12345-ip
+
+{
+  "user": "bgembalczyk",
+  "apiKey": "12345-ip",
+  "callerIp": "127.0.0.2"
+}
+
+----
+200
+Content-Type: application/json
+
+{
+  "TransferQuotaProbeResponse": {
+    "config": {
+      "limit": 100,
+      "granularity": "Ip",
+      "period": "Hour"
+    },
+    "status": {
+      "accepted": true,
+      "remaining": 100
+    },
+    "probeType": "TransferQuotaProbeResponse"
+  }
+}

--- a/gateway/test/src/test/resources/test-plans/policies/transfer-quota-testPlan.xml
+++ b/gateway/test/src/test/resources/test-plans/policies/transfer-quota-testPlan.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan" name="rate limiting">
+<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan" name="transfer quota">
 
   <testGroup name="Test Policy">
     <test name="Publish Api" endpoint="api">test-plan-data/policies/transfer-quota/001-publish-api.resttest</test>
@@ -12,7 +12,6 @@
     <test name="Failure 2">test-plan-data/policies/transfer-quota/007-failure-ip-address.resttest</test>
     <test name="Probe IP policy state" endpoint="api">test-plan-data/policies/transfer-quota/008-probe-ip-transfer-quota.resttest</test>
     <test name="Probe IP policy state" endpoint="api">test-plan-data/policies/transfer-quota/009-probe-ip-transfer-quota.resttest</test>
-
   </testGroup>
 
 </testPlan>

--- a/gateway/test/src/test/resources/test-plans/policies/transfer-quota-testPlan.xml
+++ b/gateway/test/src/test/resources/test-plans/policies/transfer-quota-testPlan.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testPlan xmlns="urn:io.apiman.test:2014:02:testPlan" name="rate limiting">
+
+  <testGroup name="Test Policy">
+    <test name="Publish Api" endpoint="api">test-plan-data/policies/transfer-quota/001-publish-api.resttest</test>
+    <test name="Register Client" endpoint="api">test-plan-data/policies/transfer-quota/002-register-client.resttest</test>
+    <test name="Success 1">test-plan-data/policies/transfer-quota/003-success.resttest</test>
+    <test name="Probe policy state" endpoint="api">test-plan-data/policies/transfer-quota/003.5-probe-transfer-quota.resttest</test>
+    <test name="Failure 1">test-plan-data/policies/transfer-quota/004-failure.resttest</test>
+    <test name="Register Client With Ip policy" endpoint="api">test-plan-data/policies/transfer-quota/005-register-client-ip-policy.resttest</test>
+    <test name="Success 2">test-plan-data/policies/transfer-quota/006-success-ip-address.resttest</test>
+    <test name="Failure 2">test-plan-data/policies/transfer-quota/007-failure-ip-address.resttest</test>
+    <test name="Probe IP policy state" endpoint="api">test-plan-data/policies/transfer-quota/008-probe-ip-transfer-quota.resttest</test>
+    <test name="Probe IP policy state" endpoint="api">test-plan-data/policies/transfer-quota/009-probe-ip-transfer-quota.resttest</test>
+
+  </testGroup>
+
+</testPlan>

--- a/manager/ui/war/plugins/api-manager/html/policyForms/transfer-quota.include
+++ b/manager/ui/war/plugins/api-manager/html/policyForms/transfer-quota.include
@@ -33,6 +33,7 @@
 	      <option value="Client" apiman-i18n-key="rate-limiting.client-client">Client App</option>
 	      <option value="User" apiman-i18n-key="rate-limiting.user">User</option>
 	      <option value="Api" apiman-i18n-key="rate-limiting.api">API</option>
+	      <option value="Ip" apiman-i18n-key="rate-limiting.ip">IP Address</option>
 	    </select>
 
 	    <span apiman-i18n-key="per">per</span>


### PR DESCRIPTION
Added IP address to the granularity of the transfer quota policy. Furthermore added some unit tests for the policy.

Closes: #1869