### PR TITLE
Improve Vert.x Gatway Docs [Keycloak - Security]

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,8 @@ All notable changes to Apiman will be documented here (as of Apiman 3).
 
 === Removed
 
+* [docs]: removed deprecated documentation for `realm-public-key` in vert.x gateway auth config
+
 === Fixed
 
 // end::3.2.0-SNAPSHOT[]
@@ -20,14 +22,14 @@ All notable changes to Apiman will be documented here (as of Apiman 3).
 
 === Added
 
-* [gateway-vertx]: you can add a list of additional `allowed-issuers` in your Gateway API Keycloak Authentication config. 
+* [gateway-vertx]: you can add a list of additional `allowed-issuers` in your Gateway API Keycloak Authentication config.
 This better supports situations where your Keycloak server returns multiple different issuers, for example for internal vs external domains, Docker, K8s, etc. By https://github.com/msavy[Marc Savy (@msavy)^].
 
 === Changed
 
 * A large number of dependencies have been updated across the Apiman codebase in order to improve security. By https://github.com/msavy[Marc Savy (@msavy)^].
 
-* [containers/docker-compose]: to support a change in Keycloak's behaviour, we now set `allowed-issuers` in the Vert.x 
+* [containers/docker-compose]: to support a change in Keycloak's behaviour, we now set `allowed-issuers` in the Vert.x
 Gateway API authentication configuration to allow both internal and external issuers. By https://github.com/msavy[Marc Savy (@msavy)^].
 
 === Removed

--- a/containers/vertx-standalone/examples/configs/conf-standalone.json
+++ b/containers/vertx-standalone/examples/configs/conf-standalone.json
@@ -258,7 +258,6 @@
       "requiredRole": "realm:apipublisher",
       // Paste and overwrite your Keycloak config here.
       "realm": "apiman",
-      "realm-public-key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxyG61ohrfJQKNmDA/ePZtqZVpPXjwn3k3T+iWiTvMsxW2+WlnqIEmL5qZ09DMhBH9r50WZRO2gVoCb657Er9x0vfD6GNf/47XU2y33TX8axhP+hSwkv/VViaDlu4jQrfgPWz/FXMjWIZxg1xQS+nOBF2ScCRYWNQ/ZnUNnvrq8dGC2/AlyeYcgDUOdwlJuvgkGlF0QoVPQiRPurR3RwlG+BjL8JB3hbaAZhdJqwqApmGQbcpgLj2tODnlrZnEAp5cPPU/lgqCE1OOp78BAEiE91ZLPl/+D8qDHk+Maz0Io3bkeRZMXPpvtbL3qN+3GlF8Yz264HDSsTNrH+nd19tFQIDAQAB",
       "auth-server-url": "http://localhost:8080/auth",
       "ssl-required": "none",
       "resource": "apiman-gateway-api",

--- a/docs/installation/modules/ROOT/pages/gateway/security.adoc
+++ b/docs/installation/modules/ROOT/pages/gateway/security.adoc
@@ -57,13 +57,6 @@ a| Keycloak secret credential for the Apiman Gateway API (`apiman-gateway-api` c
 
 * *Default Value*: password
 
-a| * System property: apiman.auth.realm-public-key
-* Env var: APIMAN_AUTH_REALM_PUBLIC_KEY
-| String
-a| Public key for Apiman realm (only needed on Vert.x Gateway).
-
-* *Default Value*: example Apiman realm key
-
 |===
 
 WARNING: Please change default secrets and keys before deploying Apiman to production.
@@ -170,7 +163,6 @@ You can change your client type to `confidential`, or simply provide a dummy `cr
     "requiredRole": "realm:apipublisher",
     // Paste and overwrite your Keycloak config here.
     "realm": "apiman",
-    "realm-public-key": "<snip>",
     "auth-server-url": "http://localhost:8080/auth",
     "ssl-required": "none",
     "resource": "apiman-gateway-api",

--- a/docs/installation/modules/ROOT/pages/keycloak.adoc
+++ b/docs/installation/modules/ROOT/pages/keycloak.adoc
@@ -81,13 +81,6 @@ a| Keycloak secret credential for the Apiman Gateway API (`apiman-gateway-api` c
 
 * *Default Value*: password
 
-a| * System property: `apiman.auth.realm-public-key`
-* Env var: `APIMAN_AUTH_REALM_PUBLIC_KEY`
-| String
-a| Public key for Apiman realm. Get this from your Keycloak realm.
-
-* *Default Value*: Apiman will retrieve this from your Keycloak server's `.well-known` endpoint automatically.
-
 |===
 
 WARNING: Please change default secrets and keys before deploying Apiman to production.
@@ -343,7 +336,6 @@ You can change your client type to `confidential`, or simply provide a dummy `cr
       "requiredRole": "realm:apipublisher",
       // Paste and overwrite your Keycloak config here. <1>
       "realm": "apiman",
-      "realm-public-key": "<snip>",
       "auth-server-url": "http://localhost:8080/auth",
       "ssl-required": "none",
       "resource": "apiman-gateway-api",

--- a/docs/installation/modules/ROOT/pages/registries-and-components/headless.adoc
+++ b/docs/installation/modules/ROOT/pages/registries-and-components/headless.adoc
@@ -124,7 +124,6 @@ IMPORTANT: Due to a current limitation in the underlying OAuth2 library you may 
   "password": "bar",
   // Start paste & replace your Keycloak config here.
   "realm": "apiman",
-  "realm-public-key": "< snip >",
   "auth-server-url": "http://localhost:8080/auth",
   "ssl-required": "none",
   "resource": "apiman-gateway-api",


### PR DESCRIPTION
As we do not use `realm-public-key` anymore we can remove it from the docs to avoid confusion.

## Checklist

- [ ] I have added a changelog entry.
- [ ] If I've added a new feature/enhancement, I have added documentation for it.
- [ ] If I've made a change that requires migration, I've added an entry to the migration guide.
- [ ] I have tested this change manually, as well as as passing tests.
