### PR TITLE
build(deps): bump org.postgresql.jdbc.driver from 42.5.1 to 42.6.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -90,16 +90,16 @@
     <version.remote.resources.plugin>3.0.0</version.remote.resources.plugin>
 
     <!-- DBs -->
-    <version.org.postgresql.jdbc.driver>42.5.1</version.org.postgresql.jdbc.driver>
-    <version.mysql.jdbc.driver>8.0.30</version.mysql.jdbc.driver>
+    <version.org.postgresql.jdbc.driver>42.6.0</version.org.postgresql.jdbc.driver>
+    <version.mysql.jdbc.driver>8.0.33</version.mysql.jdbc.driver>
     <version.com.oracle.driver>21.7.0.0</version.com.oracle.driver>
     <version.mssql.driver>9.4.0.jre11</version.mssql.driver>
     <version.org.liquibase>4.16.1</version.org.liquibase>
 
     <!-- Dependency Versions -->
     <version.com.blazebit.blaze-persistence>1.6.8</version.com.blazebit.blaze-persistence>
-    <version.com.fasterxml.jackson>2.14.1</version.com.fasterxml.jackson>
-    <version.com.github.ben-manes.caffeine>3.1.1</version.com.github.ben-manes.caffeine>
+    <version.com.fasterxml.jackson>2.14.2</version.com.fasterxml.jackson>
+    <version.com.github.ben-manes.caffeine>3.1.6</version.com.github.ben-manes.caffeine>
     <version.com.github.seancfoley.ipaddress>5.3.4</version.com.github.seancfoley.ipaddress>
     <version.com.h2database>1.4.199</version.com.h2database> <!-- Unclear why, but 1.4.200 seems to cause some random issues, including inability for DB viewers to parse the data -->
     <version.com.lmax>3.4.4</version.com.lmax>
@@ -117,62 +117,62 @@
     <version.commons-io>2.11.0</version.commons-io>
     <version.commons-logging>1.2</version.commons-logging>
     <version.commons-pool>1.6</version.commons-pool>
-    <version.org.opensearch.opensearch>1.2.4</version.org.opensearch.opensearch>
+    <version.org.opensearch.opensearch>1.3.9</version.org.opensearch.opensearch>
     <version.com.zaxxer>2.7.9</version.com.zaxxer>
     <version.com.google.guava>31.1-jre</version.com.google.guava>
     <version.io.prometheus>0.0.13</version.io.prometheus>
-    <version.joda-time>2.12.2</version.joda-time>
+    <version.joda-time>2.12.5</version.joda-time>
     <version.junit>4.13.2</version.junit>
     <version.org.assertj>3.21.0</version.org.assertj>
-    <version.org.junit.jupiter>5.9.1</version.org.junit.jupiter>
+    <version.org.junit.jupiter>5.9.2</version.org.junit.jupiter>
     <version.org.apache.commons.commons-lang3>3.12.0</version.org.apache.commons.commons-lang3>
     <version.org.apache.directory.server>2.0.0.AM25</version.org.apache.directory.server>
     <version.org.apache.directory.api-all>2.1.0</version.org.apache.directory.api-all>
-    <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
+    <version.org.apache.httpcomponents.httpclient>4.5.14</version.org.apache.httpcomponents.httpclient>
     <version.org.apache.httpcomponents.httpcore>4.4.16</version.org.apache.httpcomponents.httpcore>
-    <version.org.apache.httpcomponents.httpasyncclient>4.1.4</version.org.apache.httpcomponents.httpasyncclient>
-    <version.org.apache.logging.log4j>2.19.0</version.org.apache.logging.log4j>
-    <version.org.agrona>1.16.0</version.org.agrona>
+    <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>
+    <version.org.apache.logging.log4j>2.20.0</version.org.apache.logging.log4j>
+    <version.org.agrona>1.18.1</version.org.agrona>
     <version.org.eclipse.jetty>9.4.41.v20210516</version.org.eclipse.jetty>
     <version.org.glassfish.javax.el>3.0.0</version.org.glassfish.javax.el>
-    <version.org.elasticsearch>7.17.6</version.org.elasticsearch>
+    <version.org.elasticsearch>7.17.9</version.org.elasticsearch>
     <version.org.hamcrest>1.3</version.org.hamcrest>
     <version.org.hibernate>5.3.20.Final</version.org.hibernate> <!-- Pin to WildFly version -->
     <version.org.infinispan>8.2.12.Final</version.org.infinispan>
     <version.org.jeasy.easy-rules>4.1.0</version.org.jeasy.easy-rules>
-    <version.org.jboss.jandex>2.4.2.Final</version.org.jboss.jandex>
+    <version.org.jboss.jandex>2.4.3.Final</version.org.jboss.jandex>
     <version.org.jboss.logging.jboss-logging>3.4.2.Final</version.org.jboss.logging.jboss-logging>
     <version.org.jboss.resteasy>3.15.3.Final</version.org.jboss.resteasy>
     <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.1.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
     <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>2.0.2.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>
     <version.org.jboss.weld.weld>3.1.8.Final</version.org.jboss.weld.weld>
-    <version.org.jdbi>3.32.0</version.org.jdbi>
-    <version.org.jsoup>1.15.3</version.org.jsoup>
+    <version.org.jdbi>3.37.1</version.org.jdbi>
+    <version.org.jsoup>1.15.4</version.org.jsoup>
     <version.org.keycloak>18.0.2</version.org.keycloak>
     <version.org.lz4.lz4-java>1.8.0</version.org.lz4.lz4-java>
-    <version.org.mockito>3.12.1</version.org.mockito>
-    <version.org.mapstruct>1.5.3.Final</version.org.mapstruct>
-    <version.org.mvel>2.4.12.Final</version.org.mvel>
-    <version.org.passay>1.6.2</version.org.passay>
+    <version.org.mockito>5.3.0</version.org.mockito>
+    <version.org.mapstruct>1.5.4.Final</version.org.mapstruct>
+    <version.org.mvel>2.4.15.Final</version.org.mvel>
+    <version.org.passay>1.6.3</version.org.passay>
     <version.org.picketbox>5.1.0.Final</version.org.picketbox>
-    <version.io.github.classgraph>4.8.152</version.io.github.classgraph>
+    <version.io.github.classgraph>4.8.157</version.io.github.classgraph>
     <version.org.slf4j>1.7.36</version.org.slf4j>
     <version.org.testcontainers>1.18.0</version.org.testcontainers>
     <version.io.apicurio>1.1.26</version.io.apicurio>
-    <version.io.netty>4.1.74.Final</version.io.netty>
+    <version.io.netty>4.1.89.Final</version.io.netty>
     <version.io.quarkus.qute>2.7.0.Final</version.io.quarkus.qute>
     <version.io.swagger>2.2.7</version.io.swagger>
     <version.xmlunit>1.6</version.xmlunit>
-    <version.io.vertx>3.9.13</version.io.vertx>
+    <version.io.vertx>3.9.15</version.io.vertx>
     <version.net.openhft>0.15</version.net.openhft>
     <version.com.ibm.icu4j>71.1</version.com.ibm.icu4j>
     <version.com.icegreen.greenmail>1.6.8</version.com.icegreen.greenmail>
     <version.com.hazelcast>4.2.6</version.com.hazelcast>
-    <version.com.jcbai>1.18.1</version.com.jcbai>
+    <version.com.jcbai>1.20.1</version.com.jcbai>
     <version.org.skyscreamer.jsonassert>1.5.1</version.org.skyscreamer.jsonassert>
-    <version.org.redisson>3.17.6</version.org.redisson>
-    <version.net.javacrumbs.json-unit>2.35.0</version.net.javacrumbs.json-unit>
-    <version.info.picocli>4.7.0</version.info.picocli>
+    <version.org.redisson>3.20.1</version.org.redisson>
+    <version.net.javacrumbs.json-unit>2.37.0</version.net.javacrumbs.json-unit>
+    <version.info.picocli>4.7.3</version.info.picocli>
 
     <!-- Sun and javax dependencies to maintain compatibility with Java 9+ module changes -->
     <version.com.sun.xml.ws>2.3.4</version.com.sun.xml.ws>


### PR DESCRIPTION
build(deps): bump mysql.jdbc.driver from 8.0.30 to 8.0.33
build(deps): bump jackson from 2.14.1 to 2.14.2
build(deps): bump caffeine from 3.1.1 to 3.1.6
build(deps): bump opensearch from 1.2.4 to 1.3.9
build(deps): bump joda-time from 2.12.2 to 2.12.5
build(deps): bump junit jupiter from 5.9.1 to 5.9.2
build(deps): bump httpclient from 4.5.13 to 4.5.14
build(deps): bump httpasyncclient 4.1.4 to 4.1.5
build(deps): bump log4j from 2.19.0 to 2.20.0
build(deps): bump agrona from 1.16.0 to 1.18.1
build(deps): bump elasticsearch from 7.17.6 to 7.17.9
build(deps): bump jandex from 2.4.2.Final to 2.4.3.Final
build(deps): bump jdbi from 3.32.0 to 3.37.1
build(deps): bump jsoup from 1.15.3 to 1.15.4
build(deps): bump mockito from 3.12.1 to 5.3.0
build(deps): bump mapstruct from 1.5.3.Final to 1.5.4.Final
build(deps): bump mvel from 2.4.12.Final to 2.4.15.Final
build(deps): bump passay from 1.6.2.Final to 1.6.3.Final
build(deps): bump classgraph from 4.8.152 to 4.8.157
build(deps): bump netty from 4.1.74.Final to 4.1.89.Final
build(deps): bump vert.x from 3.9.13 to 3.9.15
build(deps): bump jcabi from 1.18.1 to 1.20.1
build(deps): bump redisson from 3.17.6 to 3.20.1
build(deps): bump json-unit from 2.35.0 to 2.37.0
build(deps): bump picocli from 4.7.0 to 4.7.3