### PR TITLE
fix(manager-api): allow deletion of org with contracts

### DIFF
--- a/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/JpaStorage.java
+++ b/manager/api/jpa/src/main/java/io/apiman/manager/api/jpa/JpaStorage.java
@@ -2335,7 +2335,7 @@ public class JpaStorage extends AbstractJpaStorage implements IStorage, IStorage
                 // Client
                 + " JOIN contractBean.client clientVersion "
                 + " JOIN clientVersion.client client "
-                + " JOIN api.organization clientOrg "
+                + " JOIN client.organization clientOrg "
                 // Check API status
                 + " WHERE (apiOrg.id = :orgId AND apiVersion.status = :apiStatus)"
                 // Check In-Org ClientApp status
@@ -2599,12 +2599,15 @@ public class JpaStorage extends AbstractJpaStorage implements IStorage, IStorage
         String jpql =
             "DELETE FROM ContractBean deleteBean " +
                 "   WHERE deleteBean IN ( " +
-                "       SELECT b " +
-                "           FROM ContractBean b " +
-                "           JOIN b.api apiVersion " +
+                "       SELECT contract " +
+                "           FROM ContractBean contract " +
+                "           JOIN contract.api apiVersion " +
                 "           JOIN apiVersion.api api " +
-                "           JOIN api.organization o " +
-                "       WHERE o.id = :orgId " +
+                "           JOIN api.organization apiOrg " +
+                "           JOIN contract.client clientVersion " +
+                "           JOIN clientVersion.client client " +
+                "           JOIN client.organization clientOrg " +
+                "       WHERE apiOrg.id = :orgId OR clientOrg.id = :orgId" +
                 "   )";
 
         Query query = getActiveEntityManager().createQuery(jpql);

--- a/manager/test/api/src/test/java/io/apiman/manager/Apiman2471Test.java
+++ b/manager/test/api/src/test/java/io/apiman/manager/Apiman2471Test.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Scheer PAS Schweiz AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  imitations under the License.
+ */
+package io.apiman.manager;
+
+import io.apiman.manager.test.junit.ManagerRestTestPlan;
+import io.apiman.manager.test.junit.ManagerRestTester;
+import org.junit.runner.RunWith;
+
+/**
+ * Runs the test plan that reproduces https://github.com/apiman/apiman/issues/2471
+ */
+@RunWith(ManagerRestTester.class)
+@ManagerRestTestPlan("test-plans/apiman-2471-delete-testPlan.xml")
+public class Apiman2471Test {
+}

--- a/manager/test/api/src/test/resources/test-plan-data/apiman-2471/001_import.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/apiman-2471/001_import.resttest
@@ -1,0 +1,315 @@
+POST /system/import admin/admin
+Content-Type: application/json
+
+{
+   "Metadata": {
+     "id": 1686577330281,
+     "apimanVersion": "8.6.0-SNAPSHOT"
+   },
+   "Users": [
+     {
+       "username": "platform.admin",
+       "fullName": "Platform Admin",
+       "email": "admin@example.com",
+       "joinedOn": "2022-03-04T14:02:03Z",
+       "locale": "de",
+       "notificationPreferences": [],
+       "admin": false
+     }
+   ],
+   "Gateways": [
+     {
+       "id": "TheGateway",
+       "name": "The Gateway",
+       "description": "This is the gateway.",
+       "createdBy": "admin",
+       "createdOn": 1445973205874,
+       "modifiedBy": "admin",
+       "modifiedOn": 1445973205874,
+       "type": "REST",
+       "configuration": "{\"endpoint\":\"http://localhost:7070/mock-gateway\",\"username\":\"admin\",\"password\":\"$CRYPT::j8rdW76Z5gUI0I+9c8/GrA==\"}"
+     }
+   ],
+   "Plugins": [],
+   "Roles": [
+     {
+       "id": "Editor",
+       "name": "Editor",
+       "description": "A user with this role has the permission to edit.",
+       "createdBy": "admin",
+       "createdOn": "2018-05-09T12:00:00Z",
+       "autoGrant": true,
+       "permissions": [
+         "clientEdit",
+         "orgView",
+         "planEdit",
+         "planView",
+         "planAdmin",
+         "orgEdit",
+         "apiAdmin",
+         "apiView",
+         "apiEdit",
+         "clientView",
+         "clientAdmin"
+       ]
+     },
+     {
+       "id": "Organization-User-Manager",
+       "name": "Organization-User-Manager",
+       "description": "A user with this role can manage members of this organization.",
+       "createdBy": "admin",
+       "createdOn": "2018-05-09T12:00:00Z",
+       "autoGrant": true,
+       "permissions": [
+         "orgView",
+         "orgEdit",
+         "orgAdmin"
+       ]
+     },
+     {
+       "id": "Viewer",
+       "name": "Viewer",
+       "description": "A user with this role can only view things within an organization.",
+       "createdBy": "admin",
+       "createdOn": "2018-05-09T12:00:00Z",
+       "autoGrant": false,
+       "permissions": [
+         "orgView",
+         "planView",
+         "apiView",
+         "clientView"
+       ]
+     }
+   ],
+   "PolicyDefinitions": [],
+   "Developers": [],
+   "Blobs": [],
+   "Orgs": [
+     {
+       "OrganizationBean": {
+         "id": "Organization1",
+         "name": "Organization1",
+         "description": "",
+         "createdBy": "platform.admin",
+         "createdOn": "2023-06-12T13:39:47Z",
+         "modifiedBy": "platform.admin",
+         "modifiedOn": "2023-06-12T13:39:47Z"
+       },
+       "Memberships": [
+         {
+           "id": 10907,
+           "userId": "platform.admin",
+           "roleId": "Editor",
+           "organizationId": "Organization1",
+           "createdOn": "2023-06-12T13:39:47Z"
+         },
+         {
+           "id": 10908,
+           "userId": "platform.admin",
+           "roleId": "Organization-User-Manager",
+           "organizationId": "Organization1",
+           "createdOn": "2023-06-12T13:39:47Z"
+         }
+       ],
+       "Plans": [
+         {
+           "PlanBean": {
+             "id": "Plan1",
+             "name": "Plan1",
+             "description": "",
+             "createdBy": "platform.admin",
+             "createdOn": "2023-06-12T13:40:22Z"
+           },
+           "Versions": [
+             {
+               "PlanVersionBean": {
+                 "id": 10914,
+                 "status": "Locked",
+                 "version": "1.0",
+                 "createdBy": "platform.admin",
+                 "createdOn": "2023-06-12T13:40:22Z",
+                 "modifiedBy": "platform.admin",
+                 "modifiedOn": "2023-06-12T13:40:22Z",
+                 "lockedOn": "2023-06-12T13:40:25Z"
+               },
+               "Policies": []
+             }
+           ]
+         }
+       ],
+       "Apis": [
+         {
+           "ApiBean": {
+             "id": "API1",
+             "name": "API1",
+             "description": "",
+             "tags": [],
+             "createdBy": "platform.admin",
+             "createdOn": "2023-06-12T13:40:00Z"
+           },
+           "Versions": [
+             {
+               "ApiVersionBean": {
+                 "id": 10910,
+                 "status": "Published",
+                 "endpoint": "http://example.com",
+                 "endpointType": "rest",
+                 "endpointContentType": "json",
+                 "endpointProperties": {},
+                 "gateways": [
+                   {
+                     "gatewayId": "TheGateway"
+                   }
+                 ],
+                 "publicAPI": false,
+                 "discoverability": "ORG_MEMBERS",
+                 "plans": [
+                   {
+                     "planId": "Plan1",
+                     "version": "1.0",
+                     "requiresApproval": false,
+                     "discoverability": "ORG_MEMBERS"
+                   }
+                 ],
+                 "version": "1.0",
+                 "createdBy": "platform.admin",
+                 "createdOn": "2023-06-12T13:40:00Z",
+                 "modifiedBy": "platform.admin",
+                 "modifiedOn": "2023-06-12T13:40:43Z",
+                 "publishedOn": "2023-06-12T13:40:47Z",
+                 "definitionType": "None",
+                 "parsePayload": false,
+                 "disableKeysStrip": false
+               },
+               "Policies": []
+             }
+           ]
+         }
+       ],
+       "Clients": [],
+       "Audits": []
+     },
+     {
+       "OrganizationBean": {
+         "id": "Organization2",
+         "name": "Organization2",
+         "description": "",
+         "createdBy": "platform.admin",
+         "createdOn": "2023-06-12T13:41:02Z",
+         "modifiedBy": "platform.admin",
+         "modifiedOn": "2023-06-12T13:41:02Z"
+       },
+       "Memberships": [
+         {
+           "id": 10920,
+           "userId": "platform.admin",
+           "roleId": "Editor",
+           "organizationId": "Organization2",
+           "createdOn": "2023-06-12T13:41:02Z"
+         },
+         {
+           "id": 10921,
+           "userId": "platform.admin",
+           "roleId": "Organization-User-Manager",
+           "organizationId": "Organization2",
+           "createdOn": "2023-06-12T13:41:02Z"
+         }
+       ],
+       "Plans": [],
+       "Apis": [],
+       "Clients": [
+         {
+           "ClientBean": {
+             "id": "Client1",
+             "name": "Client1",
+             "description": "",
+             "createdBy": "platform.admin",
+             "createdOn": "2023-06-12T13:41:15Z"
+           },
+           "Versions": [
+             {
+               "ClientVersionBean": {
+                 "id": 10923,
+                 "status": "Retired",
+                 "version": "1.0",
+                 "createdBy": "platform.admin",
+                 "createdOn": "2023-06-12T13:41:15Z",
+                 "modifiedBy": "platform.admin",
+                 "modifiedOn": "2023-06-12T13:41:27Z",
+                 "publishedOn": "2023-06-12T13:41:28Z",
+                 "retiredOn": "2023-06-12T13:41:55Z",
+                 "apikey": "ed190df7-22b9-4925-8da1-cdb6ec46d603"
+               },
+               "Policies": [],
+               "Contracts": [
+                 {
+                   "id": 10928,
+                   "api": {
+                     "api": {
+                       "organization": {
+                         "id": "Organization1"
+                       },
+                       "id": "API1",
+                       "tags": []
+                     },
+                     "endpointProperties": {},
+                     "publicAPI": false,
+                     "discoverability": "ORG_MEMBERS",
+                     "plans": [],
+                     "version": "1.0",
+                     "parsePayload": false,
+                     "disableKeysStrip": false
+                   },
+                   "plan": {
+                     "plan": {
+                       "organization": {
+                         "id": "Organization1"
+                       },
+                       "id": "Plan1"
+                     },
+                     "version": "1.0"
+                   },
+                   "createdBy": "platform.admin",
+                   "createdOn": "2023-06-12T13:41:27Z",
+                   "status": "Created"
+                 }
+               ]
+             }
+           ]
+         }
+       ],
+       "Audits": []
+     }
+   ]
+ }
+----
+200
+Content-Type: text/plain;charset=utf-8
+X-RestTest-RegexMatching: true
+
+INFO: ----------------------------
+INFO: Starting apiman data import: .*apiman_import_migrated.*\.json
+INFO: Importing a user: platform.admin
+INFO: Importing a gateway: The Gateway
+INFO: Importing a role: Editor
+INFO: Importing a role: Organization-User-Manager
+INFO: Importing a role: Viewer
+INFO: Importing an organization: Organization1
+INFO:   Importing a role membership: platform.admin\+Editor=>Organization1
+INFO:   Importing a role membership: platform.admin\+Organization-User-Manager=>Organization1
+INFO:   Importing a plan: Plan1
+INFO:     Importing a plan version: 1.0
+INFO:     Importing an API: API1
+INFO:     Importing an API version: 1.0
+INFO: Importing an organization: Organization2
+INFO:   Importing a role membership: platform.admin\+Editor=>Organization2
+INFO:   Importing a role membership: platform.admin\+Organization-User-Manager=>Organization2
+INFO:   Importing a client: Client1
+INFO:     Importing a client version: 1.0
+INFO: Importing a client contract.
+INFO: Publishing APIs to the gateway.
+INFO:  Publishing API: Organization1 / API1 -> 1.0
+INFO: Registering clients in the gateway.
+INFO: -----------------------------------
+INFO: Data import completed successfully!
+INFO: -----------------------------------

--- a/manager/test/api/src/test/resources/test-plan-data/apiman-2471/002_delete-org.resttest
+++ b/manager/test/api/src/test/resources/test-plan-data/apiman-2471/002_delete-org.resttest
@@ -1,0 +1,3 @@
+DELETE /organizations/Organization2 admin/admin
+----
+204

--- a/manager/test/api/src/test/resources/test-plans/apiman-2471-delete-testPlan.xml
+++ b/manager/test/api/src/test/resources/test-plans/apiman-2471-delete-testPlan.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testPlan name="delete and recreate" xmlns="urn:io.apiman.test:2014:02:testPlan">
+
+  <!-- Create Test Data -->
+  <!-- One retired client with contract to an API in a different org -->
+  <testGroup name="Import Apiman Data">
+    <test name="Import Apiman Data">test-plan-data/apiman-2471/001_import.resttest</test>
+  </testGroup>
+
+  <!-- Delete Org -->
+  <testGroup name="Delete Organization">
+    <test name="Delete Org (with contract to different Org)">test-plan-data/apiman-2471/002_delete-org.resttest</test>
+  </testGroup>
+
+</testPlan>


### PR DESCRIPTION
It should be possible to delete an organization with retired entities. Existing client contracts should be deleted automatically if the org is deleted and all client versions are retired. The desired behaviour is already working for API contracts but not for clients.

Closes: #2471