### PR TITLE
fix(manager-api): :bug: Load page of contracts of Api #2423

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,9 @@ All notable changes to Apiman will be documented here (as of Apiman 3).
 === Removed
 
 === Fixed
+
+* [manager-ui]: Fix loadding data of api contracts. By https://github.com/alograg[GALVEZ Henry (@alograg)^].
+
 // end::3.2.0-SNAPSHOT[]
 
 // tag::3.1.3.Final[]

--- a/manager/ui/war/plugins/api-manager/ts/api/api-contracts.ts
+++ b/manager/ui/war/plugins/api-manager/ts/api/api-contracts.ts
@@ -27,6 +27,7 @@ _module.controller("Apiman.ApiContractsController",
             contracts: $q(function(resolve, reject) {
                 $scope.currentPage = 0;
                 getNextPage(resolve, reject);
+                Logger.error('Debugging: {0}', "Henry");
             })
         });
 
@@ -93,7 +94,12 @@ _module.controller("Apiman.ApiContractsController",
                 .catch((err) => handleError(err));
         };
 
-        $scope.getNextPage = getNextPage;
+        $scope.getNextPage = function() {
+          getNextPage(function(data) {
+            $scope.contracts.push.apply($scope.contracts, data);
+          }, function(){
+          });
+        };
 
         PageLifecycle.loadPage('ApiContracts', 'apiView', pageData, $scope, function() {
             Logger.debug("::: is public: {0}", $scope.version.publicAPI);


### PR DESCRIPTION
## Description

The function assigned to the scope to load the next page of the contracts did not assign a process for the success or failure of the data load. Therefore, an error was generated and the loaded data was not added to the view.

Fixes #2423 

## Checklist

- [X] I have added a changelog entry.
- [ ] If I've added a new feature/enhancement, I have added documentation for it.
- [ ] If I've made a change that requires migration, I've added an entry to the migration guide.
- [X] I have tested this change manually, as well as as passing tests.
