### PR TITLE
fix(gateway-vertx): use cache for non-shared JDBC client

### DIFF
--- a/gateway/platforms/vertx3/vertx3/pom.xml
+++ b/gateway/platforms/vertx3/vertx3/pom.xml
@@ -176,6 +176,28 @@
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
       <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+
+    <!-- DB drivers -->
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc11</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>mssql-jdbc</artifactId>
+    </dependency>
 
     <!-- For custom Vert.x log4j2 delegate code -->
     <dependency>


### PR DESCRIPTION
## Description

Adding the default set of apiman jdbc drivers to vert.x. In addition cache non-shared clients (e.g. clients for basic-auth-policy) instead of creating a new once per request.

This is maybe not the perfect solution but I did not wanted to refactor the whole client logic as this may introduce additional bugs/breaking stuff.


Fixes #2569

## Checklist

- [ ] I have added a changelog entry.
- [ ] If I've added a new feature/enhancement, I have added documentation for it.
- [ ] I have tested this change manually, as well as as passing tests.
