### PR TITLE
feat(gateway-vertx): enable allowed-issuers list in `KeycloakOAuthFactory`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,13 +7,22 @@ All notable changes to Apiman will be documented here (as of Apiman 3).
 
 === Added
 
+* [gateway-vertx]: you can add a list of additional `allowed-issuers` in your Gateway API Keycloak Authentication config.
+This better supports situations where your Keycloak server returns multiple different issuers, for example for internal
+vs external domains, Docker, K8s, etc. By https://github.com/msavy[Marc Savy (@msavy)^].
+
 === Changed
 
 * A large number of dependencies have been updated across the Apiman codebase in order to improve security. By https://github.com/msavy[Marc Savy (@msavy)^].
 
+* [containers/docker-compose]: to support a change in Keycloak's behaviour, we now set `allowed-issuers` in the Vert.x
+Gateway API authentication configuration to allow both internal and external issuers. By https://github.com/msavy[Marc Savy (@msavy)^].
+
 === Removed
 
 === Fixed
+
+* [gateway-vertx]: array values are now always correctly substituted in Vert.x Gateway configuration. By https://github.com/msavy[Marc Savy (@msavy)^].
 
 * [portal]: show REST API documentation even when user not logged in.
 By https://github.com/bastiangem[Bastian Gembalczyk (@BastianGem)^] and https://github.com/volkflo[Florian Volk (@volkflo)^].

--- a/containers/docker-compose/src/docker/data/conf-es.json
+++ b/containers/docker-compose/src/docker/data/conf-es.json
@@ -309,6 +309,12 @@
       "requiredRole": "realm:apipublisher",
       // Override with System Properties, or paste and overwrite your Client Keycloak config here.
       "auth-server-url": "${apiman.auth.url:-http://localhost:8085}", // Location of your keycloak server.
+      // You can add extra issuers here; this can be very useful if your setup has internal vs external issuers,
+      // and you need to support both simultaneously.
+      "allowed-issuers": [
+        "${apiman.auth.public-endpoint:-}",
+        "${apiman.auth.private-endpoint:-}"
+      ],
       "realm": "${apiman.auth.realm:-apiman}",
       "resource": "apiman-gateway-api",
       "credentials": {
@@ -321,7 +327,7 @@
       // "client-keystore-password": "${apiman.keycloak.keystore.password:-changeit}"
       "ssl-required": "none",
       "disable-trust-manager": true,
-      "allow-any-hostname" : true
+      "allow-any-hostname" : true,
     }
   },
 

--- a/containers/docker-compose/src/docker/docker-compose.yml
+++ b/containers/docker-compose/src/docker/docker-compose.yml
@@ -75,6 +75,8 @@ services:
         -Dapiman.auth.url=${KEYCLOAK_PRIVATE_ENDPOINT}
         -Dapiman.auth.realm=${KEYCLOAK_REALM}
         -Dapiman.auth.gateway.secret=${KEYCLOAK_GATEWAY_SECRET}
+        -Dapiman.auth.public-endpoint=${KEYCLOAK_PUBLIC_ENDPOINT:-}
+        -Dapiman.auth.private-endpoint=${KEYCLOAK_PRIVATE_ENDPOINT:-}
         -DallowSelfSigned=${SELF_SIGNED}
         -DallowAnyHost=${SELF_SIGNED}
         -DcachingPolicy.maxCacheSize=${MAX_CACHE_SIZE_IN_MB}

--- a/distro/vertx/src/main/resources/overlay/configs/conf-es.json
+++ b/distro/vertx/src/main/resources/overlay/configs/conf-es.json
@@ -318,6 +318,12 @@
       "requiredRole": "realm:apipublisher",
       // Override with System Properties, or paste and overwrite your Client Keycloak config here.
       "auth-server-url": "${apiman.auth.url:-http://localhost:8085}", // Location of your keycloak server.
+      // You can add extra issuers here; this can be very useful if your setup has internal vs external issuers,
+      // and you need to support both simultaneously.
+      "allowed-issuers": [
+        "${apiman.auth.public-endpoint:-}",
+        "${apiman.auth.private-endpoint:-}"
+      ],
       "realm": "${apiman.auth.realm:-apiman}",
       "resource": "apiman-gateway-api",
       "credentials": {

--- a/distro/vertx/src/main/resources/overlay/configs/conf-headless-es.json
+++ b/distro/vertx/src/main/resources/overlay/configs/conf-headless-es.json
@@ -322,24 +322,27 @@
     "config": {
       "flowType": "PASSWORD",
       "requiredRole": "realm:apipublisher",
-      // Paste and overwrite your Keycloak config here.
-      "realm": "apiman",
-      "realm-public-key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxyG61ohrfJQKNmDA/ePZtqZVpPXjwn3k3T+iWiTvMsxW2+WlnqIEmL5qZ09DMhBH9r50WZRO2gVoCb657Er9x0vfD6GNf/47XU2y33TX8axhP+hSwkv/VViaDlu4jQrfgPWz/FXMjWIZxg1xQS+nOBF2ScCRYWNQ/ZnUNnvrq8dGC2/AlyeYcgDUOdwlJuvgkGlF0QoVPQiRPurR3RwlG+BjL8JB3hbaAZhdJqwqApmGQbcpgLj2tODnlrZnEAp5cPPU/lgqCE1OOp78BAEiE91ZLPl/+D8qDHk+Maz0Io3bkeRZMXPpvtbL3qN+3GlF8Yz264HDSsTNrH+nd19tFQIDAQAB",
-      "auth-server-url": "http://localhost:8080/auth",
-      "ssl-required": "none",
-      "disable-trust-manager": false,
-      "allow-any-hostname" : false,
+      // Override with System Properties, or paste and overwrite your Client Keycloak config here.
+      "auth-server-url": "${apiman.auth.url:-http://localhost:8085}", // Location of your keycloak server.
+      // You can add extra issuers here; this can be very useful if your setup has internal vs external issuers,
+      // and you need to support both simultaneously.
+      "allowed-issuers": [
+        "${apiman.auth.public-endpoint:-}",
+        "${apiman.auth.private-endpoint:-}"
+      ],
+      "realm": "${apiman.auth.realm:-apiman}",
       "resource": "apiman-gateway-api",
-      // A limitation in the current OAuth2 implementation means a credentials section is required
-      // even if your client is not set to "confidential". Leave this dummy section if you're using non-confidential.
       "credentials": {
-        "secret": "217b725d-7790-47a7-a3fc-5cf31f92a8db"
-      }//,
-      // "truststore": "/usr/src/apiman/apiman-distro-vertx/apiman.jks",
-      // "truststore-password": "secret"
-      // "client-keystore": "/usr/src/apiman/apiman-distro-vertx/apiman.jks",
-      // "client-keystore-password": "secret"
+        "secret": "${apiman.auth.gateway.secret:-password}"
+      },
       // End paste here
+      // "truststore": "${apiman.keycloak.truststore:-/opt/java/openjdk/lib/security/cacerts}",
+      // "truststore-password": "${apiman.keycloak.truststore.password:-changeit}"
+      // "client-keystore": "${apiman.keycloak.keystore:-/your/keystore/here}",
+      // "client-keystore-password": "${apiman.keycloak.keystore.password:-changeit}"
+      "ssl-required": "none",
+      "disable-trust-manager": true,
+      "allow-any-hostname" : true
     }
   },
 

--- a/docs/installation/modules/ROOT/pages/keycloak.adoc
+++ b/docs/installation/modules/ROOT/pages/keycloak.adoc
@@ -220,6 +220,61 @@ For more advanced setups, the environment variables/system properties may not be
 
 ==== Vert.x Gateway
 
+===== Additional options
+
+These options apply to the `auth.config` section.
+
+[source,json5]
+----
+{
+  // <Other sections>
+  "auth": {
+    "type": "keycloak",
+    "config": {
+      // Options inserted here.
+    }
+  }
+}
+----
+
+.Optional Params
+[cols="2,1,4",options="header"]
+|===
+
+| Name
+| Type
+| Description
+
+a| `ssl-required`
+| Boolean
+a| Whether SSL required for the server URL
+
+a| `allow-any-hostname`
+| Boolean
+a| Whether hostname verification should be performed (if true, all hostnames will be accepted).
+
+a| `disable-trust-manager`
+| Boolean
+a| Whether hostname verification should be performed (if true, all hostnames will be accepted).
+
+a| `truststore`
+| String
+a| Path to truststore
+
+a| `truststore-password`
+| String
+a| Truststore password
+
+a| `client-keystore`
+| String
+a| Path to client keystore
+
+a| `client-keystore-password`
+| String
+a| client keystore password
+
+|===
+
 ===== Additional OAuth2 issuers
 
 A common issue is that your issuers may appear different depending upon how your network is configured.

--- a/docs/installation/modules/ROOT/pages/keycloak.adoc
+++ b/docs/installation/modules/ROOT/pages/keycloak.adoc
@@ -220,6 +220,40 @@ For more advanced setups, the environment variables/system properties may not be
 
 ==== Vert.x Gateway
 
+===== Additional OAuth2 issuers
+
+A common issue is that your issuers may appear different depending upon how your network is configured.
+
+For example, proxies, Docker internal vs external networks, Kubernetes, etc.
+
+To get around this, you can set additional accepted issuers via `allowed-issuers`:
+
+[source,json]
+----
+{
+ // <Other sections>
+
+ "auth": {
+    "type": "keycloak",
+    "config": {
+      "flowType": "PASSWORD",
+      "requiredRole": "realm:apipublisher",
+      "auth-server-url": "${apiman.auth.url:-http://localhost:8085}",
+      // You can add extra issuers here; this can be very useful if
+      // your setup has internal vs external issuers, and you need to
+      // support both simultaneously.
+      "allowed-issuers": [
+        "${apiman.auth.public-endpoint:-}",
+        "${apiman.auth.private-endpoint:-}",
+        "http://example.com:8080/"
+      ]
+    }
+  }
+}
+----
+
+===== Manual setup
+
 If you don't want to use the default discovery mechanism, then for the Vert.x gateway, the simplest way to retrieve the necessary configuration is to generate it from your Keycloak server administrator console.
 
 The gateway accepts Keycloak's generated JSON, allowing you to paste your chosen client configuration from the Keycloak console into the `auth.config` section.

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/auth/KeycloakDiscovery.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/auth/KeycloakDiscovery.java
@@ -29,8 +29,8 @@ public interface KeycloakDiscovery {
     class MultiSiteOAuth2ClientOptions extends OAuth2ClientOptions {
         private final Set<String> allowedIssuers = new HashSet<>();
 
-        public MultiSiteOAuth2ClientOptions() {
-            super();
+        public MultiSiteOAuth2ClientOptions(JsonObject jso) {
+            super(jso);
         }
 
         @Override

--- a/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/auth/KeycloakOAuthFactory.java
+++ b/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/api/auth/KeycloakOAuthFactory.java
@@ -211,6 +211,9 @@ public class KeycloakOAuthFactory {
         options.addAllowedIssuer(authServerPublic);
         options.setClientID(clientId);
 
+        // TODO(msavy): this is a total mess, needs redoing to remove all
+        // this hacky manual code and document the options that have been added.
+
         config.getJsonArray("allowed-issuers", new JsonArray())
                 .stream()
                 .map(Object::toString)

--- a/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/common/config/JsonMapToPropertiesTest.java
+++ b/gateway/platforms/vertx3/vertx3/src/test/java/io/apiman/gateway/platforms/vertx3/common/config/JsonMapToPropertiesTest.java
@@ -40,13 +40,13 @@ public class JsonMapToPropertiesTest {
         JsonObject jso = new JsonObject(str);
         VertxEngineConfig vxConf = new VertxEngineConfig(jso);
 
-        @SuppressWarnings("serial")
-        Map<String, String> expected = new LinkedHashMap<String, String>(){{
-            put("races", "human,goblin,dwarf,elf,gnome,troll,golem,vampire,werewolf,zombie");
-        }};
+
+        Map<String, String> expected = Map.of(
+            "races", "human,goblin,dwarf,elf,gnome,troll,golem,vampire,werewolf,zombie"
+        );
 
         Map<String, String> actual = new LinkedHashMap<>();
-        vxConf.jsonMapToProperties("", jso.getMap(), actual);
+        vxConf.jsonMapToProperties("", jso, actual);
         Assert.assertEquals(expected, actual);
     }
 
@@ -60,14 +60,13 @@ public class JsonMapToPropertiesTest {
         JsonObject jso = new JsonObject(str);
         VertxEngineConfig vxConf = new VertxEngineConfig(jso);
 
-        @SuppressWarnings("serial")
-        Map<String, String> expected = new LinkedHashMap<String, String>(){{
-            put("favourite.food", "prime rat fillet");
-            put("favourite.drink", "quirmian cognac");
-        }};
+        Map<String, String> expected = Map.of(
+            "favourite.food", "prime rat fillet",
+            "favourite.drink", "quirmian cognac"
+        );
 
         Map<String, String> actual = new LinkedHashMap<>();
-        vxConf.jsonMapToProperties("", jso.getMap(), actual);
+        vxConf.jsonMapToProperties("", jso, actual);
         Assert.assertEquals(expected, actual);
     }
 
@@ -86,15 +85,15 @@ public class JsonMapToPropertiesTest {
         JsonObject jso = new JsonObject(str);
         VertxEngineConfig vxConf = new VertxEngineConfig(jso);
 
-        @SuppressWarnings("serial")
-        Map<String, String> expected = new LinkedHashMap<String, String>(){{
-            put("config.port", "ankh morpork");
-            put("config.favourite.food", "prime rat fillet");
-            put("config.favourite.drink", "quirmian cognac");
-        }};
+
+        Map<String, String> expected = Map.of(
+            "config.port", "ankh morpork",
+            "config.favourite.food", "prime rat fillet",
+            "config.favourite.drink", "quirmian cognac"
+        );
 
         Map<String, String> actual = new LinkedHashMap<>();
-        vxConf.jsonMapToProperties("", jso.getMap(), actual);
+        vxConf.jsonMapToProperties("", jso, actual);
         Assert.assertEquals(expected, actual);
     }
 
@@ -114,16 +113,16 @@ public class JsonMapToPropertiesTest {
         JsonObject jso = new JsonObject(str);
         VertxEngineConfig vxConf = new VertxEngineConfig(jso);
 
-        @SuppressWarnings("serial")
-        Map<String, String> expected = new LinkedHashMap<String, String>(){{
-            put("config.port", "victoria");
-            put("config.favourite.food", "kari koko");
-            put("config.favourite.drink", "kalou");
-            put("config.places", "anse boileau,anse royale");
-        }};
+
+        Map<String, String> expected = Map.of(
+                "config.port", "victoria",
+                "config.favourite.food", "kari koko",
+                "config.favourite.drink", "kalou",
+                "config.places", "anse boileau,anse royale"
+        );
 
         Map<String, String> actual = new LinkedHashMap<>();
-        vxConf.jsonMapToProperties("", jso.getMap(), actual);
+        vxConf.jsonMapToProperties("", jso, actual);
         Assert.assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
## Description

If you need multiple issuers, this can handle it more gracefully.

Useful if you have internal vs external issuers (sometimes several).

## Checklist

- [x] I have added a changelog entry.
- [x] If I've added a new feature/enhancement, I have added documentation for it.
- [x] If I've made a change that requires migration, I've added an entry to the migration guide.
- [x] I have tested this change manually, as well as as passing tests.
