### PR TITLE
fix(metrics-es): add missing remoteAddr field to EsMetrics

### DIFF
--- a/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/EsMetrics.java
+++ b/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/EsMetrics.java
@@ -363,6 +363,7 @@ public class EsMetrics extends AbstractEsComponent implements IMetrics {
         private final long bytesDownloaded;
         private final Map<String, HeaderMap> headers;
         private final QueryMap queryParams;
+        private final String remoteAddr;
 
         public EsMetricPayload(RequestMetric requestMetricIn, Map<String, HeaderMap> headers, QueryMap queryParams) {
             this.requestStart = requestMetricIn.getRequestStart();
@@ -394,6 +395,7 @@ public class EsMetrics extends AbstractEsComponent implements IMetrics {
             this.bytesDownloaded = requestMetricIn.getBytesDownloaded();
             this.headers = headers;
             this.queryParams = queryParams;
+            this.remoteAddr = requestMetricIn.getRemoteAddr();
         }
 
         public Date getRequestStart() {
@@ -512,6 +514,10 @@ public class EsMetrics extends AbstractEsComponent implements IMetrics {
             return queryParams;
         }
 
+        public String getRemoteAddr() {
+            return remoteAddr;
+        }
+
         @Override
         public String toString() {
             return new StringJoiner(", ", EsMetricPayload.class.getSimpleName() + "[", "]")
@@ -544,6 +550,7 @@ public class EsMetrics extends AbstractEsComponent implements IMetrics {
                            .add("bytesDownloaded=" + bytesDownloaded)
                            .add("headers=" + headers)
                            .add("queryParams=" + queryParams)
+                           .add("remoteAddr='" + remoteAddr + "'")
                            .toString();
         }
     }


### PR DESCRIPTION
Due to the changes in `2cdace93e0a7a06c6dde9ee1aaf245fb179ec9ba` the `remoteAddr` field was missing in the new class `EsMetricsPayload`. Adding this field again, adds it also in the index.

The field is already part of the index mapping definition.
See:
https://github.com/apiman/apiman/blob/dabb5af66de5a9abc8ed875ce921e2c617e39d4c/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/EsMetrics.java#L259