### PR TITLE
Little UI fix - API Definition

### DIFF
--- a/manager/ui/war/plugins/api-manager/ts/consumer/consumer-api.ts
+++ b/manager/ui/war/plugins/api-manager/ts/consumer/consumer-api.ts
@@ -188,10 +188,8 @@ _module.controller("Apiman.ConsumerApiDefController",
                         ],
 
                         requestInterceptor: function(request) {
-                            // Only add auth header to requests where the URL matches the one specified above.
-                            if (request.url === url) {
-                                request.headers.Authorization = Configuration.getAuthorizationHeader();
-                            }
+                            // Send keycloak token
+                            request.headers.Authorization = Configuration.getAuthorizationHeader();
 
                             // Send the API-Key always as parameter if the URL is not the URL whrere the SwaggerFile comes from
                             // to avoid CORS Problems with the backend


### PR DESCRIPTION
Currently, we always send the "Authorization" header in all apiman applications as this avoids problems if the Keycloak OAuth policy is applied. This results now in the same behavior as the Swagger UI for the Apiman REST API itself and like it is handled in the developer portal.