### PR TITLE
fix(gateway-engine-es): throw `ClientNotFoundException` if client not found when unregistering

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,8 @@ All notable changes to Apiman will be documented here (as of Apiman 3).
 
 === Fixed
 
+* fix[gateway-engine-es]: throw ClientNotFoundException if client not found when unregistering. By https://github.com/fvolk[Florian Volk (@fvolk)^].
+
 * [manager-api]: Perform unregister only if client is in correct state. By https://github.com/fvolk[Florian Volk (@fvolk)^].
 
 **Full Changelog**: link:https://github.com/apiman/apiman/compare/3.0.0.Final...3.1.0-SNAPSHOT[3.0.0.Final...3.1.0-SNAPSHOT]

--- a/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/EsRegistry.java
+++ b/gateway/engine/es/src/main/java/io/apiman/gateway/engine/es/EsRegistry.java
@@ -221,7 +221,7 @@ public class EsRegistry extends AbstractEsComponent implements IRegistry {
             if (response.status().equals(RestStatus.OK)) {
                 handler.handle(AsyncResultImpl.create((Void) null));
             } else {
-                handler.handle(AsyncResultImpl.create(new ApiNotFoundException(Messages.i18n.format("EsRegistry.ClientNotFound")))); //$NON-NLS-1$
+                handler.handle(AsyncResultImpl.create(new ClientNotFoundException(Messages.i18n.format("EsRegistry.ClientNotFound")))); //$NON-NLS-1$
             }
         } catch (IOException e) {
             handler.handle(AsyncResultImpl.create(new PublishingException(Messages.i18n.format("EsRegistry.ErrorUnregisteringClient"), e), Void.class)); //$NON-NLS-1$


### PR DESCRIPTION
Replace ApiNotFoundException with ClientNotFoundException