### PR TITLE
fix(ui): avoid undefined errors

### DIFF
--- a/manager/ui/war/plugins/api-manager/ts/policies.ts
+++ b/manager/ui/war/plugins/api-manager/ts/policies.ts
@@ -306,20 +306,22 @@ _module.controller('Apiman.IPListFormController',
                 $scope.currentTypedValue = $('#ip-address').text();
             }
 
-            var validate = function(config) {
-                var valid = true;
+            const validate = function (config) {
+                // set default configs in validate method as both IP (Allow/Block) policies share the IPListFormController
+                // otherwise we run into undefined errors if user switches between the policies
+                // as the config object is reset during NewPolicyController#loadTemplate
+                if (!$scope.config.ipList) {
+                    $scope.config.ipList = [];
+                }
+                if (!$scope.config.responseCode) {
+                    $scope.config.responseCode = '500';
+                }
+
+                const valid = true;
                 $scope.setValid(valid);
             };
 
             $scope.$watch('config', validate, true);
-
-            if (!$scope.config.ipList) {
-                $scope.config.ipList = [];
-            }
-
-            if (!$scope.config.responseCode) {
-                $scope.config.responseCode = '500';
-            }
 
             $scope.add = function(ip) {
                 $scope.remove(ip);

--- a/manager/ui/war/pom.xml
+++ b/manager/ui/war/pom.xml
@@ -172,7 +172,7 @@
             </goals>
             <phase>generate-resources</phase>
             <configuration>
-              <arguments>--mode production --stats verbose</arguments>
+              <arguments>--mode production</arguments>
             </configuration>
           </execution>
         </executions>

--- a/manager/ui/war/webpack.config.js
+++ b/manager/ui/war/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = (env, argv) => {
       static: './dist',
       historyApiFallback: true
     },
+    stats: 'normal',
     plugins: [
       new HtmlWebpackPlugin({
         title: 'Apiman',


### PR DESCRIPTION
If one switches between ip policies the ip-list could be undefined. Moving the check into the validate method fixes the problem.