### PR TITLE
fix(distro-ddl):  fix multiple MSSQL DDL issues

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,8 @@ All notable changes to Apiman will be documented here (as of Apiman 3).
 
 === Fixed
 
+* Multiple small MSSQL (Microsoft SQL Server) DDL fixes. By https://github.com/msavy[Marc Savy (@msavy)^].
+
 // end::3.2.0-SNAPSHOT[]
 
 == 3.1.1.Final

--- a/distro/data/src/main/resources/ddls/apiman-gateway_mssql15.ddl
+++ b/distro/data/src/main/resources/ddls/apiman-gateway_mssql15.ddl
@@ -1,42 +1,27 @@
-
-USE [apiman_gateway];
-GO
-
 CREATE TABLE [gw_apis] ([org_id] VARCHAR(255) NOT NULL, [id] VARCHAR(255) NOT NULL, [version] VARCHAR(255) NOT NULL, [bean] TEXT NOT NULL);
-GO
 
 ALTER TABLE [gw_apis] ADD PRIMARY KEY ([org_id], [id], [version]);
-GO
 
 CREATE TABLE [gw_clients] ([api_key] VARCHAR(255) NOT NULL, [org_id] VARCHAR(255) NOT NULL, [id] VARCHAR(255) NOT NULL, [version] VARCHAR(255) NOT NULL, [bean] TEXT NOT NULL);
-GO
 
 ALTER TABLE [gw_clients] ADD PRIMARY KEY ([api_key]);
-GO
 
 ALTER TABLE [gw_clients] ADD CONSTRAINT [UK_gw_clients_1] UNIQUE ([org_id], [id], [version]);
-GO
 
 CREATE NONCLUSTERED INDEX [IDX_gw_clients_1] ON [gw_clients]([org_id], [id], [version]);
-GO
 
 CREATE TABLE [gw_dataversion] ([version] BIGINT NOT NULL);
-GO
 
 CREATE TABLE [gw_requests] (
-	[rstart] BIGINT NOT NULL, [rend] BIGINT NOT NULL, [duration] BIGINT NOT NULL, 
+	[rstart] BIGINT NOT NULL, [rend] BIGINT NOT NULL, [duration] BIGINT NOT NULL,
 	[month] BIGINT NOT NULL, [week] BIGINT NOT NULL, [day] BIGINT NOT NULL, [hour] BIGINT NOT NULL, [minute] BIGINT NOT NULL,
-	[api_org_id] VARCHAR(255) NOT NULL, [api_id] VARCHAR(255) NOT NULL, [api_version] VARCHAR(255) NOT NULL, 
+	[api_org_id] VARCHAR(255) NOT NULL, [api_id] VARCHAR(255) NOT NULL, [api_version] VARCHAR(255) NOT NULL,
 	[client_org_id] VARCHAR(255), [client_id] VARCHAR(255), [client_version] VARCHAR(255), [plan] VARCHAR(255),
 	[user_id] VARCHAR(255), [resp_type] VARCHAR(255), [bytes_up] BIGINT NOT NULL, [bytes_down] BIGINT NOT NULL
 );
-GO
 
 CREATE NONCLUSTERED INDEX [IDX_gw_requests_1] ON [gw_requests]([api_org_id], [api_id], [api_version]);
-GO
 
 CREATE NONCLUSTERED INDEX [IDX_gw_requests_2] ON [gw_requests]([client_org_id], [client_id], [client_version]);
-GO
 
 CREATE NONCLUSTERED INDEX [IDX_gw_requests_3] ON [gw_requests]([resp_type]);
-GO

--- a/distro/data/src/main/resources/ddls/apiman_mssql15.ddl
+++ b/distro/data/src/main/resources/ddls/apiman_mssql15.ddl
@@ -676,3 +676,5 @@ GO
 
 --  Changeset src/main/liquibase/current/20220623-explicit-api-plan-order.xml::1655976671166-6::msavy (generated)
 ALTER TABLE api_plans ADD order_index INT DEFAULT 0 NOT NULL;
+
+CREATE SEQUENCE hibernate_sequence;

--- a/distro/ddl/src/main/resources/liquibase/current/000-apiman-manager-api.db.sequences.changelog.xml
+++ b/distro/ddl/src/main/resources/liquibase/current/000-apiman-manager-api.db.sequences.changelog.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+    <!-- TODO: this likely can be retired, I don't think it's needed any more? -->
     <changeSet dbms="mysql,mariadb" author="apiman" id="1434723514712-1">
         <sql dbms="mysql,mariadb">
             CREATE TABLE hibernate_sequence (next_val bigint(20) DEFAULT NULL) ENGINE=InnoDB DEFAULT CHARSET=latin1;
@@ -10,7 +11,7 @@
         </sql>
     </changeSet>
 
-    <changeSet author="apiman (generated)" id="1434723514712-2"> <!-- Was limited to h2 and postgres for some reason? -->
+    <changeSet author="apiman (generated)" dbms="!mysql,!mariadb" id="1434723514712-2">
         <createSequence sequenceName="hibernate_sequence" startValue="999"/> <!-- Why 999? -->
     </changeSet>
 </databaseChangeLog>

--- a/distro/ddl/src/main/resources/liquibase/current/000-apiman-manager-api.db.sequences.changelog.xml
+++ b/distro/ddl/src/main/resources/liquibase/current/000-apiman-manager-api.db.sequences.changelog.xml
@@ -10,7 +10,7 @@
         </sql>
     </changeSet>
 
-    <changeSet dbms="h2,postgresql" author="apiman (generated)" id="1434723514712-2">
-        <createSequence sequenceName="hibernate_sequence" startValue="999"/>
+    <changeSet author="apiman (generated)" id="1434723514712-2"> <!-- Was limited to h2 and postgres for some reason? -->
+        <createSequence sequenceName="hibernate_sequence" startValue="999"/> <!-- Why 999? -->
     </changeSet>
 </databaseChangeLog>

--- a/distro/ddl/src/main/resources/liquibase/current/201-add-json-type.changelog.xml
+++ b/distro/ddl/src/main/resources/liquibase/current/201-add-json-type.changelog.xml
@@ -4,4 +4,8 @@
     <comment>H2 JSON field (needed for versions older than 1.4.200)</comment>
     <sql stripComments="true">CREATE domain IF NOT EXISTS json AS other</sql>
   </changeSet>
+  <changeSet author="msavy marc@blackparrotlabs.io" id="mssql-json-type" dbms="mssql" failOnError="false">
+    <comment>JSON field type</comment>
+    <sql stripComments="true">CREATE TYPE JSON FROM NVARCHAR(MAX)</sql>
+  </changeSet>
 </databaseChangeLog>

--- a/distro/ddl/src/main/resources/liquibase/master.xml
+++ b/distro/ddl/src/main/resources/liquibase/master.xml
@@ -2,8 +2,8 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
 
   <!-- A few DBs don't accept JSON data type still -->
-  <property name="apiman_json" value="JSON" dbms="!mssql"/>
-  <property name="apiman_json" value="nvarchar(max)" dbms="mssql"/>
+  <property name="apiman_json" value="json"/>
+<!--  <property name="apiman_json" value="nvarchar(max)" dbms="mssql"/>-->
   <!--
     MySQL has strict 3k limits on length of indexes, and each char is 4 bytes.
     We break this in several places with multiple standard 255 length fields.

--- a/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/ApimanH2Dialect.java
+++ b/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/ApimanH2Dialect.java
@@ -30,7 +30,7 @@ public class ApimanH2Dialect extends H2Dialect {
      * Constructor.
      */
     public ApimanH2Dialect() {
-        registerColumnType(Types.LONGVARCHAR, "CLOB"); //$NON-NLS-1$
+        registerColumnType(Types.LONGVARCHAR, "CLOB");
         registerColumnType(Types.VARBINARY, "BLOB");
         registerColumnType(Types.NCLOB, "CLOB");
     }

--- a/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/ApimanMSSQLDialect.java
+++ b/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/ApimanMSSQLDialect.java
@@ -1,0 +1,16 @@
+package io.apiman.manager.api.jpa;
+
+import org.hibernate.dialect.SQLServer2012Dialect;
+
+/**
+ * Author: Marc Savy <marc@blackparrotlabs.io>
+ */
+public class ApimanMSSQLDialect extends SQLServer2012Dialect {
+
+    /**
+     * Constructor.
+     */
+    public ApimanMSSQLDialect() {
+        super();
+    }
+}

--- a/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/JpaDialectMapper.java
+++ b/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/JpaDialectMapper.java
@@ -18,12 +18,6 @@ package io.apiman.manager.api.jpa;
 
 import io.apiman.common.logging.ApimanLoggerFactory;
 import io.apiman.common.logging.IApimanLogger;
-
-import java.util.HashMap;
-import java.util.Map;
-import javax.naming.InitialContext;
-import javax.sql.DataSource;
-
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.MySQL8Dialect;
 import org.hibernate.dialect.MySQLDialect;
@@ -37,8 +31,12 @@ import org.hibernate.dialect.PostgreSQL94Dialect;
 import org.hibernate.dialect.PostgreSQL95Dialect;
 import org.hibernate.dialect.PostgreSQL9Dialect;
 import org.hibernate.dialect.PostgreSQLDialect;
-import org.hibernate.dialect.SQLServer2012Dialect;
 import org.hibernate.dialect.SQLServerDialect;
+
+import javax.naming.InitialContext;
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Initializes the database by installing the appropriate DDL for the database in
@@ -79,9 +77,8 @@ public class JpaDialectMapper {
         DB_TYPE_MAP.put(PostgreSQL95Dialect.class.getName(), NamePair.of("postgresql11", PostgreSQL95Dialect.class.getName()));
 
         DB_TYPE_MAP.put("mssql15", NamePair.of(SQLServerDialect.class.getName(), "mssql15"));
-        DB_TYPE_MAP.put(SQLServerDialect.class.getName(), NamePair.of("mssql15", SQLServerDialect.class.getName()));
-        DB_TYPE_MAP.put(SQLServer2012Dialect.class.getName(), NamePair.of("mssql15", SQLServer2012Dialect.class.getName()));
-
+        DB_TYPE_MAP.put(SQLServerDialect.class.getName(), NamePair.of("mssql15", ApimanMSSQLDialect.class.getName()));
+        DB_TYPE_MAP.put(ApimanMSSQLDialect.class.getName(), NamePair.of("mssql15", ApimanMSSQLDialect.class.getName()));
     }
 
     private final DataSource ds;


### PR DESCRIPTION
∙ `hibernate_sequence` creation was limited to H2 and Postgres only for some reason.

∙ `GO` statement separators in gateway DDL did not play nicely with Apiman's Gateway DDL runner.

∙ Explicit database name was used in Gateway DDL which caused issues if using non-default DB name.

∙ Use custom JSON type to make handling of JSON in MSSQL easier when also using Hibernate.