### PR TITLE
test(gateway-test): refactor flaky transfer-quota test by using day granularity

### DIFF
--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/002-register-client.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/002-register-client.resttest
@@ -14,7 +14,7 @@ Content-Type: application/json
       "policies" : [
         {
           "policyImpl" : "class:io.apiman.gateway.engine.policies.TransferQuotaPolicy",
-          "policyJsonConfig" : "{\"limit\":100,\"direction\":\"both\",\"granularity\":\"Client\",\"period\":\"Hour\"}"
+          "policyJsonConfig" : "{\"limit\":355,\"direction\":\"both\",\"granularity\":\"Client\",\"period\":\"Day\"}"
         }
       ]
     }

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/003-success.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/003-success.resttest
@@ -1,13 +1,28 @@
-GET /Policy_TransferQuotaTest/echo/1.0.0/path/to/app/resource admin/admin
+POST /Policy_TransferQuotaTest/echo/1.0.0/path/to/app/resource admin/admin
 X-API-Key: 12345
+
+{
+  "sdsdsd":"adasdasdasda",
+  "sdsdsx":"adasdasdasda",
+  "sdsdsy":"adasdasdasda",
+  "sdsdsz":"adasdasdasda",
+  "sdsdsa":"adasdasdasda",
+  "sdsdsb":"adasdasdasda",
+  "sdsdsc":"adasdasdasda",
+  "sdsdsd":"adasdasdasda",
+  "sdsdse":"adasdasdasda",
+  "sdsdsf":"adasdasdasda",
+  "sdsdsg":"adasdasdasda",
+  "sdsdsi":"adasdasdasda"
+}
 
 ----
 200
 Content-Type: application/json
-X-TransferQuota-Limit: 100
+X-TransferQuota-Limit: 355
 
 {
-  "method" : "GET",
+  "method" : "POST",
   "resource" : "/path/to/app/resource",
   "uri" : "/path/to/app/resource"
 }

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/003.5-probe-transfer-quota.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/003.5-probe-transfer-quota.resttest
@@ -26,8 +26,7 @@ Content-Type: application/json
 			"direction": "both"
 		},
 		"status": {
-			"accepted": false,
-			"remaining": -490
+			"accepted": false
 		}
 	}
 }

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/003.5-probe-transfer-quota.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/003.5-probe-transfer-quota.resttest
@@ -13,15 +13,21 @@ X-API-Key: 12345
 Content-Type: application/json
 
 {
-  "TransferQuotaProbeResponse": {
-    "config": {
-      "limit": 100,
-      "granularity": "Client",
-      "period": "Hour"
-    },
-    "status": {
-      "accepted": false
-    },
-    "probeType": "TransferQuotaProbeResponse"
-  }
+	"TransferQuotaProbeResponse": {
+		"probeType": "TransferQuotaProbeResponse",
+		"config": {
+			"limit": 355,
+			"granularity": "Client",
+			"period": "Day",
+			"userHeader": null,
+			"headerRemaining": null,
+			"headerLimit": null,
+			"headerReset": null,
+			"direction": "both"
+		},
+		"status": {
+			"accepted": false,
+			"remaining": -490
+		}
+	}
 }

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/004-failure.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/004-failure.resttest
@@ -1,5 +1,9 @@
-GET /Policy_TransferQuotaTest/echo/1.0.0/path/to/app/resource admin/admin
+POST /Policy_TransferQuotaTest/echo/1.0.0/path/to/app/resource admin/admin
 X-API-Key: 12345
+
+{
+  "some-kind-of-payload": "we've gone way over our limits, sorry!"
+}
 
 ----
 429

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/005-register-client-ip-policy.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/005-register-client-ip-policy.resttest
@@ -14,7 +14,7 @@ Content-Type: application/json
       "policies" : [
         {
           "policyImpl" : "class:io.apiman.gateway.engine.policies.TransferQuotaPolicy",
-          "policyJsonConfig" : "{\"limit\":100,\"direction\":\"both\",\"granularity\":\"Ip\",\"period\":\"Hour\"}"
+          "policyJsonConfig" : "{\"limit\":355,\"direction\":\"both\",\"granularity\":\"Ip\",\"period\":\"Day\"}"
         }
       ]
     }

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/006-success-ip-address.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/006-success-ip-address.resttest
@@ -13,7 +13,9 @@ X-API-Key: 12345-ip
   "sdsdse":"adasdasdasda",
   "sdsdsf":"adasdasdasda",
   "sdsdsg":"adasdasdasda",
-  "sdsdsi":"adasdasdasda"
+  "sdsdsh":"adasdasdasda",
+  "sdsdsi":"adasdasdasda",
+  "sdsdsj":"adasdasdasda"
 }
 
 ----

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/006-success-ip-address.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/006-success-ip-address.resttest
@@ -2,21 +2,26 @@ POST /Policy_TransferQuotaTest/echo/1.0.0/path/to/app/resource admin/admin
 X-API-Key: 12345-ip
 
 {
-  "sdsdsd":"adasdasdasda",
-  "sdsdsx":"adasdasdasda",
-  "sdsdsy":"adasdasdasda",
-  "sdsdsz":"adasdasdasda",
-  "sdsdsa":"adasdasdasda",
-  "sdsdsb":"adasdasdasda",
-  "sdsdsc":"adasdasdasda",
-  "sdsdsd":"adasdasdasda",
-  "sdsdse":"adasdasdasda",
-  "sdsdsf":"adasdasdasda",
-  "sdsdsg":"adasdasdasda",
-  "sdsdsh":"adasdasdasda",
-  "sdsdsi":"adasdasdasda",
-  "sdsdsj":"adasdasdasda"
-}
+  "K6Y5n9zB" : "TVALMWVryKL0zfbC",
+  "gMUjvY63" : "93J42WOTctQc49mN",
+  "XWzQHNb8" : "YGo72D1F46gU5r1r",
+  "6k1o4Ee8" : "7fTwgcyXhFg0f4f3",
+  "P6SsjAru" : "069WIGpo6oz2Kr9M",
+  "04wJ9491" : "SKf3eJwVT4Hm71XP",
+  "mmFFbmZ3" : "Ngs5q4K3vLf9lu5U",
+  "03id3m5p" : "878SJ1SH6e9ku736",
+  "cx58s226" : "5PzhYXVa133zp3mI",
+  "di5zgxYT" : "kM4XKvU7KaNtwBhB",
+  "BNBE8Qo8" : "0JxN1UafeOMFEDZ2",
+  "qaA4cW1P" : "w3aVhqhkIiqM607Y",
+  "U3y0m41t" : "s5yOHf0M9CUhKT2P",
+  "yjQQ6264" : "yYJY56rEqSIFF49E",
+  "LJ9CsXE0" : "M3kb8iUVm5ESHd22",
+  "KjIHXY56" : "XVVGQbGN0DaVnpsp",
+  "d6VJ2yIk" : "gLl02FE117t3Yf7r",
+  "it4yC2Id" : "OxhB17lhZV5258c9",
+  "qcaALQm1" : "VCw0OTK69qkiZ4hQ"
+ }
 
 ----
 200

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/006-success-ip-address.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/006-success-ip-address.resttest
@@ -1,13 +1,28 @@
-GET /Policy_TransferQuotaTest/echo/1.0.0/path/to/app/resource admin/admin
+POST /Policy_TransferQuotaTest/echo/1.0.0/path/to/app/resource admin/admin
 X-API-Key: 12345-ip
+
+{
+  "sdsdsd":"adasdasdasda",
+  "sdsdsx":"adasdasdasda",
+  "sdsdsy":"adasdasdasda",
+  "sdsdsz":"adasdasdasda",
+  "sdsdsa":"adasdasdasda",
+  "sdsdsb":"adasdasdasda",
+  "sdsdsc":"adasdasdasda",
+  "sdsdsd":"adasdasdasda",
+  "sdsdse":"adasdasdasda",
+  "sdsdsf":"adasdasdasda",
+  "sdsdsg":"adasdasdasda",
+  "sdsdsi":"adasdasdasda"
+}
 
 ----
 200
 Content-Type: application/json
-X-TransferQuota-Limit: 100
+X-TransferQuota-Limit: 355
 
 {
-  "method" : "GET",
+  "method" : "POST",
   "resource" : "/path/to/app/resource",
   "uri" : "/path/to/app/resource"
 }

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/008-probe-ip-transfer-quota.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/008-probe-ip-transfer-quota.resttest
@@ -15,9 +15,9 @@ Content-Type: application/json
 {
   "TransferQuotaProbeResponse": {
     "config": {
-      "limit": 100,
+      "limit": 355,
       "granularity": "Ip",
-      "period": "Hour"
+      "period": "Day"
     },
     "status": {
       "accepted": false

--- a/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/009-probe-ip-transfer-quota.resttest
+++ b/gateway/test/src/test/resources/test-plan-data/policies/transfer-quota/009-probe-ip-transfer-quota.resttest
@@ -15,13 +15,12 @@ Content-Type: application/json
 {
   "TransferQuotaProbeResponse": {
     "config": {
-      "limit": 100,
+      "limit": 355,
       "granularity": "Ip",
-      "period": "Hour"
+      "period": "Day"
     },
     "status": {
-      "accepted": true,
-      "remaining": 100
+      "accepted": true
     },
     "probeType": "TransferQuotaProbeResponse"
   }

--- a/gateway/test/src/test/resources/test-plans/policies/transfer-quota-testPlan.xml
+++ b/gateway/test/src/test/resources/test-plans/policies/transfer-quota-testPlan.xml
@@ -11,7 +11,7 @@
     <test name="Success 2">test-plan-data/policies/transfer-quota/006-success-ip-address.resttest</test>
     <test name="Failure 2">test-plan-data/policies/transfer-quota/007-failure-ip-address.resttest</test>
     <test name="Probe IP policy state" endpoint="api">test-plan-data/policies/transfer-quota/008-probe-ip-transfer-quota.resttest</test>
-    <test name="Probe IP policy state" endpoint="api">test-plan-data/policies/transfer-quota/009-probe-ip-transfer-quota.resttest</test>
+    <test name="Probe IP policy state (different IP address)" endpoint="api">test-plan-data/policies/transfer-quota/009-probe-ip-transfer-quota.resttest</test>
   </testGroup>
 
 </testPlan>


### PR DESCRIPTION
Use daily time granularity to avoid issue where test could fail due to coincidental rollover into new hour.

Add some data to the request to make the test more realistic.