### PR TITLE
fix(sec): upgrade org.json:json to 20180130

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -18,7 +18,7 @@
   <!-- todo: push to parent when possible -->
   <properties>
     <version.org.bouncycastle>1.67</version.org.bouncycastle>
-    <version.org.json>20140107</version.org.json>
+    <version.org.json>20180130</version.org.json>
     <version.org.mock-server>5.11.2</version.org.mock-server>
     <version.io.jsonwebtoken.jjwt>0.9.1</version.io.jsonwebtoken.jjwt>
     <version.com.auth0.jwks-rsa>0.8.2</version.com.auth0.jwks-rsa>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.json:json 20140107
- [MPS-2022-13520](https://www.oscs1024.com/hd/MPS-2022-13520)


### What did I do？
Upgrade org.json:json from 20140107 to 20180130 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS